### PR TITLE
update a few references to deprecated is_pyramid parameter

### DIFF
--- a/tutorials/applications/dask.md
+++ b/tutorials/applications/dask.md
@@ -101,7 +101,7 @@ and handing a `numpy` array to `napari` each time a new timepoint or channel is 
 ```python
 import napari
 
-# specify contrast_limits and is_pyramid=False with big data
+# specify contrast_limits and multiscale=False with big data
 # to avoid unnecessary computations
 napari.view_image(stack, contrast_limits=[0,2000], multiscale=False)
 ```
@@ -125,7 +125,7 @@ import napari
 from dask_image.imread import imread
 
 stack = imread("/path/to/experiment/*.tif")
-napari.view_image(stack, contrast_limits=[0,2000], is_pyramid=False)
+napari.view_image(stack, contrast_limits=[0,2000], multiscale=False)
 ```
 
 ![image: mCherry-H2B showing chromosome separation during mitosis. Collected on a lattice light sheet microscope](../assets/tutorials/dask1.gif)
@@ -230,11 +230,11 @@ deconvolved = deskewed.map_blocks(deconv, dtype="float32")
 cropped = deconvolved.map_blocks(crop, dtype="float32")
 
 # put the resulting dask array into napari.
-# (don't forget the contrast limits and is_pyramid==False !)
+# (don't forget the contrast limits and multiscale==False !)
 v = napari.view_image(
     cropped,
     contrast_limits=[90, 1500],
-    is_pyramid=False,
+    multiscale=False,
     ndisplay=3,
     scale=(3, 1, 1),
 )

--- a/tutorials/fundamentals/image.md
+++ b/tutorials/fundamentals/image.md
@@ -131,7 +131,7 @@ for performance. If, however you don't have a precomputed pyramid but try and
 show a exceptionally large image napari will try and compute pyramids for you
 unless you tell it not too.
 
-You can use the `is_pyramid` keyword argument to specify if your data is an
+You can use the `multiscale` keyword argument to specify if your data is an
 image pyramid or not. If you don't provide this value, then will try and guess
 whether your data is or needs to be an image pyramid.
 


### PR DESCRIPTION
The `is_pyramid` argument has been renamed to `multiscale`. This PR updates remaining references to `is_pyramid` in the docs (keeping only the mention in the release notes for v0.3.0)

