### PR TITLE
Removes webkit scrollbar styles

### DIFF
--- a/theme/src/scss/_scrollbar.scss
+++ b/theme/src/scss/_scrollbar.scss
@@ -1,7 +1,0 @@
-::-webkit-scrollbar {
-  @apply w-2 absolute right-0;
-}
-
-::-webkit-scrollbar-thumb {
-  @apply bg-napari-primary;
-}

--- a/theme/src/scss/global.scss
+++ b/theme/src/scss/global.scss
@@ -1,6 +1,5 @@
 @import '@/scss/utils';
 @import '@/scss/_admonitions';
-@import '@/scss/_scrollbar';
 
 html {
   /*


### PR DESCRIPTION
It seems I added some styles I was playing around with for the scollbar. This PR removes it so that that the scrollbar styling is consistent across browsers.