### PR TITLE
Update version_switcher.json for 0.4.18

### DIFF
--- a/dev/_static/version_switcher.json
+++ b/dev/_static/version_switcher.json
@@ -5,9 +5,14 @@
 		"url": "https://napari.org/dev/"
 	},
 	{
-		"name": "stable (0.4.17)",
-		"version": "0.4.17",
+		"name": "stable (0.4.18)",
+		"version": "0.4.18",
 		"url": "https://napari.org/stable/"
+	},
+	{
+		"name": "0.4.17",
+		"version": "0.4.17",
+		"url": "https://napari.org/0.4.17/"
 	},
 	{
 		"name": "0.4.16",


### PR DESCRIPTION
In:
https://github.com/napari/docs/pull/139
and
https://github.com/napari/napari.github.io/pull/381
we switched to using just the `dev` version switcher for all pages.
Currently, that one is not updated for 0.4.18, see:
<img width="235" alt="image" src="https://github.com/napari/napari.github.io/assets/76622105/3bc711d8-f938-4d16-b3f2-c066d3a5bdf2">

This PR updates the `dev` version switcher with the changes from https://github.com/napari/napari.github.io/blob/gh-pages/0.4.18/_static/version_switcher.json