### PR TITLE
napari theme Global Table of Contents

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "clean:api-stable": "find api/stable/ ! -name 'index.rst' -type f -exec rm -f {} +",
     "clean:docs": "rm -rf _build/html",
     "clean:theme": "rm -rf dist public",
+    "clean:next": "rm -rf .next",
 
     "// Scripts for using various linters on the codebase.": "",
     "lint": "run-p lint:*",

--- a/theme/src/components/App/App.tsx
+++ b/theme/src/components/App/App.tsx
@@ -19,7 +19,7 @@ function InPageTableOfContents() {
 }
 
 function Content() {
-  const pageContentRef = useRef<HTMLDivElement>();
+  const pageContentRef = useRef<HTMLDivElement | null>(null);
   const router = useRouter();
 
   const { globalHeaders, rootGlobalHeaders, pageTitle, pageBodyHtml } =

--- a/theme/src/components/App/App.tsx
+++ b/theme/src/components/App/App.tsx
@@ -2,7 +2,10 @@ import clsx from 'clsx';
 
 import { AppBar } from '@/components/AppBar';
 import { Media } from '@/components/media';
-import { TableOfContents } from '@/components/TableOfContents';
+import {
+  GlobalTableOfContents,
+  TableOfContents,
+} from '@/components/TableOfContents';
 import { useJupyterBookData } from '@/context/jupyterBook';
 
 import styles from './App.module.scss';
@@ -13,7 +16,8 @@ function InPageTableOfContents() {
 }
 
 function Content() {
-  const { pageTitle, pageBodyHtml } = useJupyterBookData();
+  const { globalHeaders, rootGlobalHeaders, pageTitle, pageBodyHtml } =
+    useJupyterBookData();
 
   return (
     <div
@@ -27,7 +31,10 @@ function Content() {
     >
       {/* Global table of contents */}
       <Media greaterThanOrEqual="screen-1150">
-        <p>Global TOC placeholder</p>
+        <GlobalTableOfContents
+          headers={globalHeaders}
+          rootHeaders={rootGlobalHeaders}
+        />
       </Media>
 
       {/* Main content */}

--- a/theme/src/components/App/App.tsx
+++ b/theme/src/components/App/App.tsx
@@ -1,4 +1,6 @@
 import clsx from 'clsx';
+import { useRouter } from 'next/router';
+import { useEffect, useRef } from 'react';
 
 import { AppBar } from '@/components/AppBar';
 import { Media } from '@/components/media';
@@ -7,6 +9,7 @@ import {
   TableOfContents,
 } from '@/components/TableOfContents';
 import { useJupyterBookData } from '@/context/jupyterBook';
+import { isExternalUrl } from '@/utils/url';
 
 import styles from './App.module.scss';
 
@@ -16,8 +19,30 @@ function InPageTableOfContents() {
 }
 
 function Content() {
+  const pageContentRef = useRef<HTMLDivElement>();
+  const router = useRouter();
+
   const { globalHeaders, rootGlobalHeaders, pageTitle, pageBodyHtml } =
     useJupyterBookData();
+
+  useEffect(() => {
+    const pageContentNode = pageContentRef.current;
+    if (!pageContentNode) {
+      return;
+    }
+
+    const linkNodes = Array.from(pageContentNode.querySelectorAll('a'));
+    for (const link of linkNodes) {
+      const href = link.href.replace(window.location.origin, '');
+      if (!isExternalUrl(href)) {
+        link.addEventListener('click', (event) => {
+          event.preventDefault();
+          // eslint-disable-next-line @typescript-eslint/no-floating-promises
+          router.push(href);
+        });
+      }
+    }
+  }, [router]);
 
   return (
     <div
@@ -56,6 +81,7 @@ function Content() {
 
         {/* Page content */}
         <div
+          ref={pageContentRef}
           className={clsx('prose max-w-full', styles.content)}
           // eslint-disable-next-line react/no-danger
           dangerouslySetInnerHTML={{ __html: pageBodyHtml }}

--- a/theme/src/components/AppBar/AppBar.tsx
+++ b/theme/src/components/AppBar/AppBar.tsx
@@ -8,28 +8,9 @@ import { MenuPopover } from '@/components/MenuPopover';
 import { SearchInput } from '@/components/SearchInput';
 import { useJupyterBookData } from '@/context/jupyterBook';
 import { LinkInfo } from '@/types';
+import { isExternalUrl } from '@/utils/url';
 
 import styles from './AppBar.module.scss';
-
-/**
- * Checks if the string is an external URL. This works by using the value to
- * create a URL object. URL objects will throw errors for relative URLs if a
- * base URL isn't provided, so an error will indicate that the URL is an absolute URL.
- *
- * One limitation with this is it only checks for absolute URLs since Jupyter
- * Book uses relative URLs for the TOC. If an absolute URL is used that has the
- * same host, it'll be treated as an external URL, but so far there are no use cases.
- *
- * @param url The string to check.
- * @returns True if the string is an external URL, false if relative.
- */
-function isExternalUrl(url: string) {
-  try {
-    return url !== '#' && !!new URL(url);
-  } catch (_) {
-    return false;
-  }
-}
 
 /**
  * App bar component that renders the home link, search bar, and menu.

--- a/theme/src/components/TableOfContents/GlobalTableOfContents.module.scss
+++ b/theme/src/components/TableOfContents/GlobalTableOfContents.module.scss
@@ -1,0 +1,5 @@
+.externalLink {
+  path {
+    stroke: #000;
+  }
+}

--- a/theme/src/components/TableOfContents/GlobalTableOfContents.module.scss.d.ts
+++ b/theme/src/components/TableOfContents/GlobalTableOfContents.module.scss.d.ts
@@ -1,0 +1,9 @@
+export type Styles = {
+  externalLink: string;
+};
+
+export type ClassNames = keyof Styles;
+
+declare const styles: Styles;
+
+export default styles;

--- a/theme/src/components/TableOfContents/GlobalTableOfContents.tsx
+++ b/theme/src/components/TableOfContents/GlobalTableOfContents.tsx
@@ -1,0 +1,196 @@
+import { Collapse } from '@material-ui/core';
+import clsx from 'clsx';
+import { useRouter } from 'next/router';
+import { Fragment } from 'react';
+
+import { ExternalLink } from '@/components/icons';
+import { Link } from '@/components/Link';
+import { TOCHeader } from '@/context/jupyterBook';
+import { isExternalUrl } from '@/utils/url';
+
+import styles from './GlobalTableOfContents.module.scss';
+
+interface Props {
+  headers: Record<string, TOCHeader>;
+  rootHeaders: string[];
+}
+
+/**
+ * Enum values for identifying header levels in the global table of contents
+ * data structure.
+ */
+enum Header {
+  Category = 1,
+  Title = 2,
+  Subtitle = 3,
+}
+
+/**
+ * Constant for applying styles to the title headers.
+ */
+const HEADER_TITLES = [Header.Title, Header.Subtitle];
+
+/**
+ * Component for rendering the global table of contents list. This uses a
+ * recursive render function to render the global TOC data structure since the
+ * data is deeply nested.
+ */
+export function GlobalTableOfContents({ headers, rootHeaders }: Props) {
+  const router = useRouter();
+
+  /**
+   * @returns The router pathname without hashes or query parameters.
+   */
+  function getPathname() {
+    return new URL(router.asPath, 'http://tmp.com').pathname;
+  }
+
+  /**
+   * Determines if a particular header is within an expanded column.
+   *
+   * @param headerId The header ID.
+   * @returns True if the header ID is in a category that's expanded.
+   */
+  function isCategoryExpanded(headerId: string) {
+    // Use DFS to check if the header ID is in a expanded category.
+    const stack = [headerId];
+
+    while (stack.length > 0) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const currentHeaderId = stack.pop()!;
+
+      // If the current header is equal to the pathname, then the original
+      // header should be within an expanded category.
+      if (currentHeaderId === getPathname()) {
+        return true;
+      }
+
+      // Traverse down the header tree.
+      for (const childId of headers[currentHeaderId].children ?? []) {
+        stack.push(childId);
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * Recursive render function used to render the table of contents list at
+   * different levels. The function is recursive so that markup can be reused
+   * for different levels of the list, and because the table of contents data
+   * structure is deeply nested.
+   *
+   * @param headerId The header to render recursively.
+   * @returns A fragment of list nodes.
+   */
+  function render(headerId: string) {
+    // Grab header data.
+    const header = headers[headerId];
+
+    // Render children recursively.
+    const children = headers[headerId].children?.map((childId) =>
+      render(childId),
+    );
+
+    // Bool for if the URL point somewhere outside of napari.org.
+    const isExternal = isExternalUrl(header.href);
+
+    // Bool for if the header link matches the current page.
+    const isActive = header.href === getPathname();
+
+    // Bool for if the current category is expanded.
+    const isExpanded =
+      header.level === Header.Category && isCategoryExpanded(headerId);
+
+    return (
+      <Fragment key={headerId}>
+        <li
+          className={clsx(
+            // Category list spacing.
+            header.level === Header.Category && 'first:mt-0 mt-2 mb-2',
+
+            // Sub-list black border.
+            HEADER_TITLES.includes(header.level ?? 0) &&
+              'border-l border-black',
+          )}
+        >
+          <div
+            className={clsx(
+              'flex items-center',
+
+              // Hover styles for items in the TOC.
+              HEADER_TITLES.includes(header.level ?? 0) && [
+                'border-l-4 hover:border-napari-hover py-1',
+                isActive ? 'border-black' : 'border-transparent',
+              ],
+
+              header.level === Header.Title && 'pl-6',
+              header.level === Header.Subtitle && 'pl-6',
+            )}
+          >
+            <Link
+              className={clsx(
+                header.level === Header.Category && [
+                  'text-base hover:font-bold',
+
+                  // Render category bold if its currently expanded.
+                  isExpanded && 'font-bold',
+                ],
+
+                header.level === Header.Title && [
+                  'text-xs',
+
+                  // Render link bold if there are sub-pages for this particular page.
+                  (header.children?.length ?? 0) > 0 && 'font-bold',
+
+                  // Render as semi-bold if there are no sub-pages and if it's
+                  // the currently active page.
+                  isActive &&
+                    (header.children?.length ?? 0) === 0 &&
+                    'font-semibold',
+                ],
+
+                header.level === Header.Subtitle && [
+                  'text-sm',
+
+                  // Render subtitle semibold if it's active.
+                  isActive && 'font-semibold',
+                ],
+              )}
+              href={header.href}
+              // Open link in new tab if it's external.
+              newTab={isExternal}
+            >
+              {header.text}
+            </Link>
+
+            {/* Render icon if the link is external.  */}
+            {isExternal && (
+              <ExternalLink className={clsx(styles.externalLink, 'ml-2')} />
+            )}
+          </div>
+        </li>
+
+        {/*
+          The category list is collapsed by default, and is expanded when the
+          user visits a page within the category.
+        */}
+        {header.level === Header.Category ? (
+          <>
+            {isExpanded && (
+              // Render as list component and return a new sub-list.
+              <Collapse component="li" in={isExpanded} unmountOnExit>
+                <ul>{children}</ul>
+              </Collapse>
+            )}
+          </>
+        ) : (
+          children
+        )}
+      </Fragment>
+    );
+  }
+
+  // Render global TOC using root headers at the top of the list.
+  return <ul>{rootHeaders.map((href) => render(href))}</ul>;
+}

--- a/theme/src/components/TableOfContents/GlobalTableOfContents.tsx
+++ b/theme/src/components/TableOfContents/GlobalTableOfContents.tsx
@@ -116,7 +116,7 @@ export function GlobalTableOfContents({ headers, rootHeaders }: Props) {
             headerLevel === Header.Category && 'first:mt-0 mt-2 mb-2',
 
             // Sub-list black border.
-            HEADER_TITLES.includes(headerLevel) && 'border-l border-black',
+            HEADER_TITLES.includes(headerLevel) && 'border-l border-black py-1',
           )}
         >
           {/* Container for rendering the left border and adding padding to the titles. */}
@@ -125,7 +125,7 @@ export function GlobalTableOfContents({ headers, rootHeaders }: Props) {
               'flex items-center',
 
               // Hover styles for items in the TOC.
-              HEADER_TITLES.includes(headerLevel) && 'border-l-4 py-1 pl-6',
+              HEADER_TITLES.includes(headerLevel) && 'border-l-4 py-1 pl-4',
 
               headerLevel === Header.Title && 'border-transparent',
 
@@ -156,8 +156,8 @@ export function GlobalTableOfContents({ headers, rootHeaders }: Props) {
                   headerLevel === Header.Title && [
                     'text-xs',
 
-                    // Render link bold if there are sub-pages for this particular page.
-                    hasChildren && 'font-bold',
+                    // Styles for if there are sub-pages for this particular page.
+                    hasChildren && 'font-bold uppercase tracking-widest',
 
                     // Render as semi-bold if there are no sub-pages and if it's
                     // the currently active page.

--- a/theme/src/components/TableOfContents/GlobalTableOfContents.tsx
+++ b/theme/src/components/TableOfContents/GlobalTableOfContents.tsx
@@ -114,18 +114,16 @@ export function GlobalTableOfContents({ headers, rootHeaders }: Props) {
               'border-l border-black',
           )}
         >
+          {/* Container for rendering the left border and adding padding to the titles. */}
           <div
             className={clsx(
               'flex items-center',
 
               // Hover styles for items in the TOC.
               HEADER_TITLES.includes(header.level ?? 0) && [
-                'border-l-4 hover:border-napari-hover py-1',
+                'border-l-4 hover:border-napari-hover py-1 pl-6',
                 isActive ? 'border-black' : 'border-transparent',
               ],
-
-              header.level === Header.Title && 'pl-6',
-              header.level === Header.Subtitle && 'pl-6',
             )}
           >
             <Link

--- a/theme/src/components/TableOfContents/GlobalTableOfContents.tsx
+++ b/theme/src/components/TableOfContents/GlobalTableOfContents.tsx
@@ -42,7 +42,20 @@ export function GlobalTableOfContents({ headers, rootHeaders }: Props) {
    * @returns The router pathname without hashes or query parameters.
    */
   function getPathname() {
-    return new URL(router.asPath, 'http://tmp.com').pathname;
+    // Use URL constructor to extract pathname.
+    return new URL(
+      // `router.asPath` will return the pathname + query parameters and hash
+      // values like `/example?foo=bar#foobar`. Because of this, we need to
+      // extract the pathname without the query parameters or hash value using
+      // `URL.pathname`. This will return a path like `/example`.
+      router.asPath,
+
+      // Since `router.asPath` will only return a pathname, a base URL is
+      // required when creating a URL object, otherwise it'll throw a runtime
+      // error. The actual value of the URL doesn't matter since we only care
+      // about `pathname`.
+      'http://tmp.com',
+    ).pathname;
   }
 
   /**

--- a/theme/src/components/TableOfContents/GlobalTableOfContents.tsx
+++ b/theme/src/components/TableOfContents/GlobalTableOfContents.tsx
@@ -127,7 +127,11 @@ export function GlobalTableOfContents({ headers, rootHeaders }: Props) {
               // Hover styles for items in the TOC.
               HEADER_TITLES.includes(headerLevel) && 'border-l-4 py-1 pl-4',
 
-              headerLevel === Header.Title && 'border-transparent',
+              headerLevel === Header.Title && [
+                isActive && !hasChildren
+                  ? 'border-black'
+                  : 'border-transparent',
+              ],
 
               headerLevel === Header.Subtitle && [
                 'hover:border-napari-primary',

--- a/theme/src/components/TableOfContents/GlobalTableOfContents.tsx
+++ b/theme/src/components/TableOfContents/GlobalTableOfContents.tsx
@@ -176,14 +176,10 @@ export function GlobalTableOfContents({ headers, rootHeaders }: Props) {
           user visits a page within the category.
         */}
         {header.level === Header.Category ? (
-          <>
-            {isExpanded && (
-              // Render as list component and return a new sub-list.
-              <Collapse component="li" in={isExpanded} unmountOnExit>
-                <ul>{children}</ul>
-              </Collapse>
-            )}
-          </>
+          // Render as list component and return a new sub-list.
+          <Collapse component="li" in={isExpanded} unmountOnExit>
+            <ul>{children}</ul>
+          </Collapse>
         ) : (
           children
         )}

--- a/theme/src/components/TableOfContents/TableOfContents.tsx
+++ b/theme/src/components/TableOfContents/TableOfContents.tsx
@@ -56,7 +56,7 @@ export function TableOfContents({ active, className, headers, free }: Props) {
       )}
     >
       {headers.map((header) => {
-        const isActive = header.id === activeHeader;
+        const isActive = header.href === activeHeader;
 
         return (
           <li
@@ -82,7 +82,7 @@ export function TableOfContents({ active, className, headers, free }: Props) {
               'border-transparent',
               isActive && 'screen-1425:border-black',
             )}
-            key={header.id}
+            key={header.href}
             data-active={isActive}
             data-testid="tocItem"
           >
@@ -92,7 +92,7 @@ export function TableOfContents({ active, className, headers, free }: Props) {
             */}
             <a
               className={clsx(isActive && 'screen-1425:font-bold')}
-              href={`#${header.id}`}
+              href={header.href}
               onClick={(event) => {
                 // If highlighting is disabled, treat this as a regular link.
                 if (!enabled) {
@@ -108,8 +108,8 @@ export function TableOfContents({ active, className, headers, free }: Props) {
                 disableEventHandlers();
 
                 // Set the hash to the header ID so that the page scrolls to it.
-                window.location.hash = header.id;
-                setActiveHeader(header.id);
+                window.location.hash = header.href;
+                setActiveHeader(header.href);
 
                 // Wrap in timeout so that the browser has time to scroll the
                 // header. If we don't wrap it in a timeout, then setting the

--- a/theme/src/components/TableOfContents/TableOfContents.tsx
+++ b/theme/src/components/TableOfContents/TableOfContents.tsx
@@ -11,11 +11,6 @@ interface Props {
   className?: string;
 
   /**
-   * onClick: callback for when headings are clicked.
-   */
-  onClick?(heading: string): void;
-
-  /**
    * headers: header ids and titles to link to
    */
   headers: TOCHeader[];
@@ -42,13 +37,7 @@ const ENABLE_EVENT_HANDLERS_TIMEOUT_MS = 100;
  * Component for rendering TOC from the given headers. Highlighting will
  * only work if the headers match those present on the page.
  */
-export function TableOfContents({
-  active,
-  className,
-  onClick,
-  headers,
-  free,
-}: Props) {
+export function TableOfContents({ active, className, headers, free }: Props) {
   const enabled = active === undefined;
   const {
     activeHeader,
@@ -116,7 +105,6 @@ export function TableOfContents({
                 // Set the hash to the header ID so that the page scrolls to it.
                 window.location.hash = header.id;
                 setActiveHeader(header.id);
-                onClick?.(header.text);
 
                 // Wrap in timeout so that the browser has time to scroll the
                 // header. If we don't wrap it in a timeout, then setting the

--- a/theme/src/components/TableOfContents/TableOfContents.tsx
+++ b/theme/src/components/TableOfContents/TableOfContents.tsx
@@ -94,6 +94,11 @@ export function TableOfContents({ active, className, headers, free }: Props) {
               className={clsx(isActive && 'screen-1425:font-bold')}
               href={`#${header.id}`}
               onClick={(event) => {
+                // If highlighting is disabled, treat this as a regular link.
+                if (!enabled) {
+                  return;
+                }
+
                 event.preventDefault();
 
                 // The event handlers are disabled here because we want to set

--- a/theme/src/components/TableOfContents/index.ts
+++ b/theme/src/components/TableOfContents/index.ts
@@ -1,2 +1,3 @@
+export * from './GlobalTableOfContents';
 export * from './TableOfContents';
 export * from './TableOfContents.constants';

--- a/theme/src/context/jupyterBook.tsx
+++ b/theme/src/context/jupyterBook.tsx
@@ -1,13 +1,9 @@
 import { createContext, ReactNode, useContext } from 'react';
 
 export interface TOCHeader {
-  id: string;
-  text: string;
-}
-export interface GlobalHeader {
-  children: string[];
+  children?: string[];
   href: string;
-  level: number;
+  level?: number;
   text: string;
 }
 
@@ -41,7 +37,7 @@ export interface JupyterBookState {
    * https://redux.js.org/usage/structuring-reducers/normalizing-state-shape
    *
    */
-  globalHeaders: Record<string, GlobalHeader>;
+  globalHeaders: Record<string, TOCHeader>;
 
   /**
    * An array of the top-most headers in order of appearance on the DOM.

--- a/theme/src/utils/ssg.ts
+++ b/theme/src/utils/ssg.ts
@@ -3,11 +3,7 @@
 import cheerio, { Cheerio, Element } from 'cheerio';
 import fs from 'fs-extra';
 
-import {
-  GlobalHeader,
-  JupyterBookState,
-  TOCHeader,
-} from '@/context/jupyterBook';
+import { JupyterBookState, TOCHeader } from '@/context/jupyterBook';
 
 interface StackItem<T> {
   level: number;
@@ -53,7 +49,7 @@ function getGlobalHeaders<T>({
   getLinkData,
   getNextNodes,
 }: GetGlobalHeadersOptions<T>) {
-  const globalHeaders: Record<string, GlobalHeader> = {};
+  const globalHeaders: Record<string, TOCHeader> = {};
   const rootGlobalHeaders: string[] = [];
 
   const stack: StackItem<T>[] = getRootNodes().map((node) => ({
@@ -82,7 +78,7 @@ function getGlobalHeaders<T>({
 
       // Add current header as child of parent header.
       if (parentId) {
-        globalHeaders[parentId].children.push(link.href);
+        globalHeaders[parentId].children?.push(link.href);
       }
 
       const nextLevel = level + 1;
@@ -102,7 +98,7 @@ function getGlobalHeaders<T>({
   // Reverse header lists because stacks pop items in reverse.
   rootGlobalHeaders.reverse();
   for (const header of Object.values(globalHeaders)) {
-    header.children.reverse();
+    header.children?.reverse();
   }
 
   return {
@@ -120,8 +116,7 @@ function getPageHeaders(contentToc: Cheerio<Element>) {
       const href = link.attr('href') ?? '';
 
       return {
-        // Remove the starting hash on the link if it exists.
-        id: href.replace(/^#/, ''),
+        href,
         text: link.text(),
       };
     });

--- a/theme/src/utils/url.ts
+++ b/theme/src/utils/url.ts
@@ -1,0 +1,15 @@
+/**
+ * Checks if the string is an external URL. This works by using the value to
+ * create a URL object. URL objects will throw errors for relative URLs if a
+ * base URL isn't provided, so an error will indicate that the URL is an absolute URL.
+ *
+ * @param url The string to check.
+ * @returns True if the string is an external URL, false if relative.
+ */
+export function isExternalUrl(url: string): boolean {
+  try {
+    return !!new URL(url);
+  } catch (_) {
+    return false;
+  }
+}


### PR DESCRIPTION
## Description

This PR implements the Global Table of Contents component for the napari.org. The implementation works by using a recursive render function to render the markup for the TOC.

### List Levels

The list levels are separated into three types:

1. Category
2. Title
3. Subtitle

The designs currently limit it to 3 levels, but the code is written in a way that allow us to add additional levels of nesting if needed in the future.

### Recursive Rendering

Rendering works recursively so that for each category, its titles are rendered. And for each title, its subtitle is rendered if it exists. Rendering the TOC recursively this way allows us to reuse markup in the component and allows us to traverse the deeply nested TOC data structure in a more natural way.

### Category Expansion Detection

When rendering level 1 TOC items (Categories), we need to check if the current column is expanded. This works by performing DFS on the TOC data structure and checking if the current page belongs to the current category being rendered.

### Extract TOC data from index.html

The global TOC data will always be different for each page because Jupyter Book uses relative URLs. For example, on the home page, the TOC would have the following links:

- `community/index.html`
- `tutorials/index.html`
- etc.

However, if we're already on the `community/index.html` page, the links will look like:

- `#`
- `../tutorials/index.html`
- etc.

There are a few issues with working with relative URLs, so the pre-rendering code was updated to extract the TOC links from the `index.html` file only so that the links are always consistent and can be converted to absolute paths like `/community/index.html`.

## Demo

https://napari-org-global-toc.vercel.app

https://user-images.githubusercontent.com/2176050/132783933-6f082e15-a493-4e49-ad10-352055f957e3.mp4
