### PR TITLE
update footer according to new designs

### DIFF
--- a/theme/src/components/Footer.tsx
+++ b/theme/src/components/Footer.tsx
@@ -70,7 +70,7 @@ function FooterLinks() {
           className={clsx(
             'text-white',
             'whitespace-nowrap',
-            ' mr-4 last:mr-0 mb-4', // TODO: when flex gap is more widely used, remove this (replaced by `gap-4` in parent)
+            'mr-4 last:mr-0 mb-4', // TODO: when flex gap is more widely used, remove this (replaced by `gap-4` in parent)
             'flex flex-row items-center',
           )}
           key={item.link}

--- a/theme/src/components/Footer.tsx
+++ b/theme/src/components/Footer.tsx
@@ -6,6 +6,7 @@ import {
   IconColorProps,
   ImageSC,
   NapariHub,
+  NapariLogo,
   Twitter,
   Zulip,
 } from '@/components/icons';
@@ -21,11 +22,13 @@ interface FooterItem {
 
 const FOOTER_LINKS: FooterItem[] = [
   {
-    title: (
-      <>
-        <span className="font-normal">napari</span> hub
-      </>
-    ),
+    title: 'napari',
+    link: 'https://napari.org',
+    alt: 'Return to Home Page',
+    icon: NapariLogo,
+  },
+  {
+    title: 'napari hub',
     link: 'https://napari-hub.org',
     alt: 'Visit napari hub',
     icon: NapariHub,
@@ -66,9 +69,11 @@ function FooterLinks() {
         <Link
           className={clsx(
             'text-white',
-            'whitespace-nowrap mr-4 last:mr-0',
+            'whitespace-nowrap',
+            ' mr-4 last:mr-0 mb-4', // TODO: when flex gap is more widely used, remove this (replaced by `gap-4` in parent)
             'flex flex-row items-center',
           )}
+          key={item.link}
           href={item.link}
           newTab
         >
@@ -91,8 +96,10 @@ export function Footer() {
   return (
     <div
       className={clsx(
-        'flex flex-row items-center justify-start',
-        'h-[4.6875em] w-full',
+        'flex flex-row flex-wrap',
+        'items-center justify-start',
+        'w-full',
+        'pt-6 pb-2', // TODO: when flex gap is more widely used, replace this with `py-6 gap-4`
         'px-6 screen-495:px-12',
         'bg-black',
       )}

--- a/theme/src/components/Footer.tsx
+++ b/theme/src/components/Footer.tsx
@@ -17,15 +17,17 @@ interface FooterItem {
   link: string;
   alt: string;
   icon: ComponentType<IconColorProps>;
+  sameTab?: boolean;
   size?: string;
 }
 
 const FOOTER_LINKS: FooterItem[] = [
   {
     title: 'napari',
-    link: 'https://napari.org',
+    link: '/',
     alt: 'Return to Home Page',
     icon: NapariLogo,
+    sameTab: true,
   },
   {
     title: 'napari hub',
@@ -75,7 +77,7 @@ function FooterLinks() {
           )}
           key={item.link}
           href={item.link}
-          newTab
+          newTab={!item.sameTab}
         >
           <item.icon
             className={clsx(


### PR DESCRIPTION
- added link back to napari.org homepage in footer
- footer now wraps at smaller screen sizes

NOTE: flex gap was only recently supported by iOS (~3 months ago), so we're using a temporary workaround with margins until enough people have upgraded (see code comments for more details)

![Screen Shot 2021-10-05 at 11 21 39 AM](https://user-images.githubusercontent.com/29165011/136081242-a21d7641-2b8b-480a-8691-4f2ab0c63c4e.png)
![Screen Shot 2021-10-05 at 11 21 55 AM](https://user-images.githubusercontent.com/29165011/136081250-ad948685-a921-4131-ac7f-a4bdf86970ab.png)
![Screen Shot 2021-10-05 at 11 22 15 AM](https://user-images.githubusercontent.com/29165011/136081265-5942f327-e513-435f-8a97-7da88563e08e.png)


