### PR TITLE
Add deployment trigger to unversioned pages workflow

### DIFF
--- a/.github/workflows/unversioned_pages.yml
+++ b/.github/workflows/unversioned_pages.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - gh-pages
+  deployment:
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
The unversioned pages workflow is not being triggered by pages deployment from napari/napari or napari/docs. I believe this deployment is not a "push" event to the gh-pages branch, but a "deployment" event.

This PR adds the deployment trigger to the workflow.

See https://docs.github.com/en/webhooks/webhook-events-and-payloads#deployment