### PR TITLE
Bug bash - Medium priority bug fixes

### DIFF
--- a/theme/src/components/App/App.tsx
+++ b/theme/src/components/App/App.tsx
@@ -111,6 +111,10 @@ function Content() {
         className={clsx(
           'col-span-3 mb-6 screen-495:mb-12',
           'screen-1425:col-start-2 screen-1425:col-span-3',
+
+          // Allow overflow for really long content. This can happen for things
+          // like long Python class names on the API reference pages.
+          'overflow-x-auto',
         )}
       >
         {/* Page title */}

--- a/theme/src/components/GlobalTableOfContents.tsx
+++ b/theme/src/components/GlobalTableOfContents.tsx
@@ -203,10 +203,10 @@ export function GlobalTableOfContents({ headers, rootHeaders }: Props) {
               ],
 
               headerLevel === Header.Level2 && [
-                'text-xs',
-
                 // Styles for if there are sub-pages for this particular page.
-                hasChildren && 'font-bold uppercase tracking-widest',
+                hasChildren
+                  ? 'text-xs font-bold uppercase tracking-widest'
+                  : 'text-sm hover:border-napari-primary',
 
                 // Highlight active items with semi-bold and a black border, but
                 // only if there are no level 3 items.

--- a/theme/src/components/TableOfContents/TableOfContents.tsx
+++ b/theme/src/components/TableOfContents/TableOfContents.tsx
@@ -34,6 +34,25 @@ interface Props {
 const ENABLE_EVENT_HANDLERS_TIMEOUT_MS = 100;
 
 /**
+ * Helper for scrolling to the selected header. By default, the browser will
+ * scroll to the heading when the hash values is changed. However, if the hash
+ * is already set to the same value, the browser will not scroll to the heading.
+ * Because of this, we'l need to manually scroll to the heading when the hash
+ * values are the same.
+ *
+ * @param header The header to scroll to.
+ */
+function scrollToHeading(header: TOCHeader) {
+  if (window.location.hash === header.href) {
+    const headerNode = document.getElementById(header.href.replace(/^#/, ''));
+    const alignToTop = true;
+    headerNode?.scrollIntoView(alignToTop);
+  } else {
+    window.location.hash = header.href;
+  }
+}
+
+/**
  * Component for rendering TOC from the given headers. Highlighting will
  * only work if the headers match those present on the page.
  */
@@ -94,12 +113,13 @@ export function TableOfContents({ active, className, headers, free }: Props) {
               className={clsx(isActive && 'screen-1425:font-bold')}
               href={header.href}
               onClick={(event) => {
-                // If highlighting is disabled, treat this as a regular link.
+                event.preventDefault();
+
+                // If highlighting is disabled, only handle scrolling to the header.
                 if (!enabled) {
+                  scrollToHeading(header);
                   return;
                 }
-
-                event.preventDefault();
 
                 // The event handlers are disabled here because we want to set
                 // the active header AND scroll to the header. If the handlers
@@ -107,8 +127,7 @@ export function TableOfContents({ active, className, headers, free }: Props) {
                 // `setActiveHeader()` will have a race condition.
                 disableEventHandlers();
 
-                // Set the hash to the header ID so that the page scrolls to it.
-                window.location.hash = header.href;
+                scrollToHeading(header);
                 setActiveHeader(header.href);
 
                 // Wrap in timeout so that the browser has time to scroll the

--- a/theme/src/scss/_scrollbar.scss
+++ b/theme/src/scss/_scrollbar.scss
@@ -1,0 +1,7 @@
+::-webkit-scrollbar {
+  @apply w-2 absolute right-0;
+}
+
+::-webkit-scrollbar-thumb {
+  @apply bg-napari-primary;
+}

--- a/theme/src/scss/global.scss
+++ b/theme/src/scss/global.scss
@@ -1,5 +1,6 @@
 @import '@/scss/utils';
 @import '@/scss/_admonitions';
+@import '@/scss/_scrollbar';
 
 html {
   /*
@@ -26,6 +27,9 @@ html {
 }
 
 body {
+  // Add scroll for all pages so that the page width stays consistent.
+  @apply overflow-y-scroll;
+
   /*
     Overflow body along x-axis when contents are too long for the page. This
     should only happen in rare cases where the viewport is < 300px.

--- a/theme/src/utils/ssg.ts
+++ b/theme/src/utils/ssg.ts
@@ -337,9 +337,19 @@ export async function getPageData(file: string): Promise<JupyterBookState> {
   // The search page requires separate pre-processing of data for rendering.
   const isSearch = last(file.split('/')) === 'search.html';
 
-  if (isSearch) {
-    const pageBody = $('body');
+  const pageBody = $(isSearch ? 'body' : '#page-body');
 
+  // Make all external links open in a new tab.
+  pageBody
+    .find('a.external')
+    .toArray()
+    .map((link) => $(link))
+    .forEach((link) => {
+      link.attr('target', '_blank');
+      link.attr('rel', 'noreferrer');
+    });
+
+  if (isSearch) {
     SEARCH_PAGE_SELECTOR_REMOVE_LIST.forEach((selector) =>
       pageBody.find(selector).remove(),
     );
@@ -359,8 +369,6 @@ export async function getPageData(file: string): Promise<JupyterBookState> {
       pageFrontMatter: {},
     };
   } else {
-    const pageBody = $('#page-body');
-
     // Get page title from header text content.
     const pageHeader = pageBody.find('h1').first();
     const pageTitle = pageHeader.text().replace('¶', '');


### PR DESCRIPTION
## Description

Fixes the medium priority bugs found during the bug bash.

## Fixes

### Overflow for long page contents

This fixes two bugs related to overflow:

- [Source code pages have large amount of whitespace on right (Android/Chrome)](https://airtable.com/shr6MXADGlNNaohN7/tblKHsTqQzLZW70S9/viwhDGIqzDkq0EprV/recKepQQttU6gwHt4)
- [[MobilePhone] When doing a search with lots of results, screen size reduces](https://airtable.com/shr6MXADGlNNaohN7/tblKHsTqQzLZW70S9/viwhDGIqzDkq0EprV/reckqfiht3GpTuK0h)
- [Demo](https://napari-org-med-bugs.vercel.app/_modules/napari/layers/image/image.html)

![image](https://user-images.githubusercontent.com/2176050/135530856-f3e8b76c-f4a9-402f-891a-f814e0ede172.png)


### [Desktop] When navigating thru menu, content seems to not be aligned within pages

- [Airtable](https://airtable.com/shr6MXADGlNNaohN7/tblKHsTqQzLZW70S9/viwhDGIqzDkq0EprV/rec4ALEVDOsl7j4x7)
- [Demo](https://napari-org-med-bugs.vercel.app/)

https://user-images.githubusercontent.com/2176050/135531136-4b6420f5-6785-4e7c-b2e7-654884cf8059.mp4

### External link in content are opening in same tab when they should open in a new tab

- [Airtable](https://airtable.com/shr6MXADGlNNaohN7/tblKHsTqQzLZW70S9/viwhDGIqzDkq0EprV/recM7zZ3tdF4OAC6Q)
- [Demo](https://napari-org-med-bugs.vercel.app/)

https://user-images.githubusercontent.com/2176050/135531353-9fc0291f-b045-47e3-abc0-34bc6d3e6fc5.mp4

### [MobilePhone] when tapping on a menu and screen scrolls down, when going back up, if clicking again, link is not responsive

While this is actually the correct behavior for the browser since we use the URL hash for scrolling, it's better UX to allow re-scrolling to the same location.

- [Airtable](https://airtable.com/shr6MXADGlNNaohN7/tblKHsTqQzLZW70S9/viwhDGIqzDkq0EprV/recEeHrDY9acJZPhJ)
- [Demo](https://napari-org-med-bugs.vercel.app/)

https://user-images.githubusercontent.com/2176050/135531772-1234261f-c345-4c9a-ac58-44be9fdc8a61.mp4

### Left menubar links without parent groupings aren't styled correctly

- [Airtable](https://airtable.com/shr6MXADGlNNaohN7/tblKHsTqQzLZW70S9/viwhDGIqzDkq0EprV/recSJlg3jhyR6LzFE)
- [Demo](https://napari-org-med-bugs.vercel.app/community/mission_and_values.html)

![napari-org-toc-highlighting](https://user-images.githubusercontent.com/2176050/135531959-56cab838-ab49-4cda-a677-97ad10db7a68.gif)
