### PR TITLE
Redo of unversioned workflow

### DIFF
--- a/.github/workflows/unversioned_pages.yml
+++ b/.github/workflows/unversioned_pages.yml
@@ -1,12 +1,12 @@
 name: Copy unversioned pages
 
 on:
-  # push:
-  #   branches:
-  #     - gh-pages
-  #   paths:
-  #     - 'dev/developers/**'
-  #     - 'dev/index.html'
+  push:
+    branches:
+      - gh-pages
+    paths:
+      - 'dev/developers/**'
+      - 'dev/index.html'
   workflow_dispatch:
 
 jobs:
@@ -25,14 +25,27 @@ jobs:
       - name: Copy pages
         run: |
           ls -la
+          rm -rf ./stable/developers
           cp -Rv ./dev/developers/ ./stable/
+          rm -rf ./stable/naps
+          cp -Rv ./dev/naps/ ./stable/
+          rm -rf ./stable/release
+          cp -Rv ./dev/release/ ./stable/
+          rm -rf ./stable/roadmaps
+          cp -Rv ./dev/roadmaps/ ./stable/
           cp -v ./dev/index.html ./stable/
+          find stable/developers -type f -exec sed -i 's+/_static+/../dev/_static+g' {} +
+          find stable/naps -type f -exec sed -i 's+/_static+/../dev/_static+g' {} +
+          find stable/release -type f -exec sed -i 's+/_static+/../dev/_static+g' {} +
+          find stable/roadmaps -type f -exec sed -i 's+/_static+/../dev/_static+g' {} +
+          sed -i 's+_static+../dev/_static+g' stable/index.html
 
       - name: Commit files
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          git commit -m "Copy unversioned files" -a
+          git add .
+          git commit -m "Copy unversioned files" --allow-empty
 
       - name: Push changes
         uses: ad-m/github-push-action@master

--- a/.github/workflows/unversioned_pages.yml
+++ b/.github/workflows/unversioned_pages.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - gh-pages
-    paths:
-      - 'dev/developers/**'
-      - 'dev/index.html'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Hi all - this is a new version of the unversioned workflow. 

I have confirmed with a deployment to my fork: https://melissawm.github.io/napari.github.io/stable/index.html

This PR:
* Removes stable developer pages before copying latest: pages that were moved or deleted were lingering in the stable folder.
* Fix commit command: allow for empty commits (for example, if we manually want to re-reploy pages) and include newly created files in the commit (we were not doing that previously and were missing the files that were recently moved to subfolder under the developer folder)
* Use sed to replace css in all unversioned pages (use dev version of css for dev versions of pages)
* Include naps, release notes and roadmaps in unversioned pages (prevents breakage since this files are all in the developer ToC.

We may want to move naps, release notes and roadmaps to be under the developer folder in the future, but this action will work with the current folder structure.