### PR TITLE
Update links to napari.github.io repository

### DIFF
--- a/tutorials/applications/annotate_points.md
+++ b/tutorials/applications/annotate_points.md
@@ -1,6 +1,6 @@
 # annotating videos with napari
 
-**Note**: this tutorial has been updated and is now compatible with napari > 0.4.5 and magicgui > 0.2.5. For details, see [this pull request](https://github.com/napari/tutorials/pull/114). 
+**Note**: this tutorial has been updated and is now compatible with napari > 0.4.5 and magicgui > 0.2.5. For details, see [this pull request](https://github.com/napari/napari.github.io/pull/114).
 
 In this tutorial, we will use napari (requires version 0.3.2 or greater) to make a simple GUI application for annotating points in videos.
 This GUI could be useful for making annotations required to train algorithms for markless tracking of animals (e.g., [DeepLabCut](http://www.mousemotorlab.org/deeplabcut)).

--- a/tutorials/index.md
+++ b/tutorials/index.md
@@ -90,7 +90,8 @@ interacting with you there.
 ## improving the tutorials
 
 Our tutorials are hosted on Github at
-[napari/tutorials](https://github.com/napari/tutorials). If as you're going
+[napari/napari.github.io](https://github.com/napari/napari.github.io)
+in the "tutorials" folder. If as you're going
 through the tutorials you spot any errors or can think of ways to improve them
 please raise an issue on the repository or make a PR, we'd love to have the
 community help make them better for everyone.


### PR DESCRIPTION
I noticed a few links pointing to the old repository name `napari/tutorials`, instead of `napari/napari.github.io`. That does redirect here, but I figure it's nicer to have it correct in the docs.

