### PR TITLE
Dev server build hash

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,13 +16,14 @@
     "next:fix-dist-file-names": "ts-node -P tsconfig.node.json scripts/fix-dist-file-names",
 
     "// Scripts for running napari.org locally in development mode.": "",
-    "dev": "yarn clean && mkdir -p _build/html && run-p dev:*",
+    "dev": "run-p dev:*",
     "dev:server": "PYTHONPATH=$PWD ts-node -P tsconfig.node.json scripts/dev-server",
     "dev:tsm": "tsm -w -e default -p.@ theme/src 'theme/src/**/*.module.scss'",
 
     "// Scripts for cleaning build files.": "",
     "clean": "run-p clean:*",
     "clean:api-stable": "find api/stable/ ! -name 'index.rst' -type f -exec rm -f {} +",
+    "clean:build-hash": "rm -rf _build/jupyter-build-hash",
     "clean:docs": "rm -rf _build/html",
     "clean:theme": "rm -rf dist public",
     "clean:next": "rm -rf .next",
@@ -89,6 +90,7 @@
     "eslint-plugin-react-hooks": "4.2.0",
     "eslint-plugin-simple-import-sort": "7.0.0",
     "express": "4.17.1",
+    "file-type": "^16.5.3",
     "glob": "^7.1.7",
     "husky": "7.0.2",
     "lint-staged": "11.1.2",

