### PR TITLE
DOC: Sync install instructions in index with install.md

### DIFF
--- a/index.md
+++ b/index.md
@@ -108,7 +108,7 @@ napari into a clean virtual environment using an environment manager like
 [venv](https://docs.python.org/3/library/venv.html).  For example, with `conda`:
 
 ```sh
-conda create -y -n napari-env python=3.8
+conda create -y -n napari-env -c conda-forge python=3.9
 conda activate napari-env
 pip install "napari[all]"
 ```


### PR DESCRIPTION
Bump to python 3.9, and use -c conda-forge

There are other minor differences, like the use of `python -m` in
install.md, but i did not went this far.