### PR TITLE
Resource list - previous napari workshops (with links to videos & materials)

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -29,6 +29,7 @@
       - file: tutorials/applications/dask
       - file: tutorials/applications/napari_imageJ
       - file: tutorials/applications/cell_tracking
+    - file: tutorials/further-resources/napari-workshops
     title: Tutorials
   - file: plugins/stable/index
     sections:

--- a/tutorials/further-resources/napari-workshops.md
+++ b/tutorials/further-resources/napari-workshops.md
@@ -1,0 +1,37 @@
+# napari workshops
+
+There have been many workshops and talks given about napari.
+This page contains a list, to make them easier to find online.
+Workshops and talks are listed in reverse chronological order. Have you given a talk recently? Please update this page in [our documention](https://github.com/napari/napari.github.io).
+
+## Workshops
+
+* November 2020, [scikit-image, napari, & friends workshop]() at the [I2K conference](https://www.janelia.org/you-janelia/conferences/from-images-to-knowledge-with-imagej-friends)
+  * [Workshop materials available here](https://github.com/jni/i2k-skimage-napari)
+
+* June 2020, [NEUBIAS Academy@Home workshop](http://eubias.org/NEUBIAS/training-schools/neubias-academy-home/neubias-academy-archive-spring2020/)
+  * [Watch it here](https://www.youtube.com/watch?v=VgvDSq5aCDQ) (1 hour and 30 minute video)
+  * [Workshop materials available here](https://github.com/sofroniewn/napari-training-course)
+
+## Talks
+
+* May 2021 - *napari: a fast, interactive, multi-dimensional image viewer*
+  * [Watch it here](https://www.youtube.com/watch?v=66m8qtOQehs) (20 minute video)
+  * Presented by Nick Sofroniew at [BIDS ImageXD](https://bids.berkeley.edu/events/imagexd-2021) 2021
+
+* May 2021 - *napari: Life science lightning talk*
+  * [Watch it here](https://www.youtube.com/watch?v=YrQzAMdLU6c&list=PLJ0vO2F_f6OBAY6hjRHM_mIQ9yh32mWr0&index=4) (9 minute video)
+  * [Talk slides/notebooks](https://github.com/tlambert03/dask_lls_napari)
+  * Presented by Talley Lambert at the [Dask Summit](https://summit.dask.org/) 2021
+
+* January 2021 - *napari: an n-dimensional image viewer in Python*
+  * [Watch it here](https://www.youtube.com/watch?v=VXdFOcBCto4) (10 minute video)
+  * Presented by Juan Nunez-Iglesias at [Vis2021](https://www.vis2021.com.au/)
+
+* October 2020 - *napari: a fast n dimensional array viewer for scientifc Python*
+  * [Watch it here](https://www.youtube.com/watch?v=9_Zo2sR75To) (30 minute video)
+  * Presented by Juan Nunez-Iglesias at [SciPy Japan](https://www.scipyjapan.scipy.org/) 2020
+
+* September 2019 - *napari: multi-dimensional image visualization in Python*
+  * [Watch it here](https://www.youtube.com/watch?v=L6flM3PYI0Q) (12 minute video)
+  * Presented by Kira Evans at [ImageXD)(https://bids.berkeley.edu/events/imagexd-2019) 2019

--- a/tutorials/further-resources/napari-workshops.md
+++ b/tutorials/further-resources/napari-workshops.md
@@ -6,7 +6,11 @@ Workshops and talks are listed in reverse chronological order. Have you given a 
 
 ## Workshops
 
-* November 2020, [scikit-image, napari, & friends workshop]() at the [I2K conference](https://www.janelia.org/you-janelia/conferences/from-images-to-knowledge-with-imagej-friends)
+* June 2021, Bioimage analysis fundamentals in Python workshop at [SciPy 2021](https://www.scipy2021.scipy.org/)
+  * [Watch it here](https://www.youtube.com/watch?v=kXdy_Tp12zA) (2 hour and 20 minute video)
+  * [Workshop materials available here](https://github.com/sofroniewn/tutorial-scipy2021-bioimage-analysis-fundamentals)
+
+* November 2020, scikit-image, napari, & friends workshop at the [I2K conference](https://www.janelia.org/you-janelia/conferences/from-images-to-knowledge-with-imagej-friends)
   * [Workshop materials available here](https://github.com/jni/i2k-skimage-napari)
 
 * June 2020, [NEUBIAS Academy@Home workshop](http://eubias.org/NEUBIAS/training-schools/neubias-academy-home/neubias-academy-archive-spring2020/)

--- a/tutorials/further-resources/napari-workshops.md
+++ b/tutorials/further-resources/napari-workshops.md
@@ -19,6 +19,7 @@ You can find more videos of talks, tutorials and demos on the
   * [Workshop materials available here](https://github.com/sofroniewn/tutorial-scipy2021-bioimage-analysis-fundamentals)
 
 * November 2020, scikit-image, napari, & friends workshop at the [I2K conference](https://www.janelia.org/you-janelia/conferences/from-images-to-knowledge-with-imagej-friends)
+  * [Watch it here](https://www.youtube.com/watch?v=NZWSGXb3_Mg)
   * [Workshop materials available here](https://github.com/jni/i2k-skimage-napari)
 
 * June 2020, [NEUBIAS Academy@Home workshop](http://eubias.org/NEUBIAS/training-schools/neubias-academy-home/neubias-academy-archive-spring2020/)

--- a/tutorials/further-resources/napari-workshops.md
+++ b/tutorials/further-resources/napari-workshops.md
@@ -15,6 +15,10 @@ Workshops and talks are listed in reverse chronological order. Have you given a 
 
 ## Talks
 
+* April 2021 - *napari: n-dimensional data viewer in python*
+  * [Watch it here](https://www.youtube.com/watch?v=rOO6tK7z6yk) (25 minute video)
+  * Presented by Talley Lambert at the CZI Imaging Scientists meeting 2021
+
 * May 2021 - *napari: a fast, interactive, multi-dimensional image viewer*
   * [Watch it here](https://www.youtube.com/watch?v=66m8qtOQehs) (20 minute video)
   * Presented by Nick Sofroniew at [BIDS ImageXD](https://bids.berkeley.edu/events/imagexd-2021) 2021

--- a/tutorials/further-resources/napari-workshops.md
+++ b/tutorials/further-resources/napari-workshops.md
@@ -6,6 +6,10 @@ Workshops are listed in reverse chronological order.
 
 ## Workshops
 
+* August 2021 [NDCN](https://chanzuckerberg.com/science/programs-resources/neurodegeneration-challenge/) Workshop / September 2021 [ZIDAS](https://www.zidas.org/) Workshop
+  * [Read the workshop materials online](https://alisterburt.github.io/napari-workshops/home.html)
+  * [Workshop materials available here](https://github.com/alisterburt/napari-workshops)
+
 * June 2021, Bioimage analysis fundamentals in Python workshop at [SciPy 2021](https://www.scipy2021.scipy.org/)
   * [Watch it here](https://www.youtube.com/watch?v=kXdy_Tp12zA) (2 hour and 20 minute video)
   * [Workshop materials available here](https://github.com/sofroniewn/tutorial-scipy2021-bioimage-analysis-fundamentals)

--- a/tutorials/further-resources/napari-workshops.md
+++ b/tutorials/further-resources/napari-workshops.md
@@ -2,9 +2,13 @@
 
 There have been many workshops and tutorials given about napari.
 This page contains a list, to make them easier to find online.
-Workshops are listed in reverse chronological order.
+
+You can find more videos of talks, tutorials and demos on the
+[napari youtube channel](https://www.youtube.com/channel/UCbTgw84ew4pxTJ9qu3W2hqg/playlists).
 
 ## Workshops
+
+*Workshops are listed from newest to oldest.*
 
 * August 2021 [NDCN](https://chanzuckerberg.com/science/programs-resources/neurodegeneration-challenge/) Workshop / September 2021 [ZIDAS](https://www.zidas.org/) Workshop
   * [Read the workshop materials online](https://alisterburt.github.io/napari-workshops/home.html)

--- a/tutorials/further-resources/napari-workshops.md
+++ b/tutorials/further-resources/napari-workshops.md
@@ -1,8 +1,8 @@
 # napari workshops
 
-There have been many workshops and talks given about napari.
+There have been many workshops and tutorials given about napari.
 This page contains a list, to make them easier to find online.
-Workshops and talks are listed in reverse chronological order. Have you given a talk recently? Please update this page in [our documention](https://github.com/napari/napari.github.io).
+Workshops are listed in reverse chronological order.
 
 ## Workshops
 
@@ -16,30 +16,3 @@ Workshops and talks are listed in reverse chronological order. Have you given a 
 * June 2020, [NEUBIAS Academy@Home workshop](http://eubias.org/NEUBIAS/training-schools/neubias-academy-home/neubias-academy-archive-spring2020/)
   * [Watch it here](https://www.youtube.com/watch?v=VgvDSq5aCDQ) (1 hour and 30 minute video)
   * [Workshop materials available here](https://github.com/sofroniewn/napari-training-course)
-
-## Talks
-
-* April 2021 - *napari: n-dimensional data viewer in python*
-  * [Watch it here](https://www.youtube.com/watch?v=rOO6tK7z6yk) (25 minute video)
-  * Presented by Talley Lambert at the CZI Imaging Scientists meeting 2021
-
-* May 2021 - *napari: a fast, interactive, multi-dimensional image viewer*
-  * [Watch it here](https://www.youtube.com/watch?v=66m8qtOQehs) (20 minute video)
-  * Presented by Nick Sofroniew at [BIDS ImageXD](https://bids.berkeley.edu/events/imagexd-2021) 2021
-
-* May 2021 - *napari: Life science lightning talk*
-  * [Watch it here](https://www.youtube.com/watch?v=YrQzAMdLU6c&list=PLJ0vO2F_f6OBAY6hjRHM_mIQ9yh32mWr0&index=4) (9 minute video)
-  * [Talk slides/notebooks](https://github.com/tlambert03/dask_lls_napari)
-  * Presented by Talley Lambert at the [Dask Summit](https://summit.dask.org/) 2021
-
-* January 2021 - *napari: an n-dimensional image viewer in Python*
-  * [Watch it here](https://www.youtube.com/watch?v=VXdFOcBCto4) (10 minute video)
-  * Presented by Juan Nunez-Iglesias at [Vis2021](https://www.vis2021.com.au/)
-
-* October 2020 - *napari: a fast n dimensional array viewer for scientifc Python*
-  * [Watch it here](https://www.youtube.com/watch?v=9_Zo2sR75To) (30 minute video)
-  * Presented by Juan Nunez-Iglesias at [SciPy Japan](https://www.scipyjapan.scipy.org/) 2020
-
-* September 2019 - *napari: multi-dimensional image visualization in Python*
-  * [Watch it here](https://www.youtube.com/watch?v=L6flM3PYI0Q) (12 minute video)
-  * Presented by Kira Evans at [ImageXD)(https://bids.berkeley.edu/events/imagexd-2019) 2019


### PR DESCRIPTION
Closes https://github.com/napari/napari.github.io/issues/135

If @sofroniewn gets a napari youtube channel up and running, we may remove the "talks" section and just link to the youtube. I can see that getting stale and out of date easily. (I still feel strongly that we should maintain a list of past workshops - that is extremely useful for new & existing users to find)


