### PR TITLE
Update TOC design for smaller screens

### DIFF
--- a/theme/src/components/App/App.tsx
+++ b/theme/src/components/App/App.tsx
@@ -53,11 +53,11 @@ function InPageTableOfContents() {
 
   return (
     <>
-      <Media greaterThanOrEqual="screen-1150">
+      <Media greaterThanOrEqual="screen-1425">
         <TableOfContents headers={[...sectionHeaders, ...pageHeaders]} />;
       </Media>
 
-      <Media lessThan="screen-1150">
+      <Media lessThan="screen-1425">
         <TableOfContents
           headers={[...sectionHeaders, ...pageHeaders]}
           variant="collapsed"
@@ -144,9 +144,7 @@ function Content() {
         {/* In page table of content that renders above the main content. */}
         {!isSearch && (
           <Media lessThan="screen-1425">
-            <div className="screen-1150:my-12">
-              <InPageTableOfContents />
-            </div>
+            <InPageTableOfContents />
           </Media>
         )}
 

--- a/theme/src/components/App/App.tsx
+++ b/theme/src/components/App/App.tsx
@@ -51,7 +51,20 @@ function InPageTableOfContents() {
     }
   }
 
-  return <TableOfContents headers={[...sectionHeaders, ...pageHeaders]} />;
+  return (
+    <>
+      <Media greaterThanOrEqual="screen-1150">
+        <TableOfContents headers={[...sectionHeaders, ...pageHeaders]} />;
+      </Media>
+
+      <Media lessThan="screen-1150">
+        <TableOfContents
+          headers={[...sectionHeaders, ...pageHeaders]}
+          variant="collapsed"
+        />
+      </Media>
+    </>
+  );
 }
 
 function Content() {
@@ -131,7 +144,7 @@ function Content() {
         {/* In page table of content that renders above the main content. */}
         {!isSearch && (
           <Media lessThan="screen-1425">
-            <div className="my-12">
+            <div className="screen-1150:my-12">
               <InPageTableOfContents />
             </div>
           </Media>

--- a/theme/src/components/TableOfContents/TableOfContents.tsx
+++ b/theme/src/components/TableOfContents/TableOfContents.tsx
@@ -1,7 +1,10 @@
+import { Button, Collapse } from '@material-ui/core';
 import clsx from 'clsx';
+import { useState } from 'react';
 
 import { TOCHeader } from '@/context/jupyterBook';
 
+import { ChevronDown, ChevronUp } from '../icons';
 import { useActiveHeader } from './TableOfContents.hooks';
 
 interface Props {
@@ -26,6 +29,13 @@ interface Props {
    * highlighting completely.
    */
   active?: string;
+
+  /**
+   * Variant of the table of contents to render. The collapsed variant renders
+   * the TOC in a collapsible component so that it can save vertical space on
+   * smaller screens.
+   */
+  variant?: 'normal' | 'collapsed';
 }
 
 /**
@@ -56,7 +66,13 @@ function scrollToHeading(header: TOCHeader) {
  * Component for rendering TOC from the given headers. Highlighting will
  * only work if the headers match those present on the page.
  */
-export function TableOfContents({ active, className, headers, free }: Props) {
+export function TableOfContents({
+  active,
+  className,
+  headers,
+  free,
+  variant = 'normal',
+}: Props) {
   const enabled = active === undefined;
   const {
     activeHeader,
@@ -64,8 +80,9 @@ export function TableOfContents({ active, className, headers, free }: Props) {
     enableEventHandlers,
     disableEventHandlers,
   } = useActiveHeader({ enabled, headers });
+  const [expanded, setExpanded] = useState(false);
 
-  return (
+  const tableOfContentsNode = (
     <ul
       className={clsx(
         className,
@@ -147,4 +164,29 @@ export function TableOfContents({ active, className, headers, free }: Props) {
       })}
     </ul>
   );
+
+  if (variant === 'collapsed') {
+    const chevronClassName = 'w-5 h-5';
+
+    return (
+      <div className={clsx('transition-all', expanded ? 'mb-12' : 'mb-0')}>
+        <Button
+          className={clsx('pl-0 transition-all', expanded ? 'mb-4' : 'mb-0')}
+          onClick={() => setExpanded((prevExpanded) => !prevExpanded)}
+        >
+          {expanded ? (
+            <ChevronUp className={chevronClassName} />
+          ) : (
+            <ChevronDown className={chevronClassName} />
+          )}
+
+          <p className="ml-2 uppercase font-semibold">Table of Contents</p>
+        </Button>
+
+        <Collapse in={expanded}>{tableOfContentsNode}</Collapse>
+      </div>
+    );
+  }
+
+  return tableOfContentsNode;
 }

--- a/theme/src/components/icons/ChevronDown.tsx
+++ b/theme/src/components/icons/ChevronDown.tsx
@@ -1,0 +1,25 @@
+import { IconColorProps } from './icons.type';
+
+export function ChevronDown({
+  alt,
+  className,
+  color = 'black',
+}: IconColorProps) {
+  return (
+    <svg
+      className={className}
+      width="35"
+      height="35"
+      viewBox="0 0 35 35"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      {alt && <title>{alt}</title>}
+      <path
+        d="M6 12L17.8587 23.8587L29.7173 12"
+        stroke={color}
+        strokeWidth="3"
+      />
+    </svg>
+  );
+}

--- a/theme/src/components/icons/ChevronUp.tsx
+++ b/theme/src/components/icons/ChevronUp.tsx
@@ -1,0 +1,21 @@
+import { IconColorProps } from './icons.type';
+
+export function ChevronUp({ alt, className, color = 'black' }: IconColorProps) {
+  return (
+    <svg
+      className={className}
+      width="35"
+      height="35"
+      viewBox="0 0 35 35"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      {alt && <title>{alt}</title>}
+      <path
+        d="M30 23L18.1413 11.1413L6.28267 23"
+        stroke={color}
+        strokeWidth="3"
+      />
+    </svg>
+  );
+}

--- a/theme/src/components/icons/index.ts
+++ b/theme/src/components/icons/index.ts
@@ -1,3 +1,5 @@
+export * from './ChevronDown';
+export * from './ChevronUp';
 export * from './Close';
 export * from './ExternalLink';
 export * from './GitHub';


### PR DESCRIPTION
## Description

Updates the TOC to use a collapsible layout for smaller screens so that it takes up less vertical space.

## Demo

https://napari-org-collapsible-toc.vercel.app

https://user-images.githubusercontent.com/2176050/137065489-37d49cc0-9e70-4e5b-b94b-730e9dcda071.mp4