### PR TITLE
Fix capitalization in docs/section titles for tutorials

### DIFF
--- a/tutorials/applications/annotate_points.md
+++ b/tutorials/applications/annotate_points.md
@@ -1,4 +1,4 @@
-# annotating videos with napari
+# Annotating videos with napari
 
 **Note**: this tutorial has been updated and is now compatible with napari > 0.4.5 and magicgui > 0.2.5. For details, see [this pull request](https://github.com/napari/napari.github.io/pull/114).
 
@@ -11,7 +11,6 @@ At the end of this tutorial, we will have created a GUI for annotating points in
 ```python
 im_path = '<path to directory with data>/*.png'
 point_annotator(im_path, labels=['ear_l', 'ear_r', 'tail'])
-
 ```
 
 The resulting viewer looks like this (images from [Mathis et al., 2018](https://www.nature.com/articles/s41593-018-0209-y), downloaded from [here](https://github.com/DeepLabCut/DeepLabCut/tree/f21321ef8060c537f9df0ce9346189bda07701b5/examples/openfield-Pranav-2018-10-30/labeled-data/m4s1)):
@@ -151,7 +150,7 @@ def point_annotator(
         points_layer.current_properties = current_properties
 ```
 
-## point_annotator()
+## `point_annotator()`
 
 We will create the GUI within a function called `point_annotator()`.
 Wrapping the GUI creation in the function allows us to integrate it into other functions (e.g., a command line interface) and applications.
@@ -171,7 +170,6 @@ def point_annotator(
     labels : List[str]
         list of the labels for each keypoint to be annotated (e.g., the body parts to be labeled).
     """
-
 ```
 
 ## Loading the video
@@ -284,8 +282,6 @@ To make the a dropdown menu populated with the valid point labels, we simply cre
 label_menu = ComboBox(label='feature_label', choices=labels)
 label_widget = Container(widgets=[label_menu])
 ```
-
-
 
 We then need to connect the dropdown menu (`label_menu`) to the points layer to ensure the menu selection is always synchronized to the `Points` layer model.
 
@@ -413,7 +409,6 @@ Now that you've put it all together, you should be ready to test! You can call t
 im_path = '<path to directory with data>/*.png'
 
 point_annotator(im_path, labels=['ear_l', 'ear_r', 'tail'])
-
 ```
 
 ### Saving the annotations

--- a/tutorials/applications/annotate_segmentation.md
+++ b/tutorials/applications/annotate_segmentation.md
@@ -1,4 +1,4 @@
-# annotating segmentation with text and bounding boxes
+# Annotating segmentation with text and bounding boxes
 
 In this tutorial, we will use napari to view and annotate a segmentation with bounding boxes and text labels. Here we perform a segmentation by setting an intensity threshold with Otsu's method, but this same approach could also be used to visualize the results of other image processing algorithms such as [object detection with neural networks](https://www.tensorflow.org/lite/models/object_detection/overview).
 
@@ -138,7 +138,7 @@ napari.run()
 
 ```
 
-## segmentation
+## Segmentation
 We start by defining a function to perform segmentation of an image based on intensity. Based on the [skimage segmentation example](https://scikit-image.org/docs/stable/auto_examples/applications/plot_thresholding.html), we determine the threshold intensity that separates the foreground and background pixels using [Otsu's method](https://en.wikipedia.org/wiki/Otsu%27s_method). We then perform some cleanup and generate a label image where each discrete region is given a unique integer index.
 
 ```python
@@ -168,7 +168,6 @@ def segment(image):
     label_image = label(cleared)
 
     return label_image
-
 ```
 
 We can test the segmentation and view it in napari.
@@ -189,7 +188,7 @@ napari.run()
 
 ![image: segmentation labels](../assets/tutorials/segmentation_labels.png)
 
-## analyzing the segmentation
+## Analyzing the segmentation
 
 Next, we use [`regionprops_table`](https://scikit-image.org/docs/dev/api/skimage.measure.html#regionprops-table) from skimage to quantify some parameters of each detection object (e.g., area and perimeter).
 
@@ -243,8 +242,8 @@ def circularity(perimeter, area):
     return circularity
 ```
 
-
 We can then calculate the circularity of each region and save it as a property.
+
 ```python
 properties['circularity'] = circularity(
     properties['perimeter'], properties['area']
@@ -290,8 +289,7 @@ Finally, we can use an list comprension to pass the bounding box extents to `mak
 bbox_rects = make_bbox([properties[f'bbox-{i}'] for i in range(4)])
 ```
 
-
-## visualizing the segmentation results
+## Visualizing the segmentation results
 Now that we have performed out analysis, we can visualize the results in napari. To do so, we will utilize 3 napari layer types: (1) Image, (2) Labels, and (3) Shapes.
 
 As we saw above in the segmentation section, we can visualize the original image and the resulting label images as follows:
@@ -321,7 +319,7 @@ Next, we will use the Shapes layer to overlay the bounding boxes for each detect
 
 The first positional argument (`bbox_rects`) contains the bounding boxes we created above. We specified that the face of each bounding box has no color (`face_color='transparent'`) and the edges of the bounding box are green (`edge_color='green'`). Finally, the name of the layer displayed in the layer list in the napari GUI is `bounding box` (`name='bounding box'`).
 
-## annotating shapes with text
+## Annotating shapes with text
 We can further annotate our analysis by using text to display properties of each segmentation. The code to create a shapes layer with text is pasted here and explained below.
 
 ```python
@@ -345,7 +343,6 @@ properties = {
 }
 ```
 
-
 Each bounding box can be annotated with text drawn from the layer `properties`. To specity the text and display properties of the text, we pass a dictionary with the text parameters (`text_parameters`). We define `text_parameters` as:
 
 ```python
@@ -368,7 +365,6 @@ circ: 0.83
 ```
 
 We set the text to green (`'color': 'green'`) with a font size of 12 (`'size': 12`). We specify that the text will be anchored in the upper left hand corner of the bounding box (`'anchor': 'upper_left'`). The valid anchors are: `'upper_right'`, `'upper_left'`, `'lower_right'`, `'lower_left'`, and `'center'`. We then offset the text from the anchor in order to make sure it does not overlap with the bounding box edge (`'translation': [-3, 0]`). The translation is relative to the anchor point. The first dimension is the vertical axis on the canvas (negative is "up") and the second dimension is along the horizontal axis of the canvas.
-
 
 All together, the visualization code is:
 
@@ -406,7 +402,7 @@ shapes_layer = viewer.add_shapes(
 napari.run()
 ```
 
-## summary
+## Summary
 In this tutorial, we have used napari to view and annotate segmentation results.
 
 ![image: annotated bounding box](../assets/tutorials/annotated_bbox.png)

--- a/tutorials/applications/cell_tracking.md
+++ b/tutorials/applications/cell_tracking.md
@@ -1,4 +1,4 @@
-# single cell tracking with napari
+# Single cell tracking with napari
 
 In this application note, we will use napari (requires version 0.4.0 or greater) to visualize single cell tracking data using the `Tracks` layer. For an overview of the `Tracks` layer, please see the [tracks layer fundamentals tutorial](../fundamentals/tracks).
 
@@ -6,15 +6,13 @@ This application note covers two examples:
 1. Visualization of a cell tracking challenge dataset
 2. Single cell tracking using btrack and napari
 
-
-## 1. cell tracking challenge data
+## 1. Cell tracking challenge data
 
 The first example of track visualization uses data from the [cell tracking challenge](http://celltrackingchallenge.net/3d-datasets/). We will use the *C. elegans* developing embryo [dataset](http://data.celltrackingchallenge.net/training-datasets/Fluo-N3DH-CE.zip) which consists of 3D+t volumetric imaging data, manually annotated tracks and cell lineage information.
 
 A full description of the data format can be found [here](https://public.celltrackingchallenge.net/documents/Naming%20and%20file%20content%20conventions.pdf).
 
-
-### extracting the tracks from the dataset
+### Extracting the tracks from the dataset
 
 We need to extract the centroids of each cell and their associated track labels from the annotated dataset. We start by loading the images containing the centroids and unique track labels:
 
@@ -91,7 +89,7 @@ napari.view_tracks(data, name='tracklets')
 napari.run()
 ```
 
-### calculating the graph using the lineage information
+### Calculating the graph using the lineage information
 
 The `Tracks` layer can also be used to visualize a track 'graph' using the additional keyword argument `graph`. The `graph`  represents associations between tracks, by defining the
 mapping between a `track_id` and the parents of the track. This graph can be useful in single cell tracking to understand the lineage of cells over multiple cell division events. For more information on the format of the track `graph`, please see the "tracks graph" section of the [tracks layer fundamentals tutorial](../fundamentals/tracks).
@@ -121,7 +119,7 @@ Finally, we remove the root nodes (*i.e.* cells without a parent) for visualizat
 graph = {k: v for k, v in full_graph.items() if v != 0}
 ```
 
-### traversing the lineage trees to identify the root nodes
+### Traversing the lineage trees to identify the root nodes
 
 One property that is useful to visualize in single cell tracking is the `track_id` of the root node of the lineage trees, *i.e.* the founder cell.
 We create it with the following code:
@@ -152,7 +150,7 @@ The `Tracks` layer enables the vertices of the tracks to be colored by user spec
 properties = {'root_id': [roots[idx] for idx in data[:, 0]]}
 ```
 
-### visualizing the tracks with napari
+### Visualizing the tracks with napari
 
 Alongside the tracks, we can also visualize the fluorescence imaging data.
 
@@ -182,7 +180,7 @@ napari.run()
 
 ---
 
-## 2. using `btrack` to track cells
+## 2. Using `btrack` to track cells
 
 The `btrack` library can be used for cell tracking. It provides a convenient `to_napari()` function to enable rapid visualization of the tracking results. You can learn more about the `btrack` library [here](https://github.com/quantumjot/BayesianTracker).
 
@@ -219,7 +217,6 @@ with btrack.BayesianTracker() as tracker:
 
 We set the configuration of the tracker using a configuration file using the `.configure_from_file()` method. An example configuration file can be found [here](https://github.com/quantumjot/BayesianTracker/blob/master/models/cell_config.json).
 
-
 Next, the objects are linked into tracks using the `.track_interactive()` method. The `step_size` argument specifies how many steps are taken before reporting the tracking statistics. The `.optimize()` method then performs a global optimization on the dataset and creates lineage trees automatically.
 
 Finally, the `.to_napari()` method returns the track vertices, track properties and graph in a format that can be directly visualized using the napari `Tracks` layer:
@@ -234,10 +231,10 @@ napari.run()
 
 A notebook for this example can be found in the btrack examples directory ([`napari_btrack.ipynb`](https://github.com/quantumjot/BayesianTracker/blob/caa56fa82330e4b16b5d28150f9b60ed963165c7/examples/napari_btrack.ipynb))
 
-## summary
+## Summary
 In this application note, we have used napari to track and visualize single cells.
 
-## further reading
+## Further reading
 
 References for cell tracking challenge:
 + https://www.nature.com/articles/nmeth.1228

--- a/tutorials/applications/dask.md
+++ b/tutorials/applications/dask.md
@@ -1,4 +1,4 @@
-# using dask and napari to process & view large datasets
+# Using Dask and napari to process & view large datasets
 
 Often in microscopy, multidimensional data is acquired and written to disk in many small files,
 each of which contain a subset of one or more dimensions from the complete dataset.
@@ -37,7 +37,7 @@ The second part of this tutorial demonstrates the use of the [`dask.array.map_bl
 to describe an arbitrary sequence of functions in a declarative manner
 that will be performed *on demand* as you explore the data (i.e. move the sliders) in `napari`.
 
-## using dask.delayed to load images
+## Using `dask.delayed` to load images
 
 If you have a function that can take a filename and return a `numpy` array,
 such as `skimage.io.imread`,
@@ -109,7 +109,7 @@ napari.view_image(stack, contrast_limits=[0,2000], multiscale=False)
 *Note: providing the* `contrast_limits` *and* `multiscale` *arguments prevents* `napari` *from trying to calculate the data min/max, which can take an extremely long time with big data.
 See [napari issue #736](https://github.com/napari/napari/issues/736) for further discussion.*
 
-## make your life easier with `dask-image`
+## Make your life easier with `dask-image`
 
 This pattern for creating a `dask.array` from image data
 has been previously described in an [excellent blog post](https://blog.dask.org/2019/06/20/load-image-data) by John Kirkham.
@@ -130,7 +130,7 @@ napari.view_image(stack, contrast_limits=[0,2000], is_pyramid=False)
 
 ![image: mCherry-H2B showing chromosome separation during mitosis. Collected on a lattice light sheet microscope](../assets/tutorials/dask1.gif)
 
-### **side note regarding higher-dimensional datasets**
+### **Side note regarding higher-dimensional datasets**
 
 In the above example, it would be quite common to have a 5+ dimensional dataset
 (e.g. different timepoints *and* channels represented among the 3D TIFF files in a folder).
@@ -174,7 +174,7 @@ stack[0, 0].compute()  # incurs a single file read
 
 ```
 
-## processing data with `dask.array.map_blocks`
+## Processing data with `dask.array.map_blocks`
 
 As previously mentioned,
 sometimes it is desirable to process data prior to viewing.
@@ -255,10 +255,8 @@ that describes a similar image processing pipeline using [ITK](https://itk.org/)
 `napari` simply sits at the end of this lazy processing chain,
 ready to show you the result on demand!
 
-## Further Reading
+## Further reading
 
-[Documentation on dask.delayed](https://docs.dask.org/en/latest/delayed.html)
-
-[Dask working notes on dask-image](https://blog.dask.org/2019/06/20/load-image-data)
-
-[Dask working notes on image processing with `dask.array.map_blocks`](https://blog.dask.org/2019/08/09/image-itk)
+- [Documentation on dask.delayed](https://docs.dask.org/en/latest/delayed.html)
+- [Dask working notes on dask-image](https://blog.dask.org/2019/06/20/load-image-data)
+- [Dask working notes on image processing with `dask.array.map_blocks`](https://blog.dask.org/2019/08/09/image-itk)

--- a/tutorials/applications/napari_imageJ.md
+++ b/tutorials/applications/napari_imageJ.md
@@ -4,7 +4,7 @@ ImageJ is a Java-based image processing program that provides extensibility via 
 
 People who wish to try their hands on ImageJ can do so by downloading and installing it using this [link](https://imagej.net/Fiji/Downloads)
 
-### Reading image with ImageJ and viewing them with napari
+### Reading images with ImageJ and viewing them with napari
 
 Here we first cut at reading images with SCIFIO+Bio-Formats via PyimageJ into NumPy arrays
 and then display them with Napari.

--- a/tutorials/applications/napari_imageJ.md
+++ b/tutorials/applications/napari_imageJ.md
@@ -1,12 +1,14 @@
-# Napari + ImageJ How-to-Guide
+# napari + ImageJ how-to guide
 
 ImageJ is a Java-based image processing program that provides extensibility via Java plugins and recordable macros. It can display, edit, analyze, process, save, and print 8-bit color and grayscale, 16-bit integer, and 32-bit floating point images. It can read many image file formats, including TIFF, PNG, GIF, JPEG, BMP, DICOM, and FITS, as well as raw formats. It has a plethora of features that can be checked out [here](https://en.wikipedia.org/wiki/ImageJ#Features).
 
 People who wish to try their hands on ImageJ can do so by downloading and installing it using this [link](https://imagej.net/Fiji/Downloads)
 
-### Reading Image with ImageJ and Viewing them with Napari 
+### Reading image with ImageJ and viewing them with napari
+
 Here we first cut at reading images with SCIFIO+Bio-Formats via PyimageJ into NumPy arrays
 and then display them with Napari.
+
 ```python
 import napari, sys
 
@@ -19,7 +21,6 @@ try:
 except ImportError:
     raise ImportError("""This example uses ImageJ but pyimagej is not
     installed. To install try 'conda install pyimagej'.""")
-
 
 print('--> Initializing imagej')
 ij = imagej.init('sc.fiji:fiji') # Fiji includes Bio-Formats.
@@ -39,34 +40,44 @@ viewer.grid_view()
 napari.run()
 ```
 
-### Using ImageJ and Napari side-by-side 
-#### Issues with using ImageJ and Napari simultaneously
+### Using ImageJ and napari side-by-side
+#### Issues with using ImageJ and napari simultaneously
+
 - Threading concerns with macOS i.e. to display the Fiji user interface, Java AWT must be started on the Cocoa event loop, however, attempting to invoke the napari viewer from the Cocoa event loop thread crashes the program with errors. 
 - If we code a script to open napari and ImageJ together then
   - The napari UI starts,
   - But, the script blocks until the close of napari viewer window.
   - Even after closing the window, the ImageJ UI never appears even though the code to start ImageJ does then execute.
  
-#### Simultaneously using ImageJ and Napari in various environments
+#### Simultaneously using ImageJ and napari in various environments
+
 Due to behavioural differences between plain Python and IPython we use slightly different approaches to run ImageJ and python simultaneously in each different environment. 
 
 ##### 1. Running napari+ImageJ from plain Python
-Firstly import napari
+
+Firstly import napari:
+
 ```python
 import napari
 viewer = napari.Viewer()
 ```
+
 When napari comes up, open the Jupyter Qt console and type:
+
 ```python
 import imagej
 ij = imagej.init(headless=False)
 ij.ui().showUI()
 ```
+
 This works because the console in napari is running in the correctly initialized Qt GUI/main thread. However,if we even touch the Java UI from Python it locks up i.e.  Python will now lock up even for the simplest line of code such as:
+
 ```python 
 ij.ui().showDialog('hello')
 ```
+
 To fix this we can use either of these 3 following methods :
+
 1. Use Java’s EventQueue to queue the task on the Java event dispatch thread:
     ```python 
     from jnius import PythonJavaClass, java_method, autoclass
@@ -118,8 +129,11 @@ if __name__ == "__main__":
 Note that the app.exec_() call blocks the main thread, because Qt takes it over as its GUI/main thread. On macOS, the main thread is the only thread that works for Qt to use as its GUI/main thread.
 
 ##### 3. Starting napari+ImageJ from IPython
+
 A code that successfully starts ImageJ from IPython 
-**NOTE: First initialize Qt using %gui qt or at launch via ipython --gui=qt
+
+**NOTE:** First initialize Qt using %gui qt or at launch via ipython --gui=qt
+
 ```python
 def start_imagej():
     import imagej
@@ -131,4 +145,4 @@ from PyQt5 import QtCore
 QtCore.QTimer.singleShot(0, start_imagej)
 ```
 
-This how-to-guide is an adaptation of demos provided by [Curtis Rueden](https://forum.image.sc/u/ctrueden) on [https://forum.image.sc/](https://forum.image.sc/t/read-images-with-imagej-display-them-with-napari/32156) platform. 
+This how-to guide is an adaptation of demos provided by [Curtis Rueden](https://forum.image.sc/u/ctrueden) on [https://forum.image.sc/](https://forum.image.sc/t/read-images-with-imagej-display-them-with-napari/32156) platform.

--- a/tutorials/fundamentals/getting_started.md
+++ b/tutorials/fundamentals/getting_started.md
@@ -1,4 +1,4 @@
-# getting started with napari
+# Getting started with napari
 
 Welcome to the getting started with **napari** tutorial!
 
@@ -8,7 +8,7 @@ For help with installation see our [installation tutorial](./installation).
 This tutorial will teach you all the different ways to launch napari.
 At the end of the tutorial you should be able to launch napari and see the viewer your favorite way.
 
-## launching napari
+## Launching napari
 
 There are four ways to launch the **napari** viewer:
 
@@ -20,7 +20,7 @@ There are four ways to launch the **napari** viewer:
 All four of these methods will launch the same napari viewer
 but depending on your use-case different ones may be preferable.
 
-### command line usage
+### Command line usage
 
 To launch napari from the command line simply run
 
@@ -54,7 +54,7 @@ but it doesn't allow you to preprocess your images before opening them.
 It is also currently not possible to save images or other layer types directly from the viewer,
 but we'll be adding support for this functionality soon as discussed in [#379](https://github.com/napari/napari/issues/379).
 
-### python script usage
+### Python script usage
 
 To launch napari from a python script, inside your script you should import `napari`,
 and then create the `Viewer` by adding some data.
@@ -110,7 +110,7 @@ is that the you can continue to programmatically interact with the viewer from t
 including bidirectional communication, where code run in the console will update the current viewer
 and where data changed in the GUI will be accessible in the console.
 
-### jupyter notebook usage
+### Jupyter notebook usage
 
 You can also launch napari from a jupyter notebook,
 such as [`examples/notebook.ipynb`](https://github.com/napari/napari/tree/master/examples/notebook.ipynb)
@@ -123,7 +123,7 @@ is that you can continue to programmatically interact with the viewer from jupyt
 including bidirectional communication, where code run in the notebook will update the current viewer
 and where data changed in the GUI will be accessible in the notebook.
 
-## next steps
+## Next steps
 
 To learn more about how to use the napari viewer with different types of napari layers
 checkout the [viewer tutorial](./viewer) and more of our tutorials listed below.

--- a/tutorials/fundamentals/installation.md
+++ b/tutorials/fundamentals/installation.md
@@ -10,9 +10,9 @@ for more advanced installation procedures. At the end of the tutorial you should
 have napari successfully installed on your computer and be able to make the
 napari viewer appear.
 
-## installation
+## Installation
 
-### which distribution to install
+### Which distribution to install
 
 If you want to contribute back to the napari codebase, you should install from
 source code: see the [from source](#clone-the-repository-locally-and-install-in-editable-mode) section.
@@ -24,7 +24,7 @@ is the easiest way to install, it does not require having python pre-installed.
 If you are using napari from Python to programmatically interact with the app,
 you can install via pip, conda-forge, or from source.
 
-### from pip, with "batteries included"
+### From pip, with "batteries included"
 
 napari can be installed on most macOS, Linux, and Windows systems with Python
 3.7, 3.8, and 3.9 using pip:
@@ -49,7 +49,7 @@ pip install "napari[all]"
 ```
 ````
 
-### from conda-forge
+### From conda-forge
 
 If you prefer to manage packages with conda, napari is available on the
 conda-forge channel. You can install it with:
@@ -58,7 +58,7 @@ conda-forge channel. You can install it with:
 conda install -c conda-forge napari
 ```
 
-### install from the master branch on Github
+### Install from the main branch on Github
 
 To install the "next-release" version from github via pip, call
 
@@ -66,7 +66,7 @@ To install the "next-release" version from github via pip, call
 pip install "git+https://github.com/napari/napari.git#egg=napari[all]"
 ```
 
-### clone the repository locally and install in editable mode
+### Clone the repository locally and install in editable mode
 
 To clone the github repository for local install
 
@@ -76,7 +76,7 @@ cd napari
 pip install -e .[all]
 ```
 
-## checking it worked
+## Checking it worked
 
 After installation you should be able to launch napari from the command line by
 simply running
@@ -89,7 +89,7 @@ An empty napari viewer should appear as follows
 
 ![image: An empty napari viewer](../assets/tutorials/launch_cli_empty.png)
 
-## upgrading
+## Upgrading
 
 If you installed napari with `pip` you can upgrade by calling
 
@@ -97,7 +97,7 @@ If you installed napari with `pip` you can upgrade by calling
 pip install "napari[all]" --upgrade
 ```
 
-## choosing a different Qt backend
+## Choosing a different Qt backend
 
 ````{admonition} Specifying a GUI Backend
 :class: tip
@@ -128,7 +128,7 @@ pip install "napari[pyside2]"  # for PySide2
 *Note: if you switch backends, it's a good idea to `pip uninstall` the one
 you're not using.*
 
-## installing as a bundled app
+## Installing as a bundled app
 
 napari can also be installed as a bundled app on each of the major platforms,
 MacOS, Windows, and Linux with a simple one click download and installation
@@ -148,7 +148,7 @@ assets](../assets/tutorials/installation/bundle_assets.png)
 
 You can then download the appropriate zip file for your platform.
 
-### installing the MacOS bundle
+### Installing the MacOS bundle
 
 Once you have downloaded the MacOS bundle zip you will have a zip file with a
 name like `napari-0.3.7-macOS.zip`. After unzipping you will have a file with a
@@ -195,7 +195,7 @@ box](../assets/tutorials/installation/bundle_open.png)
 After clicking "Open", the viewer should appear. Don't worry, you only have to
 go through this process once when you install a new bundle.
 
-### installing the Windows bundle
+### Installing the Windows bundle
 
 Once you have downloaded the Windows bundle zip you will have a zip file with a
 name like `napari-0.3.7-Windows.zip`. Unzip the bundle (you may like to use a
@@ -234,12 +234,12 @@ The very first time you launch napari the startup time will be fairly slow, but
 after that you will find that napari launches more quickly.
 
 
-### installing the Linux bundle
+### Installing the Linux bundle
 
 (Guide coming soon... In the meantime, if you try it and encounter issues, see
 below for how to contact us.)
 
-## bug reports
+## Bug reports
 
 If you are running into issues, please open a new issue on our [issue
 tracker](https://github.com/napari/napari/issues) and include the output of the
@@ -249,14 +249,14 @@ following command
 napari --info
 ```
 
-## help
+## Help
 
 We're a community partner on the [imagesc
 forum](https://forum.image.sc/tags/napari) and all usage support requests should
 be posted on the forum with the tag `napari`. We look forward to interacting
 with you there.
 
-## next steps
+## Next steps
 
 Now that you've got napari installed, checkout our [getting
 started](./getting_started) tutorial to start learning how to use it!

--- a/tutorials/fundamentals/viewer.md
+++ b/tutorials/fundamentals/viewer.md
@@ -29,7 +29,7 @@ on the screen and the data inside of it.
 
 +++
 
-## launching the viewer
+## Launching the viewer
 
 As discussed in [getting started](./getting_started) tutorial the napari viewer
 can be launched from the command-line, a python script, an IPython console, or a
@@ -96,7 +96,7 @@ continue exploring the rest of the viewer.
 
 +++
 
-## layout of the viewer
+## Layout of the viewer
 
 The viewer is organized into a few key areas:
 
@@ -106,7 +106,7 @@ We'll go through each of these in the next sections.
 
 +++
 
-### main canvas
+### Main canvas
 
 The main canvas is in the center of the viewer and contains the visual display
 of the data passed to **napari**, including images, point, shapes, and our other
@@ -122,7 +122,7 @@ performant. You can also return to the original zoom level by clicking the
 
 +++
 
-### layer list
+### Layer list
 
 One of the basic **napari** objects are layers. There are different layer types
 for `Image`, `Points`, `Shapes`, and other basic data types. They can be added
@@ -191,7 +191,7 @@ You can rearrange layers by clicking and dragging them.
 viewer.close()
 ```
 
-### layer controls
+### Layer controls
 
 Above the layers list in the top left corner of the viewer there is a box that
 contains the layer controls. The controls that you have available to you depend
@@ -242,7 +242,7 @@ specific tutorials listed at the bottom of this tutorial.
 
 +++
 
-### new layer buttons
+### New layer buttons
 
 New `Points`, `Shapes`, and `Labels` layers can be added to the viewer using the
 new layer buttons in the bottom righthand corner of the GUI. These correspond to
@@ -268,7 +268,7 @@ viewer.layers.pop(i)
 
 +++
 
-## dimension sliders
+## Dimension sliders
 
 One of the main strengths of **napari** is that it has been designed from the
 beginning to handle n-dimensional data. While much consumer photography is 2D
@@ -314,7 +314,7 @@ viewer.add_image(blobs, name='blobs', opacity=0.5, colormap='red')
 nbscreenshot(viewer)
 ```
 
-### viewer buttons
+### Viewer buttons
 
 Underneath the layers list there is a row of buttons that includes the `Console`
 button that will show or hide our console that allows you to interact with a
@@ -373,7 +373,7 @@ initial values.
 
 +++
 
-### status bar
+### Status bar
 
 At the very bottom of the GUI there is a status bar that contains useful updates
 and tips.
@@ -389,7 +389,7 @@ which layer and tools are currently selected.
 
 +++
 
-## changing viewer theme
+## Changing viewer theme
 
 Currently, **napari** comes with two different themes `light` and `dark`, which
 is the default. To change the theme, update `theme` property of the viewer:
@@ -422,7 +422,7 @@ more information about building the icons and add one yourself!
 
 +++
 
-## custom keybinding
+## Custom keybinding
 
 One of the promises of **napari** is to provide a beginner friendly environment
 for interactive analysis. For example, we want to enable workflows where people
@@ -488,7 +488,7 @@ within **napari** and we hope you take full advantage of them.
 
 +++
 
-## next steps
+## Next steps
 
 Hopefully, this tutorial has given you an overview of the functionality
 available on the **napari** viewer, including the `LayerList` and some of the

--- a/tutorials/index.md
+++ b/tutorials/index.md
@@ -23,7 +23,7 @@ developing it.
 
 +++
 
-## what is napari?
+## What is napari?
 
 **napari** is a fast, interactive, multi-dimensional image viewer for Python.
 It's designed for browsing, annotating, and analyzing large multi-dimensional
@@ -66,7 +66,7 @@ To checkout some cool example uses of **napari** with scientific data see our
 
 +++
 
-## getting started
+## Getting started
 
 These tutorials target people who want to use napari as a user. If you are also
 interested in contributing to napari then please check out [contributing
@@ -78,7 +78,7 @@ checkout our [installing napari](./fundamentals/installation) tutorial.
 
 +++
 
-## help
+## Help
 
 We're a community partner on the [imagesc
 forum](https://forum.image.sc/tags/napari) and all help and support requests
@@ -87,7 +87,7 @@ interacting with you there.
 
 +++
 
-## improving the tutorials
+## Improving the tutorials
 
 Our tutorials are hosted on Github at
 [napari/napari.github.io](https://github.com/napari/napari.github.io)


### PR DESCRIPTION
Changes documents/section titles to sentence case (this is part of #176)

The layers tutorials are not changed as they will be fixed as part of the refactor (to be done after the main docs reorganization).