### PR TITLE
Fix typo in `dev` package script

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "run-p lint:*",
     "lint:scss": "stylelint theme/scss",
     "lint:js": "eslint theme/js",
-    "dev": "yarn build:dev && mkdir -p _build/html && run-p dev:*",
+    "dev": "yarn build && mkdir -p _build/html && run-p dev:*",
     "dev:server": "node dev-server",
     "dev:theme": "gulp watch",
     "postinstall": "husky install",


### PR DESCRIPTION
This fixes a typo in the `dev` package script introduced in #116 

![image](https://user-images.githubusercontent.com/2176050/112208067-26316b80-8bd5-11eb-8d55-9128a6dd7a52.png)
