### PR TITLE
Call lint-staged with yarn so that the local install can be used.

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-lint-staged
+yarn lint-staged


### PR DESCRIPTION
This change means that `./node_modules/.bin` does not have to be in `PATH` and fixes an issue that I ran into when I was committing for the first time in this repo.