### PR TITLE
Fix a few small doc typos and formatting issues.

### DIFF
--- a/tutorials/fundamentals/image.md
+++ b/tutorials/fundamentals/image.md
@@ -291,7 +291,7 @@ Because the contrast limits are defined by two values the corresponding slider
 has two handles, one the adjusts the smaller value, one that adjusts the larger
 value.
 
-As of right now adjusting the contras limits has no effect for `rgb` data.
+As of right now adjusting the contrast limits has no effect for `rgb` data.
 
 If no contrast limits are passed, then napari will compute them. If your data is
 small, then napari will just take the minimum and maximum values across your
@@ -333,7 +333,7 @@ to black as you decrease its opacity.
 
 The `translucent` setting will cause the layer to blend with the layers below it
 if you decrease its opacity but will fully block those layers if its opacity is
-1. This is a reasonable default, useful for many applications.
+1\. This is a reasonable default, useful for many applications.
 
 The final blending mode `additive` will cause the layer to blend with the layers
 below even when it has full opacity. This mode is especially useful for many

--- a/tutorials/fundamentals/tracks.md
+++ b/tutorials/fundamentals/tracks.md
@@ -58,7 +58,7 @@ tracks_data = [
     [3, 4, 636, 1000]
 ]
 
-viewer = napari.view_image(test_im, name='image')
+viewer = napari.view_image(hubble_image, name='image')
 viewer.add_tracks(tracks_data, name='tracks')
 
 napari.run()

--- a/tutorials/fundamentals/viewer.md
+++ b/tutorials/fundamentals/viewer.md
@@ -225,7 +225,10 @@ as follows:
 
 +++
 
-viewer.layers[0].name = 'astronaut' viewer.layers[0].opacity = 0.7
+```python
+viewer.layers[0].name = 'astronaut'
+viewer.layers[0].opacity = 0.7
+```
 
 ```{code-cell} python
 :tags: [remove-cell]


### PR DESCRIPTION
I worked my way through the napari tutorials and found a few small issues like typos, formatting, and missing variable names. I bundled these three fixes together to fix those. Note that the `\` before the `.` is needed to escape and prevent the `1.` at the beginning of the line being intrepreted as the beginning of a numbered list (see screenshot below for what I saw).

![Screen Shot 2021-05-14 at 10 33 06 AM](https://user-images.githubusercontent.com/2608297/118333796-353fe600-b4c1-11eb-8dd7-7af374e30ad3.png)