--- a/scripts/dev-server.ts
+++ b/scripts/dev-server.ts
@@ -203,7 +203,6 @@ class DevServer extends EventEmitter {
     watcher.on('change', (path) => {
       console.log(`${path} changed, re-building docs`);
 
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       this.buildDocs().catch((err) => {
         console.error('Unable to build docs on file changes:', err);
         process.exit(-1);
@@ -229,8 +228,9 @@ class DevServer extends EventEmitter {
 
     // Copy public files after every build.
     this.on(Events.JupyterBuildComplete, () => {
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      copyPublicFiles();
+      copyPublicFiles().catch((err) =>
+        console.error('Unable to copy public files:', err),
+      );
     });
 
     await this.watchDocs();

--- a/scripts/dev-server.ts
+++ b/scripts/dev-server.ts
@@ -88,7 +88,7 @@ class DevServer extends EventEmitter {
    * Creates a new SHA256 hash string from the file contents of the files used
    * by Jupyter Book. This hash is used for speeding up future `yarn dev`
    * invocations so that the Jupyter Book HTML doesn't have to rebuilt if the
-   * files hasn't changed.
+   * files haven't changed.
    *
    * @returns The build hash string.
    */

--- a/scripts/dev-server.ts
+++ b/scripts/dev-server.ts
@@ -1,6 +1,11 @@
+/* eslint-disable no-await-in-loop */
+
 import { ChildProcess, spawn } from 'child_process';
 import chokidar from 'chokidar';
+import { createHash } from 'crypto';
 import { EventEmitter } from 'events';
+import FileType from 'file-type';
+import fs from 'fs-extra';
 import { resolve } from 'path';
 
 import { getTOCFiles } from '../theme/src/utils/jupyterBook';
@@ -8,6 +13,10 @@ import { copyPublicFiles } from './copy-public-files';
 
 const ROOT_DIR = resolve(__dirname, '..');
 const PORT = process.env.PORT || '8080';
+const BUILD_HASH_FILE = resolve(ROOT_DIR, '_build/jupyter-build-hash');
+
+const BUILD_HASH_IGNORE_PATTERN = /\.DS_Store/;
+const MEDIA_FILE_PATTERN = /image|video/;
 
 function isErronoException(value: unknown): value is NodeJS.ErrnoException {
   return !!(value as NodeJS.ErrnoException).errno;
@@ -30,12 +39,26 @@ class DevServer extends EventEmitter {
    * Runs `jupyter-book` to build the napari docs as a subprocess. Running
    * processes are cancelled to ensure the build is up-to-date.
    */
-  private buildDocs() {
+  private async buildDocs() {
     // Kill existing build if there is one
     if (this.buildProcess) {
       console.log('Cancelling existing build');
       this.buildProcess.kill();
     }
+
+    const buildHash = await this.createBuildHash();
+    const prevBuildHash = await this.getBuildHash();
+
+    if (buildHash === prevBuildHash) {
+      console.log('Skipping Jupyter Book build');
+      console.log('Hash:', buildHash);
+      this.emit(Events.JupyterBuildComplete);
+
+      return;
+    }
+
+    console.log('Building Jupyter Book');
+    console.log('Hash:', buildHash);
 
     this.buildProcess = spawn('jupyter-book', ['build', ROOT_DIR], {
       // Pipe process output to terminal
@@ -52,9 +75,89 @@ class DevServer extends EventEmitter {
     });
 
     this.buildProcess.once('exit', () => {
+      this.writeBuildHash(buildHash).catch((err) =>
+        console.error('Unable to write build hash:', err),
+      );
+
       this.buildProcess = undefined;
       this.emit(Events.JupyterBuildComplete);
     });
+  }
+
+  /**
+   * Creates a new SHA256 hash string from the file contents of the files used
+   * by Jupyter Book. This hash is used for speeding up future `yarn dev`
+   * invocations so that the Jupyter Book HTML doesn't have to rebuilt if the
+   * files hasn't changed.
+   *
+   * @returns The build hash string.
+   */
+  private async createBuildHash() {
+    const fileStack = await this.getWatchFiles();
+    const files: string[] = [];
+    const hash = createHash('sha256');
+
+    // Get full file list recursively.
+    while (fileStack.length > 0) {
+      const file = fileStack.pop() as string;
+      if (await fs.pathExists(file)) {
+        const stats = await fs.stat(file);
+
+        if (stats.isDirectory()) {
+          const nextFiles = await fs.readdir(file);
+          fileStack.push(
+            ...nextFiles.map((nextFile) => resolve(file, nextFile)),
+          );
+        } else if (!BUILD_HASH_IGNORE_PATTERN.exec(file)) {
+          files.push(file);
+        }
+      }
+    }
+
+    // Concurrently read files and update the file hash.
+    const hashValues = await Promise.all(
+      files.map(async (file) => {
+        const fileType = await FileType.fromFile(file);
+        const mime = fileType?.mime ?? '';
+
+        // For media files, create a hash based on their creation and modified
+        // time to speed up hashing.
+        if (MEDIA_FILE_PATTERN.exec(mime)) {
+          const stats = await fs.stat(file);
+          return (stats.ctimeMs + stats.mtimeMs).toString();
+        }
+
+        return fs.readFile(file, 'utf-8');
+      }),
+    );
+
+    // Sort hash values to ensure a consistent hash is produced.
+    hashValues.sort().forEach((value) => hash.update(value));
+
+    return hash.digest('base64').toString();
+  }
+
+  /**
+   * Writes the build hash to the build hash file.
+   *
+   * @param hash The build hash string.
+   */
+  private async writeBuildHash(hash: string) {
+    return fs.writeFile(BUILD_HASH_FILE, hash);
+  }
+
+  /**
+   * Reads the build hash file or returns an empty string if it doesn't exist.
+   *
+   * @returns The build hash string.
+   */
+  private async getBuildHash() {
+    const exists = await fs.pathExists(BUILD_HASH_FILE);
+    if (!exists) {
+      return '';
+    }
+
+    return fs.readFile(BUILD_HASH_FILE, 'utf-8');
   }
 
   /**
@@ -66,7 +169,13 @@ class DevServer extends EventEmitter {
    */
   private async getWatchFiles() {
     const files = await getTOCFiles();
-    const watchFiles = new Set(['assets', '_toc.yml', '_config.yml']);
+    const watchFiles = new Set([
+      'assets',
+      '_toc.yml',
+      '_config.yml',
+      'theme/napari',
+      'theme/napari_code_theme.py',
+    ]);
 
     // For each file, add the top-most directory so we can watch all files
     // within that directory.
@@ -93,11 +202,16 @@ class DevServer extends EventEmitter {
 
     watcher.on('change', (path) => {
       console.log(`${path} changed, re-building docs`);
-      this.buildDocs();
+
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      this.buildDocs().catch((err) => {
+        console.error('Unable to build docs on file changes:', err);
+        process.exit(-1);
+      });
     });
 
     // Build docs on initial run
-    this.buildDocs();
+    await this.buildDocs();
   }
 
   private startNextDevServer() {
@@ -108,8 +222,6 @@ class DevServer extends EventEmitter {
   }
 
   async start() {
-    await this.watchDocs();
-
     // Start Next.js dev server after the first build is complete.
     this.once(Events.JupyterBuildComplete, () => {
       this.startNextDevServer();
@@ -120,6 +232,8 @@ class DevServer extends EventEmitter {
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       copyPublicFiles();
     });
+
+    await this.watchDocs();
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -503,6 +503,11 @@
     lodash.merge "^4.6.2"
     lodash.uniq "^4.5.0"
 
+"@tokenizer/token@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@tokenizer/token/-/token-0.3.0.tgz#fe98a93fe789247e998c75e74e9c7c63217aa276"
+  integrity sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==
+
 "@tsconfig/node10@^1.0.7":
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.8.tgz#c1e4e80d6f964fbecb3359c43bd48b40f7cadad9"
@@ -2694,6 +2699,15 @@ file-entry-cache@^6.0.1:
   dependencies:
     flat-cache "^3.0.4"
 
+file-type@^16.5.3:
+  version "16.5.3"
+  resolved "https://registry.yarnpkg.com/file-type/-/file-type-16.5.3.tgz#474b7e88c74724046abb505e9b8ed4db30c4fc06"
+  integrity sha512-uVsl7iFhHSOY4bEONLlTK47iAHtNsFHWP5YE4xJfZ4rnX7S1Q3wce09XgqSC7E/xh8Ncv/be1lNoyprlUH/x6A==
+  dependencies:
+    readable-web-to-node-stream "^3.0.0"
+    strtok3 "^6.2.4"
+    token-types "^4.1.1"
+
 fill-range@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"
@@ -3149,7 +3163,7 @@ icss-replace-symbols@1.1.0, icss-replace-symbols@^1.1.0:
   resolved "https://registry.yarnpkg.com/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz#06ea6f83679a7749e386cfe1fe812ae5db223ded"
   integrity sha1-Bupvg2ead0njhs/h/oEq5dsiPe0=
 
-ieee754@^1.1.4:
+ieee754@^1.1.4, ieee754@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
@@ -4726,6 +4740,11 @@ pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+peek-readable@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/peek-readable/-/peek-readable-4.0.1.tgz#9a045f291db254111c3412c1ce4fec27ddd4d202"
+  integrity sha512-7qmhptnR0WMSpxT5rMHG9bW/mYSR1uqaPFj2MHvT+y/aOUu6msJijpKt5SkTDKySwg65OWG2JwTMBlgcbwMHrQ==
+
 picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
@@ -5278,6 +5297,13 @@ readable-stream@^3.1.1, readable-stream@^3.5.0, readable-stream@^3.6.0:
     inherits "^2.0.3"
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
+
+readable-web-to-node-stream@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz#5d52bb5df7b54861fd48d015e93a2cb87b3ee0bb"
+  integrity sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==
+  dependencies:
+    readable-stream "^3.6.0"
 
 readdirp@~3.5.0:
   version "3.5.0"
@@ -5888,6 +5914,14 @@ strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
+strtok3@^6.2.4:
+  version "6.2.4"
+  resolved "https://registry.yarnpkg.com/strtok3/-/strtok3-6.2.4.tgz#302aea64c0fa25d12a0385069ba66253fdc38a81"
+  integrity sha512-GO8IcFF9GmFDvqduIspUBwCzCbqzegyVKIsSymcMgiZKeCfrN9SowtUoi8+b59WZMAjIzVZic/Ft97+pynR3Iw==
+  dependencies:
+    "@tokenizer/token" "^0.3.0"
+    peek-readable "^4.0.1"
+
 style-search@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/style-search/-/style-search-0.1.0.tgz#7958c793e47e32e07d2b5cafe5c0bf8e12e77902"
@@ -6170,6 +6204,14 @@ toidentifier@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
   integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
+
+token-types@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/token-types/-/token-types-4.1.1.tgz#ef9e8c8e2e0ded9f1b3f8dbaa46a3228b113ba1a"
+  integrity sha512-hD+QyuUAyI2spzsI0B7gf/jJ2ggR4RjkAo37j3StuePhApJUwcWDjnHDOFdIWYSwNR28H14hpwm4EI+V1Ted1w==
+  dependencies:
+    "@tokenizer/token" "^0.3.0"
+    ieee754 "^1.2.1"
 
 tr46@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
## Description

Adds a build hash feature for speeding up `yarn dev`. This works by creating an SHA256 hash of all the files used by Jupyter Book. Regular files use their content for the hash while  edia files, use the [ctime and mtime](https://nicolasbouliane.com/blog/knowing-difference-mtime-ctime-atime).

This significantly speeds up `yarn dev` because if the hashes are the same, it'll skip `jupyter-book build` and start the Next.js dev server immediately.