### PR TITLE
Table of contents for sub-pages

### DIFF
--- a/theme/src/components/TableOfContents/CategoryTableOfContents.tsx
+++ b/theme/src/components/TableOfContents/CategoryTableOfContents.tsx
@@ -1,0 +1,60 @@
+import clsx from 'clsx';
+import slug from 'slug';
+
+import { Link } from '@/components/Link';
+import { Header } from '@/constants/toc';
+import { useJupyterBookData } from '@/context/jupyterBook';
+
+interface Props {
+  /**
+   * CSS classes to apply to the root element.
+   */
+  className?: string;
+
+  /**
+   * ID of the header to render.
+   */
+  headerId: string;
+}
+
+/**
+ * Component for rendering the in page table of contents for Category index
+ * pages. If the item has children, a sub-header and sub-list will be rendered
+ * instead of a list item.
+ */
+export function CategoryTableOfContents({ className, headerId }: Props) {
+  const { globalHeaders } = useJupyterBookData();
+  const childIds = globalHeaders[headerId].children;
+
+  return (
+    <ul className={className}>
+      {childIds?.map((childId) => {
+        const header = globalHeaders[childId];
+        const hasChildren = (header.children?.length ?? 0) > 0;
+
+        return (
+          <li
+            className={clsx(!hasChildren && 'list-disc list-inside my-2')}
+            key={childId}
+          >
+            {(header.level ?? 0) < Header.Subtitle && hasChildren ? (
+              // Render sub-header and sub-list for items with children. This
+              // will only work for level 2 headers.
+              <>
+                <h2 id={slug(header.text)} className="text-2xl font-bold mt-10">
+                  {header.text}
+                </h2>
+                <CategoryTableOfContents headerId={childId} />
+              </>
+            ) : (
+              // Render as link for regular items.
+              <Link className="underline" href={header.href}>
+                {header.text}
+              </Link>
+            )}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/theme/src/components/TableOfContents/GlobalTableOfContents.tsx
+++ b/theme/src/components/TableOfContents/GlobalTableOfContents.tsx
@@ -4,6 +4,7 @@ import { createElement, Fragment } from 'react';
 
 import { ExternalLink } from '@/components/icons';
 import { Link } from '@/components/Link';
+import { Header } from '@/constants/toc';
 import { TOCHeader } from '@/context/jupyterBook';
 import { useCurrentPathname } from '@/hooks/useCurrentPathname';
 import { isExternalUrl } from '@/utils/url';
@@ -13,16 +14,6 @@ import styles from './GlobalTableOfContents.module.scss';
 interface Props {
   headers: Record<string, TOCHeader>;
   rootHeaders: string[];
-}
-
-/**
- * Enum values for identifying header levels in the global table of contents
- * data structure.
- */
-enum Header {
-  Category = 1,
-  Title = 2,
-  Subtitle = 3,
 }
 
 /**

--- a/theme/src/components/TableOfContents/GlobalTableOfContents.tsx
+++ b/theme/src/components/TableOfContents/GlobalTableOfContents.tsx
@@ -1,12 +1,12 @@
 import { Collapse } from '@material-ui/core';
 import clsx from 'clsx';
-import { useRouter } from 'next/router';
 import { createElement, Fragment } from 'react';
 
 import { ExternalLink } from '@/components/icons';
 import { Link } from '@/components/Link';
 import { TOCHeader } from '@/context/jupyterBook';
-import { createUrl, isExternalUrl } from '@/utils/url';
+import { useCurrentPathname } from '@/hooks/useCurrentPathname';
+import { isExternalUrl } from '@/utils/url';
 
 import styles from './GlobalTableOfContents.module.scss';
 
@@ -36,18 +36,7 @@ const HEADER_TITLES = [Header.Title, Header.Subtitle];
  * data is deeply nested.
  */
 export function GlobalTableOfContents({ headers, rootHeaders }: Props) {
-  const router = useRouter();
-
-  /**
-   * @returns The router pathname without hashes or query parameters.
-   */
-  function getPathname() {
-    // `router.asPath` will return the pathname + query parameters and hash
-    // values like `/example?foo=bar#foobar`. Because of this, we need to
-    // extract the pathname without the query parameters or hash value using
-    // `URL.pathname`, which will return a path like `/example`.
-    return createUrl(router.asPath).pathname;
-  }
+  const currentPathname = useCurrentPathname();
 
   /**
    * Determines if a particular header is within an expanded column.
@@ -67,7 +56,7 @@ export function GlobalTableOfContents({ headers, rootHeaders }: Props) {
       // If the current header is equal to the pathname, then the original
       // header should be within an expanded category.
       if (
-        currentHeaderId === getPathname() &&
+        currentHeaderId === currentPathname &&
         !rootHeaderSet.has(currentHeaderId)
       ) {
         return true;
@@ -106,7 +95,7 @@ export function GlobalTableOfContents({ headers, rootHeaders }: Props) {
     const isExternal = isExternalUrl(header.href);
 
     // Bool for if the header link matches the current page.
-    const isActive = header.href === getPathname();
+    const isActive = header.href === currentPathname;
 
     // Bool for if the current category is expanded.
     const isExpanded =

--- a/theme/src/components/TableOfContents/index.ts
+++ b/theme/src/components/TableOfContents/index.ts
@@ -1,3 +1,4 @@
+export * from './CategoryTableOfContents';
 export * from './GlobalTableOfContents';
 export * from './TableOfContents';
 export * from './TableOfContents.constants';

--- a/theme/src/constants/toc.ts
+++ b/theme/src/constants/toc.ts
@@ -1,0 +1,11 @@
+/**
+ * Enum values for identifying header levels in the global table of contents
+ * data structure.
+ *
+ * TODO Come up with better names for header levels.
+ */
+export enum Header {
+  Category = 1,
+  Title = 2,
+  Subtitle = 3,
+}

--- a/theme/src/hooks/useCurrentPathname.ts
+++ b/theme/src/hooks/useCurrentPathname.ts
@@ -1,0 +1,11 @@
+import { useRouter } from 'next/router';
+
+import { createUrl } from '@/utils/url';
+
+/**
+ * Hook for getting the current pathname from the Next.js router.
+ */
+export function useCurrentPathname(): string {
+  const router = useRouter();
+  return createUrl(router.asPath).pathname;
+}


### PR DESCRIPTION
## Description

This PR implements the in page table of contents for sub-pages within a category.

## Demo

https://napari-org-category-toc.vercel.app/tutorials/index.html

<img src="https://user-images.githubusercontent.com/2176050/133346019-be3b56f8-d7ab-4c11-a50f-db764b8d275e.png" width="800">

## Follow Up Work

Some pages will require updates to the content to remove duplicated data. For example, the [community page](https://napari-org-category-toc.vercel.app/community/index.html) renders the TOC twice:

<img src="https://user-images.githubusercontent.com/2176050/133346092-16a65353-47c9-469f-a173-66c30ea2e9cc.png" width="500">

This will need to happen before we release the napari theme, but the changes must be in another PR since pushes to master will start a new deployment to https://napari.org.