### PR TITLE
Fix calendar ID in 0.4.16

### DIFF
--- a/0.4.16/_sources/community/meeting_schedule.md
+++ b/0.4.16/_sources/community/meeting_schedule.md
@@ -1,6 +1,6 @@
 # Meeting schedule
 
-We hold regular meetings, the timings of which are available on our [public calendar](https://calendar.google.com/calendar/embed?src=c_35r93ec6vtp8smhm7dv5uot0v4%40group.calendar.google.com).
+We hold regular meetings, the timings of which are available on our [public calendar](https://calendar.google.com/calendar/embed?src=c_35r93ec6vtp8smhm7dv5uot0v4@group.calendar.google.com).
 
 ```{napari-calendar}
 ---

--- a/0.4.16/community/meeting_schedule.html
+++ b/0.4.16/community/meeting_schedule.html
@@ -669,7 +669,7 @@ function checkPageExistsAndRedirect(event) {
               
   <div class="tex2jax_ignore mathjax_ignore section" id="meeting-schedule">
 <h1>Meeting schedule<a class="headerlink" href="#meeting-schedule" title="Permalink to this heading">¶</a></h1>
-<p>We hold regular meetings, the timings of which are available on our <a class="reference external" href="https://calendar.google.com/calendar/embed?src=c_35r93ec6vtp8smhm7dv5uot0v4%40group.calendar.google.com">public calendar</a>.</p>
+<p>We hold regular meetings, the timings of which are available on our <a class="reference external" href="https://calendar.google.com/calendar/embed?src=c_35r93ec6vtp8smhm7dv5uot0v4@group.calendar.google.com">public calendar</a>.</p>
 <div class="napari-calendar show-filters docutils">
 </div>
 <p>If you are using napari or interested in how napari could be used in your work, please join one of our regular community meetings. If you’re interested in diving deep on particular topic you could join the closest working group meeting. We currently have four working groups ‘Bundled Application’, ‘Plugins’, ‘Architecture’, and ‘Documentation’ that meet on a semi-regular candence. You can learn more about our working groups and community meetings in the corresponding discussion streams on the <a class="reference external" href="https://napari.zulipchat.com/login/">napari Zulip</a>.</p>


### PR DESCRIPTION
Same fix as https://github.com/napari/napari/pull/4944 to the calendar ID, which fixed the dev version calendar.
This will finally close https://github.com/napari/napari.github.io/issues/371 that's bounced between repos!