### PR TITLE
Page intros from Markdown front matter

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@material-ui/styles": "^4.11.4",
     "@types/lodash-es": "4.17.4",
     "clsx": "1.1.1",
+    "front-matter": "^4.0.2",
     "fs-extra": "^10.0.0",
     "lodash": "4.17.21",
     "lodash-es": "4.17.21",

--- a/theme/src/components/App/App.tsx
+++ b/theme/src/components/App/App.tsx
@@ -55,8 +55,13 @@ function Content() {
   const router = useRouter();
   const isSearch = router.asPath.includes('/search');
 
-  const { globalHeaders, rootGlobalHeaders, pageTitle, pageBodyHtml } =
-    useJupyterBookData();
+  const {
+    globalHeaders,
+    rootGlobalHeaders,
+    pageTitle,
+    pageBodyHtml,
+    pageFrontMatter: { intro: pageIntro },
+  } = useJupyterBookData();
   const currentPathname = useCurrentPathname();
   const subPageTocEnabled = useSubPageTocEnabled();
 
@@ -106,6 +111,12 @@ function Content() {
       >
         {/* Page title */}
         <h1 className="text-5xl font-bold">{pageTitle}</h1>
+
+        {pageIntro && (
+          <h2 className="font-semibold text-xs mt-3 screen-875:text-base screen-875:mt-10">
+            {pageIntro}
+          </h2>
+        )}
 
         {/* In page table of content that renders above the main content. */}
         {!isSearch && (

--- a/theme/src/context/jupyterBook.tsx
+++ b/theme/src/context/jupyterBook.tsx
@@ -7,6 +7,10 @@ export interface TOCHeader {
   text: string;
 }
 
+export interface PageFrontMatterData {
+  intro?: string;
+}
+
 /**
  * Deserialized Jupyter Book data from the DOM.
  */
@@ -25,6 +29,8 @@ export interface JupyterBookState {
    * HTML string of the page body.
    */
   pageBodyHtml: string;
+
+  pageFrontMatter: PageFrontMatterData;
 
   /**
    * A dictionary of all global headers mapped by the header ID (in this case,
@@ -51,6 +57,7 @@ const JupyterBookContext = createContext<JupyterBookState>({
   pageTitle: '',
   globalHeaders: {},
   rootGlobalHeaders: [],
+  pageFrontMatter: {},
 });
 
 interface Props extends JupyterBookState {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2771,6 +2771,13 @@ fresh@0.5.2:
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
   integrity sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=
 
+front-matter@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/front-matter/-/front-matter-4.0.2.tgz#b14e54dc745cfd7293484f3210d15ea4edd7f4d5"
+  integrity sha512-I8ZuJ/qG92NWX8i5x1Y8qyj3vizhXS31OxjKDu3LKP+7/qBgfIKValiZIEwoVoJKUHlhWtYrktkxV1XsX+pPlg==
+  dependencies:
+    js-yaml "^3.13.1"
+
 fs-extra@^10.0.0:
   version "10.0.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.0.0.tgz#9ff61b655dde53fb34a82df84bb214ce802e17c1"


### PR DESCRIPTION
## Description

This PR sets up optional rendering of page intros using front-matter data. This uses the excellent [front-matter](https://www.npmjs.com/package/front-matter) package for parsing front-matter data into JSON.

### Adding new data

Adding new front-matter data should be easy with the new setup. For example, if we wanted to add a field for disabling the page TOC, we could add a new boolean field `disableTOC`:

1. Add to TypeScript [interface](https://github.com/napari/napari.github.io/pull/162/files#diff-47aa2dcc98ae0c67cbdbef69accc5ab8f7dba3542e106c2bcd633b8a80c8cfceR10-R12):

```ts
export interface PageFrontMatterData {
  intro?: string;
  disableTOC?: boolean;
}
```

2. Add to Markdown file:

```md
---
theme:
  intro: napari is some really cool plugin for looking at big boi images.
  disableTOC: true
---

# napari

...
```

3. Use hook to access data:

```ts
import { useJupyterBookData } from '@/context/jupyterBook';

function PageTOC() {
  const {
    pageFrontMatter: { disableTOC },
  } = useJupyterBookData();

  // use disabletTOC somehow
  ...
}
```

## Demos

### Intro on tutorials TOC

https://napari.staging.imaging.cziscience.com/tutorials/index.html

![image](https://user-images.githubusercontent.com/2176050/133677882-62031dd8-8665-418a-b006-d37f508cb7be.png)

### Intro on labels tutorial

https://napari.staging.imaging.cziscience.com/tutorials/fundamentals/labels.html

![image](https://user-images.githubusercontent.com/2176050/133677934-f84d23eb-15cb-434c-8937-14eca523aa89.png)

