### PR TITLE
Lychee command line flag `--base`/`--base-url` depends on the version

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Link Checker
         uses: lycheeverse/lychee-action@v1.0.8
         with:
-          args: --verbose --no-progress **/*.md **/*.html --base-url https://napari.org --exclude-all-private --require-https lychee links.md --user-agent "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:93.0) Gecko/20100101 Firefox/93.0"
+          args: --verbose --no-progress **/*.md **/*.html --base https://napari.org --exclude-all-private --require-https lychee links.md --user-agent "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:93.0) Gecko/20100101 Firefox/93.0"
         env:
           GITHUB_TOKEN: ${{secrets.DOCS_GITHUB_TOKEN}}
 


### PR DESCRIPTION
Closes https://github.com/napari/napari.github.io/issues/266

It looks like the version of lychee that runs with github actions is older than the one I used to test commands from my computer. One of the command line flags is different `--base` (older version) vs `--base-url` (newer lychee version). I'll update that in our github actions script.