### PR TITLE
Fix broken link to bundled app installation instructions (napari/napari#5183)

### DIFF
--- a/0.4.15/tutorials/fundamentals/installation.html
+++ b/0.4.15/tutorials/fundamentals/installation.html
@@ -649,7 +649,7 @@ This installation method does not have any prerequisites.</p>
 in active development, and may not be very stable. We strongly recommend
 <span class="xref myst">installing as a Python package instead</span>.</p>
 </div>
-<p><span class="xref myst">Click here</span> to see instructions
+<p><a class="reference internal" href="#install-as-a-bundled-app"><span class="std std-doc">Click here</span></a> to see instructions
 for installing the bundled app.</p>
 </section>
 </section>

--- a/0.4.16/tutorials/fundamentals/installation.html
+++ b/0.4.16/tutorials/fundamentals/installation.html
@@ -1864,7 +1864,7 @@ This installation method does not have any prerequisites.</p>
 in active development, and may not be very stable. We strongly recommend
 <span class="xref myst">installing as a Python package instead</span>.</p>
 </div>
-<p><span class="xref myst">Click here</span> to see instructions
+<p><a class="reference internal" href="#install-as-a-bundled-app"><span class="std std-doc">Click here</span></a> to see instructions
 for installing the bundled app.</p>
 </div>
 </div>


### PR DESCRIPTION
Note that this is far from the only broken link, in the same issue, the screenshot shows "as a Python package instead" that should also be a link.

A quick way to see the number of non-existing links woudl be:

    $ rg 'class="xref myst"' | cut -f1 -d: |cut -f1-2 -d'/' | uniq -c | sort -n
       1 0.4.16/plugins
       1 dev/plugins
       2 0.4.15/index.html
       2 0.4.16/index.html
       2 0.4.16/tutorials
       4 0.4.16/roadmaps
       5 0.4.16/plugins
       6 0.4.15/plugins
       7 0.4.15/tutorials
       8 0.4.16/roadmaps
       9 0.4.15/developers
       9 0.4.16/developers
      12 0.4.15/guides
      12 0.4.15/roadmaps
      12 0.4.16/guides

Therefore there are potentially plenty of other links to fix in already released version.