### PR TITLE
Broken link checks - Prevent 403 forbidden errors from image.sc links

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Link Checker
         uses: lycheeverse/lychee-action@v1.0.8
         with:
-          args: --verbose --no-progress **/*.md **/*.html --base-url https://napari.org --exclude-all-private --require-https
+          args: --verbose --no-progress **/*.md **/*.html --base-url https://napari.org --exclude-all-private --require-https lychee links.md --user-agent "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:93.0) Gecko/20100101 Firefox/93.0"
         env:
           GITHUB_TOKEN: ${{secrets.DOCS_GITHUB_TOKEN}}
 


### PR DESCRIPTION
This PR adds a `--user-agent` flag to our lychee broken link checks, so that we don't end up with 403 Forbidden errors from pages at image.sc

As described here https://github.com/napari/napari.github.io/issues/196#issuecomment-940828331

> Josh says that we need to set the user agent to fix the 403 forbidden errors with image.sc - https://forum.image.sc/t/how-to-check-for-broken-links-pointing-to-image-sc/58688/2
>
> Lychee has a `--user-agent` flag you can set.
>
> We'll need something like `--user-agent "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:93.0) Gecko/20100101 Firefox/93.0"`