### PR TITLE
Don't run documentation builds on forked repos

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,7 @@ on:
 jobs:
   build-and-deploy-book:
     runs-on: ${{ matrix.os }}
+    if: github.repository == 'napari/tutorials'
     strategy:
       matrix:
         os: [ubuntu-latest]


### PR DESCRIPTION
Similar to https://github.com/napari/napari/pull/1953 - I'm seeing a lot of scheduled CI runs happening in my fork, which is not intended.