### PR TITLE
Update pip install instructions to use double quotes, which works in all platforms

### DIFF
--- a/index.md
+++ b/index.md
@@ -48,7 +48,7 @@ napari can be installed on most macOS, Linux, and Windows systems with Python
 3.7, 3.8, and 3.9 using pip:
 
 ```sh
-pip install 'napari[all]'
+pip install "napari[all]"
 ```
 
 *(See `Specifying a GUI Backend` below for an explanation of the `[all]` notation.)*
@@ -62,7 +62,7 @@ napari into a clean virtual environment using an environment manager like
 ```sh
 conda create -y -n napari-env python=3.8
 conda activate napari-env
-pip install 'napari[all]'
+pip install "napari[all]"
 ```
 ````
 
@@ -73,7 +73,7 @@ To clone the repository locally and install in editable mode use
 ```sh
 git clone https://github.com/napari/napari.git
 cd napari
-pip install -e '.[all]'
+pip install -e ".[all]"
 
 # or, to install in editable mode AND grab all of the developer tools
 # (this is required if you want to contribute code back to napari)
@@ -96,16 +96,16 @@ scientific packages such as Spyder or matplotlib. If neither is available,
 running napari will result in an error message asking you to install one of
 them.
 
-Running `pip install 'napari[all]'` will install the default framework – currently
+Running `pip install "napari[all]"` will install the default framework – currently
 PyQt5, but this could change in the future.
 
 To install napari with a specific framework, you can use:
 
 ```sh
-pip install 'napari[pyqt5]'    # for PyQt5
+pip install "napari[pyqt5]"    # for PyQt5
 
 # OR
-pip install 'napari[pyside2]'  # for PySide2
+pip install "napari[pyside2]"  # for PySide2
 ```
 ````
 

--- a/release/release_0_3_4.md
+++ b/release/release_0_3_4.md
@@ -10,10 +10,10 @@ This is a short release that refactors our installation process to allow more
 flexibility around which Qt python bindings users install (PySide2, PyQt5).
 Starting with this release, running `pip install napari` will *no longer*
 install a GUI backend by default. For a complete installation with a GUI
-backend, users are now encouraged to use `pip install napari[all]`, which
+backend, users are now encouraged to use `pip install "napari[all]"`, which
 will install the default backend (currently PyQt5).  To explicitly select
-a backend, users may run either `pip install napari[pyqt5]` or
-`pip install napari[pyside2]`.
+a backend, users may run either `pip install "napari[pyqt5]"` or
+`pip install "napari[pyside2]"`.
 
 For more information, examples, and documentation, please visit our website:
 https://github.com/napari/napari

--- a/tutorials/fundamentals/installation.md
+++ b/tutorials/fundamentals/installation.md
@@ -30,7 +30,7 @@ napari can be installed on most macOS, Linux, and Windows systems with Python
 3.7, 3.8, and 3.9 using pip:
 
 ```sh
-pip install 'napari[all]'
+pip install "napari[all]"
 ```
 
 *(See `Specifying a GUI Backend` below for an explanation of the `[all]`
@@ -45,7 +45,7 @@ napari into a clean virtual environment using an environment manager like
 ```sh
 conda create -y -n napari-env python=3.8
 conda activate napari-env
-pip install 'napari[all]'
+pip install "napari[all]"
 ```
 ````
 
@@ -63,7 +63,7 @@ conda install -c conda-forge napari
 To install the "next-release" version from github via pip, call
 
 ```sh
-pip install git+https://github.com/napari/napari.git#egg=napari[all]
+pip install "git+https://github.com/napari/napari.git#egg=napari[all]"
 ```
 
 ### clone the repository locally and install in editable mode
@@ -94,7 +94,7 @@ An empty napari viewer should appear as follows
 If you installed napari with `pip` you can upgrade by calling
 
 ```sh
-pip install napari[all] --upgrade
+pip install "napari[all]" --upgrade
 ```
 
 ## choosing a different Qt backend
@@ -112,16 +112,16 @@ scientific packages such as Spyder or matplotlib. If neither is available,
 running napari will result in an error message asking you to install one of
 them.
 
-Running `pip install 'napari[all]'` will install the default framework – currently
+Running `pip install "napari[all]"` will install the default framework – currently
 PyQt5, but this could change in the future.
 
 To install napari with a specific framework, you can use:
 
 ```sh
-pip install 'napari[pyqt5]'    # for PyQt5
+pip install "napari[pyqt5]"    # for PyQt5
 
 # OR
-pip install 'napari[pyside2]'  # for PySide2
+pip install "napari[pyside2]"  # for PySide2
 ```
 ````
 


### PR DESCRIPTION
Fixes https://github.com/napari/napari/issues/2699