### PR TITLE
Update lychee version for broken link checking

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Link Checker
-        uses: lycheeverse/lychee-action@v1.0.8
+        uses: lycheeverse/lychee-action@v1.0.9
         with:
           args: --verbose --no-progress **/*.md **/*.html --base https://napari.org --exclude-all-private --require-https lychee links.md --user-agent "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:93.0) Gecko/20100101 Firefox/93.0"
         env:

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Link Checker
         uses: lycheeverse/lychee-action@v1.0.9
         with:
-          args: --verbose --no-progress **/*.md **/*.html --base https://napari.org --exclude-all-private --require-https lychee links.md --user-agent "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:93.0) Gecko/20100101 Firefox/93.0"
+          args: --verbose --no-progress **/*.md **/*.html --base-url https://napari.org --exclude-all-private --require-https --user-agent "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:93.0) Gecko/20100101 Firefox/93.0"
         env:
           GITHUB_TOKEN: ${{secrets.DOCS_GITHUB_TOKEN}}
 

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Link Checker
         uses: lycheeverse/lychee-action@v1.0.9
         with:
-          args: --verbose --no-progress **/*.md **/*.html --base-url https://napari.org --exclude-all-private --require-https --user-agent "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:93.0) Gecko/20100101 Firefox/93.0"
+          args: --verbose --no-progress **/*.md **/*.html --base-url https://napari.org --user-agent "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:93.0) Gecko/20100101 Firefox/93.0"
         env:
           GITHUB_TOKEN: ${{secrets.DOCS_GITHUB_TOKEN}}
 


### PR DESCRIPTION
Closes https://github.com/napari/napari.github.io/issues/272 (fingers crossed!)

It seems someone else had the same issue here https://github.com/lycheeverse/lychee-action/issues/46, and updating to `lycheeverse/lychee-action@v1.0.9` fixed the problem. Lets hope it fixes our problem too.

> The failure check is there b/c otherwise the reporting will not run. Even with it there, the file reporter cannot seem to find the lychee report.

> Can you try uses: `lycheeverse/lychee-action@v1.0.9`?

> That works thank you!