### PR TITLE
Bug bash - Low priority bug fixes

### DIFF
--- a/theme/src/components/App/App.module.scss
+++ b/theme/src/components/App/App.module.scss
@@ -3,6 +3,8 @@
 @import './apiReference.scss';
 
 .content {
+  @apply text-black;
+
   // Render Markdown badges as inline elements.
   p > a > img {
     /*

--- a/theme/src/components/App/App.tsx
+++ b/theme/src/components/App/App.tsx
@@ -158,7 +158,7 @@ function Content() {
         />
 
         {/* Render links + descriptions in a grid. */}
-        <QuickLinks />
+        <QuickLinks className="mt-20" />
       </div>
 
       {/* In page table of contents that renders to the right of the main content. */}

--- a/theme/src/components/App/App.tsx
+++ b/theme/src/components/App/App.tsx
@@ -131,7 +131,7 @@ function Content() {
         {/* In page table of content that renders above the main content. */}
         {!isSearch && (
           <Media lessThan="screen-1425">
-            <div className="my-6">
+            <div className="my-12">
               <InPageTableOfContents />
             </div>
           </Media>

--- a/theme/src/components/App/App.tsx
+++ b/theme/src/components/App/App.tsx
@@ -118,7 +118,7 @@ function Content() {
         )}
       >
         {/* Page title */}
-        <h1 className="text-5xl font-bold mb-3 screen-875:mb-10">
+        <h1 className="text-5xl leading-tight font-bold mb-3 screen-875:mb-10">
           {pageTitle}
         </h1>
 

--- a/theme/src/components/App/apiReference.scss
+++ b/theme/src/components/App/apiReference.scss
@@ -30,6 +30,17 @@
 
     // Add left indentation for API attributes, methods, and textual content.
     .py {
+      // Remove unnecessary padding for class names. Class names use two
+      // `<code>` tags for rendering the full name, so we need to remove the
+      // paddings in between.
+      .descclassname {
+        @apply pr-0;
+
+        & + .descname {
+          @apply pl-0;
+        }
+      }
+
       .attribute,
       .method,
       .simple {

--- a/theme/src/components/App/apiReference.scss
+++ b/theme/src/components/App/apiReference.scss
@@ -15,10 +15,21 @@
         }
       }
 
-      .longtable {
+      table.longtable {
+        @apply flex flex-col screen-495:table;
+
         // Reduce margins for API table entries.
         p {
           @apply my-2;
+        }
+
+        tbody {
+          @apply flex flex-col screen-495:table-row-group;
+        }
+
+        .row-odd,
+        .row-even {
+          @apply flex flex-col screen-495:table-row;
         }
       }
 

--- a/theme/src/components/GlobalTableOfContents.tsx
+++ b/theme/src/components/GlobalTableOfContents.tsx
@@ -193,7 +193,7 @@ export function GlobalTableOfContents({ headers, rootHeaders }: Props) {
               HEADER_TITLES.includes(headerLevel) && 'border-l-4 py-1 pl-4',
 
               headerLevel === Header.Level1 && [
-                'text-base hover:font-bold',
+                'text-base',
 
                 // Render category bold if its currently expanded.
                 (isActive || isExpanded) && 'font-bold',

--- a/theme/src/components/GlobalTableOfContents.tsx
+++ b/theme/src/components/GlobalTableOfContents.tsx
@@ -167,9 +167,6 @@ export function GlobalTableOfContents({ headers, rootHeaders }: Props) {
       <Fragment key={headerId}>
         <li
           className={clsx(
-            // Level 1 list spacing.
-            headerLevel === Header.Level1 && 'first:mt-0 mt-2 mb-2',
-
             // Sub-list black border.
             HEADER_TITLES.includes(headerLevel) && 'border-l border-black py-1',
           )}
@@ -268,5 +265,9 @@ export function GlobalTableOfContents({ headers, rootHeaders }: Props) {
   }
 
   // Render global TOC using root headers at the top of the list.
-  return <ul ref={listRef}>{rootHeaders.map((href) => render(href))}</ul>;
+  return (
+    <ul className="space-y-4" ref={listRef}>
+      {rootHeaders.map((href) => render(href))}
+    </ul>
+  );
 }

--- a/theme/src/components/QuickLinks.tsx
+++ b/theme/src/components/QuickLinks.tsx
@@ -5,11 +5,15 @@ import { Link } from '@/components/Link';
 import { useJupyterBookData } from '@/context/jupyterBook';
 import { isExternalUrl } from '@/utils/url';
 
+interface Props {
+  className?: string;
+}
+
 /**
  * Renders a grid of table of content items with descriptions. The `quickLinks`
  * frontmatter configuration is used for rendering quick link items.
  */
-export function QuickLinks() {
+export function QuickLinks({ className }: Props) {
   const {
     pageFrontMatter: { quickLinks },
   } = useJupyterBookData();
@@ -21,6 +25,7 @@ export function QuickLinks() {
   return (
     <ul
       className={clsx(
+        className,
         'grid gap-6 screen-495:gap-12 justify-center',
         'grid-cols-3 screen-875:grid-cols-5',
       )}

--- a/theme/src/components/SearchInput.tsx
+++ b/theme/src/components/SearchInput.tsx
@@ -56,12 +56,15 @@ export function SearchInput({ large, ...props }: Props) {
    * redirects to the search page with the query added to the URL.
    */
   function submitForm(searchQuery: string) {
-    if (!searchQuery) {
+    // Remove whitespaces.
+    const query = searchQuery.trim();
+
+    if (!query) {
       return;
     }
 
     const url = createUrl('/search.html', window.location.origin);
-    url.searchParams.set(SEARCH_QUERY_PARAM, searchQuery);
+    url.searchParams.set(SEARCH_QUERY_PARAM, query);
 
     // Load new page by assigning a new URL. This is to ensure that the any
     // pending fetching logic is cancelled.


### PR DESCRIPTION
## Description

Fixes most of the low priority bugs found during the bug bash.

## Fixes

### [Mobile] "API reference" page: methods with long names have their descriptions squished against right side

- [Airtable](https://airtable.com/shr6MXADGlNNaohN7/tblKHsTqQzLZW70S9/viwhDGIqzDkq0EprV/recTXI171JlhPqUiy)
- [Demo](https://napari-org-low-bugs.vercel.app/api/stable/index.html#modules)

The API tables will now use a vertical layout when the screen is small enough (<= 495px).

![image](https://user-images.githubusercontent.com/2176050/135551012-dba53dae-bf90-4699-9cb8-f288dbc0cd99.png)

###  API reference class names can have extra whitespace on left (Android/Chrome)

- [Airtable](https://airtable.com/shr6MXADGlNNaohN7/tblKHsTqQzLZW70S9/viwhDGIqzDkq0EprV/recbh0o6EN9wbeSQl)
- [Demo](https://napari-org-low-bugs.vercel.app/api/stable/napari.layers.Image.html)

![image](https://user-images.githubusercontent.com/2176050/135551070-93beaf1d-f612-4b2d-9926-6d3ca7b84a27.png)

### Searching with empty query " " goes to search page with weird query

- [Airtable](https://airtable.com/shr6MXADGlNNaohN7/tblKHsTqQzLZW70S9/viwhDGIqzDkq0EprV/recpEisV8sslpjIrJ)
- [Demo](https://napari-org-low-bugs.vercel.app/)

Searching with an empty query will no longer start a search. Any spaces at the beginning and ending of the query will also be trimmed.

### Height between quick links and page content is too small

- [Airtable](https://airtable.com/shr6MXADGlNNaohN7/tblKHsTqQzLZW70S9/viwhDGIqzDkq0EprV/recqzu0yRoQ5R9Za5)
- [Demo](https://napari-org-low-bugs.vercel.app/#help)

![image](https://user-images.githubusercontent.com/2176050/135551199-b4cfc4c9-6586-4f43-b6cb-58efd0d767c9.png)

### A lot of text of slightly grey

- [Airtable](https://airtable.com/shr6MXADGlNNaohN7/tblKHsTqQzLZW70S9/viwhDGIqzDkq0EprV/rec19T8wX1EOvoVqo)
- [Demo](https://napari-org-low-bugs.vercel.app)

![image](https://user-images.githubusercontent.com/2176050/135551297-f06ccba3-f585-4ed5-be0e-9d4e618da457.png)

### Sidebar menu vertical spacing is too tight

- [Airtable](https://airtable.com/shr6MXADGlNNaohN7/tblKHsTqQzLZW70S9/viwhDGIqzDkq0EprV/recZweSNnEFYtqsSU)
- [Demo](https://napari-org-low-bugs.vercel.app)

![image](https://user-images.githubusercontent.com/2176050/135551358-2b2818e8-7173-4ac7-b0f5-777839eaeb1b.png)

### Items in left sidebar should not bold-ify upon hover

- [Airtable](https://airtable.com/shr6MXADGlNNaohN7/tblKHsTqQzLZW70S9/viwhDGIqzDkq0EprV/recPcCbhlcnbOx8GS)
- [Demo](https://napari-org-low-bugs.vercel.app)

![global-toc-hover](https://user-images.githubusercontent.com/2176050/135551413-3f1a702c-5ede-49b3-aa2a-dd68227f5b36.gif)

### Spacing between bottom of page title and top of in-page ToC is too tight (<1150px wide)

- [Airtable](https://airtable.com/shr6MXADGlNNaohN7/tblKHsTqQzLZW70S9/viwhDGIqzDkq0EprV/recZpTE7WSi77E20g)
- [Demo](https://napari-org-low-bugs.vercel.app/community/mission_and_values.html)

![image](https://user-images.githubusercontent.com/2176050/135551509-8a13d1b6-ab2a-4908-8cdb-d0372fa525e5.png)

### Line height for page titles is too tight

- [Airtable](https://airtable.com/shr6MXADGlNNaohN7/tblKHsTqQzLZW70S9/viwhDGIqzDkq0EprV/recxxIA92Lof8JPBz)
- [Demo](https://napari-org-low-bugs.vercel.app/developers/docs.html?highlight=organizing)

![image](https://user-images.githubusercontent.com/2176050/135551558-e40108cc-fffd-48be-ace7-a425dff979e6.png)


