### PR TITLE
Fix TOCs for API reference page

### DIFF
--- a/theme/src/components/GlobalTableOfContents.tsx
+++ b/theme/src/components/GlobalTableOfContents.tsx
@@ -117,13 +117,23 @@ export function GlobalTableOfContents({ headers, rootHeaders }: Props) {
   function render(headerId: string) {
     // Grab header data.
     const header = headers[headerId];
-    const hasChildren = (header.children?.length ?? 0) > 0;
+
+    // TODO Remove when better design is available for API reference page.
+    const isApiReference = headers['/api/stable/index.html'].children?.includes(
+      header.href,
+    );
+
+    // TODO Uncomment when better design is available for API reference page.
+    // const hasChildren = (header.children?.length ?? 0) > 0;
+
+    // TODO Remove when better design is available for API reference page.
+    const hasChildren = !isApiReference && (header.children?.length ?? 0) > 0;
     const headerLevel = header.level ?? 0;
 
     // Render children recursively.
-    const children = headers[headerId].children?.map((childId) =>
-      render(childId),
-    );
+    const children =
+      hasChildren &&
+      headers[headerId].children?.map((childId) => render(childId));
 
     // Bool for if the URL point somewhere outside of napari.org.
     const isExternal = isExternalUrl(header.href);

--- a/theme/src/components/TableOfContents/SubPageTableOfContents.tsx
+++ b/theme/src/components/TableOfContents/SubPageTableOfContents.tsx
@@ -30,21 +30,51 @@ export function SubPageTableOfContents({ className, headerId }: Props) {
     <ul className={className}>
       {childIds?.map((childId) => {
         const header = globalHeaders[childId];
+
+        // TODO Remove when better design is available for API reference page.
+        const isApiReference = globalHeaders[
+          '/api/stable/index.html'
+        ].children?.includes(header.href);
+
         const hasChildren = (header.children?.length ?? 0) > 0;
 
         return (
           <li
-            className={clsx(!hasChildren && 'list-disc list-inside my-2')}
+            // className={clsx(!hasChildren && 'list-disc list-inside my-2')}
+            // TODO Remove when better design is available for API reference page.
+            className={clsx(
+              (isApiReference || !hasChildren) && 'list-disc list-inside my-2',
+            )}
             key={childId}
           >
             {(header.level ?? 0) < Header.Level3 && hasChildren ? (
               // Render sub-header and sub-list for items with children. This
               // will only work for level 2 headers.
               <>
-                <h2 id={slug(header.text)} className="text-2xl font-bold mt-10">
+                {/* TODO Uncomment when better design is available for API reference page.  */}
+                {/* <h2 id={slug(header.text)} className="text-2xl font-bold mt-10">
                   {header.text}
-                </h2>
-                <SubPageTableOfContents headerId={childId} />
+                </h2> */}
+
+                {/* TODO Remove when better design is available for API reference page.  */}
+                {isApiReference ? (
+                  <Link className="underline" href={header.href}>
+                    {header.text}
+                  </Link>
+                ) : (
+                  <h2
+                    id={slug(header.text)}
+                    className="text-2xl font-bold mt-10"
+                  >
+                    {header.text}
+                  </h2>
+                )}
+
+                <SubPageTableOfContents
+                  // TODO Remove when better design is available for API reference page.
+                  className={clsx(isApiReference && 'ml-6')}
+                  headerId={childId}
+                />
               </>
             ) : (
               // Render as link for regular items.


### PR DESCRIPTION
## Description

[Designs](https://www.figma.com/file/Vm8z7DSjDjJurEX1RxEA39/Styling?node-id=928%3A2)

Updates TOC rendering for API reference pages so that the API index pages are accessible (at least until better designs are available). The main changes are:

1. Global TOC will only show top-level links.

![image](https://user-images.githubusercontent.com/2176050/136062629-e2517999-8188-407d-b593-ec1ccf82aabd.png)

2. Sub-page TOC will also show index pages as links

![image](https://user-images.githubusercontent.com/2176050/136062608-21a51c86-1c6b-4a23-a551-28d01c054f70.png)
