### PR TITLE
Improve lychee link checker ignore file

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,13 +1,9 @@
 # Localhost links should not be checked
-http://localhost:*
+http://localhost:**
 
 # Image files should not be treated like links
-*/images/*.png
-*/images/*.jpg
-*/images/*.gif
-*/assets/*.png
-*/assets/*.jpg
-*/assets/*.gif
+**/images/**
+**/assets/**
 
 # Not real links, used in setup instructions only
 https://github.com/your-username/napari.git


### PR DESCRIPTION
PR https://github.com/napari/napari.github.io/pull/294 doesn't seem to have helped much, which is surprising to me. This issue https://github.com/napari/napari.github.io/issues/296 has more broken links, not fewer :angry: 

I'm guessing that either 
1. lychee isn't finding the ignore file at all (seems likely, but I don't understand why, that should just happen automatically), or
2. The glob patterns in the ignore file are flawed.

This PR tries to address 2. It looks like I should have used a double asterisk for the ignore paths to image files. This PR won't fix problem 1, if that is indeed what's happening.
