### PR TITLE
Add GitHub action to copy unversioned pages over latest

### DIFF
--- a/.github/workflows/unversioned_pages.yml
+++ b/.github/workflows/unversioned_pages.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - gh-pages
+    paths:
+      - 'dev/developers/**'
+      - 'dev/index.html'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/unversioned_pages.yml
+++ b/.github/workflows/unversioned_pages.yml
@@ -1,0 +1,33 @@
+name: Copy unversioned pages
+
+on:
+  push:
+    branches:
+      - gh-pages
+  workflow_dispatch:
+
+jobs:
+  copy-pages:
+    name: Copy unversioned pages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone artifacts repo
+        uses: actions/checkout@v4
+
+      - name: Copy pages
+        run: |
+          ls -la
+          cp -Rv ./dev/developers/ ./stable/
+          cp -v ./dev/index.html ./stable/
+
+      - name: Commit files
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git commit -m "Copy unversioned files" -a
+
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: gh-pages


### PR DESCRIPTION
Supersedes napari/docs#230

Creates a GitHub action, triggered by a commit to the gh-pages branch in this repo, to copy over the contents of the developer documentation (under the Contributing rubric of the website) from latest to stable. Also copies over the index.html (landing page) from latest to stable.