### PR TITLE
Take 2: Fix the calendar via fix `napari-calendar` in the .md

### DIFF
--- a/0.4.16/_sources/community/meeting_schedule.md
+++ b/0.4.16/_sources/community/meeting_schedule.md
@@ -5,6 +5,7 @@ We hold regular meetings, the timings of which are available on our [public cale
 ```{napari-calendar}
 ---
 show-filters: true
+calendar-id: c_35r93ec6vtp8smhm7dv5uot0v4@group.calendar.google.com
 ---
 ```
 


### PR DESCRIPTION
OK, so https://github.com/napari/napari.github.io/pull/372 fixed the link, but not the calendar that is displayed. 😔 
The .md file doesn't have a `calendar-id`, so I'm fixing that here. 
But the .html just has:
```
<div class="napari-calendar show-filters docutils">
</div>
```
So the calendar is autogenerated...
But will the docs be rebuilt from the .md if the PR is merged? Or is there something else?
Is it possible to download a preview of the PR-built docs?
Still confused how this repo works, to be honest.

