### PR TITLE
Set XDG_RUNTIME_DIR environment variable

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,12 +44,14 @@ jobs:
       - name: Test notebooks
         env:
           DISPLAY: ":99.0"
+          XDG_RUNTIME_DIR: "/tmp/runtime-runner"
         run: py.test --nbval-lax -n auto --dist loadscope
 
       # Build the book
       - name: Build the book
         env:
           DISPLAY: ":99.0"
+          XDG_RUNTIME_DIR: "/tmp/runtime-runner"
         run: jupyter-book build .
 
       # Deploy the book's HTML to github pages

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pytest-xdist
 nbval
 scikit-image
 pooch
+pydantic!=0.18.0


### PR DESCRIPTION
Closes https://github.com/napari/tutorials/issues/112

Set XDG_RUNTIME_DIR in deploy.yml to avoid warnings visible in the notebook output.

![2021-03-02-napari-tutorials-notebook-warnings](https://user-images.githubusercontent.com/30920819/109572423-483d4e00-7b41-11eb-977e-d6e6bd6dafe9.png)
