### PR TITLE
.lycheeignore file for automated broken link checks

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,46 @@
+# Localhost links should not be checked
+http://localhost:*
+
+# Image files should not be treated like links
+*/images/*.png
+*/images/*.jpg
+*/images/*.gif
+*/assets/*.png
+*/assets/*.jpg
+*/assets/*.gif
+
+# Not real links, used in setup instructions only
+https://github.com/your-username/napari.git
+git+https://github.com/napari/napari.git#egg=napari[all]
+https://github.com/napari/napari.git
+
+# Not real links, part of the webpage templates
+_templates/page.html
+theme/napari/page.html
+https://napari.org/napari/page.html
+https://napari.org/src/pages/%5B%5B...parts%5D%5D.tsx
+
+# Not available unless logged into github
+https://github.com/settings/emails
+# You must be a core developer & logged in to see this page
+https://github.com/orgs/napari/teams/core-devs
+
+# Linking to GitHub pages of individual users produces
+# HTTP status client error (429 Too Many Requests)
+# In alphabetical order below:
+https://github.com/AhmetCanSolak
+https://github.com/andy-sweet
+https://github.com/csweaver
+https://github.com/GenevieveBuckley
+https://github.com/goanpeca
+https://github.com/jni
+https://github.com/kevinyamauchi
+https://github.com/kne42
+https://github.com/neuromusic
+https://github.com/nclack
+https://github.com/royerloic
+https://github.com/sofroniewn
+https://github.com/tlambert03
+https://github.com/ziyangczi
+# The napari github org page also shows 429 Too Many Requests
+https://github.com/napari


### PR DESCRIPTION
A `.lycheeignore` file is the simplest way to maintain an exclude list for the automated link checking.

This PR should fix a number of the alerts we see in https://github.com/napari/napari.github.io/issues/292 (it'll fix about a third to a half of the flagged links, at a rough guess).

The main categories of things we are ignoring include:
- localhost links
- images (the markdown syntax for images is too similar to actual links, this seems to confuse lychee)
- links that aren't actually real links (eg: `https://github.com/your-username/napari.git` is in our setup instructions but isn't a real link that needs checking)
- links to individual user github pages, eg: https://github.com/jni (these produce a 429 Too Many Requests error, and there's no easy way around it)
