### PR TITLE
Fixes image display in the plugin installation tutorial.

### DIFF
--- a/plugins/stable/find-and-install-plugin.md
+++ b/plugins/stable/find-and-install-plugin.md
@@ -24,10 +24,10 @@ directly from within napari:
 
 1. From the “Plugins” menu, select “Install/Uninstall Plugins...”.
 
-   ![napari plugin menu](../images/plugin-menu.png)
+   ![napari plugin menu](/images/plugin-menu.png)
 
 2. In the resulting window that opens, where it says “Install by name/URL”, type the name of the plugin you want to install.
 
-   ![napari plugin installation dialog](../images/plugin-install-dialog.png)
+   ![napari plugin installation dialog](/images/plugin-install-dialog.png)
 
 3. Click the “Install” button next to the input bar.


### PR DESCRIPTION
This PR re-enables the plugin installation doc images which are currently absent from the website: 

<img width="779" alt="Screen Shot 2021-10-08 at 11 32 03 AM" src="https://user-images.githubusercontent.com/3949932/136575141-1e029314-9725-44c2-b0e9-d88715089de2.png">