### PR TITLE
Add script to create symlinks to duplicated videos

### DIFF
--- a/.github/workflows/duplicate_videos.sh
+++ b/.github/workflows/duplicate_videos.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash -x
+
+# This script is run from within the .github/workflows directory and so
+# all paths are relative.
+
+echo "Finding duplicate videos..."
+
+SRCDIR="../../dev/_static/images"
+
+# Find all folders with version numbers of the type m.m.m
+mapfile -t folders < <(find ../../ -maxdepth 1 -type d -name "[0-9]*.[0-9]*.[0-9]*" -exec basename {} \;)
+
+echo "Folders with version numbers: ${folders[@]}"
+
+for folder in "${folders[@]}"; do
+    DUPDIR="../../${folder}/_static/images"
+    echo "In ${DUPDIR}..."
+    # Store the hashes in arrays of two strings: the file path and the hash
+    mapfile -t dev < <(find "${SRCDIR}" -type f -name "*.webm" -exec sha256sum {} \; | awk '{print $2 " " $1}')
+    mapfile -t version < <(find "${DUPDIR}" -type f -name "*.webm" -exec sha256sum {} \; | awk '{print $2 " " $1}')
+
+    # Now, compare the two arrays to find duplicate videos
+    for item in "${dev[@]}"; do
+        split=($item)
+        for item_v in "${version[@]}"; do
+            split_v=($item_v)
+            if [[ "${split[1]}" == "${split_v[1]}" ]]; then
+                echo "Duplicate video found: ${split[0]}"
+                # Grab only filename for video in dev
+                FILE=$(basename "${split[0]}")
+                # Replace video in version with a symbolic link to the video in dev
+                ln -sf "../${SRCDIR}/${FILE}" "${DUPDIR}/${FILE}"
+                # If this is a duplicate webm, there is also a duplicate mp4 resulting from the automatic conversion in another step
+                ln -sf "../${SRCDIR}/${FILE%.*}.mp4" "${DUPDIR}/${FILE%.*}.mp4"
+            fi
+        done
+    done
+done

--- a/.github/workflows/duplicate_videos.sh
+++ b/.github/workflows/duplicate_videos.sh
@@ -1,19 +1,23 @@
 #!/usr/bin/env bash -x
 
-# This script is run from within the .github/workflows directory and so
-# all paths are relative.
+# This script is usually run from within the .github/workflows directory and so
+# all paths are relative. The ROOTDIR variable can be set via command line.
+if [ -z "$1" ]; then
+    ROOTDIR="../../"
+else
+    ROOTDIR="$1"
+fi
 
-echo "Finding duplicate videos..."
-
-SRCDIR="../../dev/_static/images"
+SRCDIR="${ROOTDIR}dev/_static/images"
+echo "Finding duplicate videos from ${ROOTDIR}"
 
 # Find all folders with version numbers of the type m.m.m
-mapfile -t folders < <(find ../../ -maxdepth 1 -type d -name "[0-9]*.[0-9]*.[0-9]*" -exec basename {} \;)
+mapfile -t folders < <(find "${ROOTDIR}" -maxdepth 1 -type d -name "[0-9]*.[0-9]*.[0-9]*" -exec basename {} \;)
 
 echo "Folders with version numbers: ${folders[@]}"
 
 for folder in "${folders[@]}"; do
-    DUPDIR="../../${folder}/_static/images"
+    DUPDIR="${ROOTDIR}${folder}/_static/images"
     echo "In ${DUPDIR}..."
     # Store the hashes in arrays of two strings: the file path and the hash
     mapfile -t dev < <(find "${SRCDIR}" -type f -name "*.webm" -exec sha256sum {} \; | awk '{print $2 " " $1}')

--- a/.github/workflows/duplicate_videos.sh
+++ b/.github/workflows/duplicate_videos.sh
@@ -8,8 +8,9 @@ else
     ROOTDIR="$1"
 fi
 
-SRCDIR="${ROOTDIR}dev/_static/images"
-echo "Finding duplicate videos from ${ROOTDIR}"
+SRCDIR_VIDEOS="${ROOTDIR}dev/_static/images"
+SRCDIR_IMAGES="${ROOTDIR}dev/_images"
+echo "Finding duplicate images/videos from ${ROOTDIR}"
 
 # Find all folders with version numbers of the type m.m.m
 mapfile -t folders < <(find "${ROOTDIR}" -maxdepth 1 -type d -name "[0-9]*.[0-9]*.[0-9]*" -exec basename {} \;)
@@ -17,25 +18,42 @@ mapfile -t folders < <(find "${ROOTDIR}" -maxdepth 1 -type d -name "[0-9]*.[0-9]
 echo "Folders with version numbers: ${folders[@]}"
 
 for folder in "${folders[@]}"; do
-    DUPDIR="${ROOTDIR}${folder}/_static/images"
-    echo "In ${DUPDIR}..."
+    DUPDIR_VIDEOS="${ROOTDIR}${folder}/_static/images"
+    DUPDIR_IMAGES="${ROOTDIR}${folder}/_images"
+    echo "In ${folder}..."
     # Store the hashes in arrays of two strings: the file path and the hash
-    mapfile -t dev < <(find "${SRCDIR}" -type f -name "*.webm" -exec sha256sum {} \; | awk '{print $2 " " $1}')
-    mapfile -t version < <(find "${DUPDIR}" -type f -name "*.webm" -exec sha256sum {} \; | awk '{print $2 " " $1}')
+    mapfile -t dev_videos < <(find "${SRCDIR_VIDEOS}" -type f -name "*.webm" -exec sha256sum {} \; | awk '{print $2 " " $1}')
+    mapfile -t version_videos < <(find "${DUPDIR_VIDEOS}" -type f -name "*.webm" -exec sha256sum {} \; | awk '{print $2 " " $1}')
+    mapfile -t dev_images < <(find "${SRCDIR_IMAGES}" -type f -name "*.png" -exec sha256sum {} \; | awk '{print $2 " " $1}')
+    mapfile -t version_images < <(find "${DUPDIR_IMAGES}" -type f -name "*.png" -exec sha256sum {} \; | awk '{print $2 " " $1}')
 
     # Now, compare the two arrays to find duplicate videos
-    for item in "${dev[@]}"; do
+    for item in "${dev_videos[@]}"; do
         split=($item)
-        for item_v in "${version[@]}"; do
+        for item_v in "${version_videos[@]}"; do
             split_v=($item_v)
             if [[ "${split[1]}" == "${split_v[1]}" ]]; then
                 echo "Duplicate video found: ${split[0]}"
                 # Grab only filename for video in dev
                 FILE=$(basename "${split[0]}")
                 # Replace video in version with a symbolic link to the video in dev
-                ln -sf "../${SRCDIR}/${FILE}" "${DUPDIR}/${FILE}"
+                ln -sf "../${SRCDIR_VIDEOS}/${FILE}" "${DUPDIR_VIDEOS}/${FILE}"
                 # If this is a duplicate webm, there is also a duplicate mp4 resulting from the automatic conversion in another step
-                ln -sf "../${SRCDIR}/${FILE%.*}.mp4" "${DUPDIR}/${FILE%.*}.mp4"
+                ln -sf "../${SRCDIR_VIDEOS}/${FILE%.*}.mp4" "${DUPDIR_VIDEOS}/${FILE%.*}.mp4"
+            fi
+        done
+    done
+    # Compare the two arrays to find duplicate images
+    for item in "${dev_images[@]}"; do
+        split=($item)
+        for item_v in "${version_images[@]}"; do
+            split_v=($item_v)
+            if [[ "${split[1]}" == "${split_v[1]}" ]]; then
+                echo "Duplicate image found: ${split[0]}"
+                # Grab only filename for image in dev
+                FILE=$(basename "${split[0]}")
+                # Replace image in version with a symbolic link to the image in dev
+                ln -sf "../${SRCDIR_IMAGES}/${FILE}" "${DUPDIR_IMAGES}/${FILE}"
             fi
         done
     done

--- a/.github/workflows/unversioned_pages.yml
+++ b/.github/workflows/unversioned_pages.yml
@@ -37,6 +37,10 @@ jobs:
           find stable/release -type f -exec sed -i 's+/_static+/../dev/_static+g' {} +
           find stable/roadmaps -type f -exec sed -i 's+/_static+/../dev/_static+g' {} +
           sed -i 's+_static+../dev/_static+g' stable/index.html
+      
+      - name: Replace duplicate videos with symlinks
+        run: |
+          bash duplicate_videos.sh
 
       - name: Commit files
         run: |


### PR DESCRIPTION
Because of the multiple versions being deployed to the gh-pages website, our artifacts are growing and contain many duplicated videos (and images).

This PR adds a script to be run from the `unversioned_pages.yml` action that replaces duplicated videos in older versions of the docs (as tested by their `sha256sum`) with the most recent version (in dev). I chose to do it this way because dev will almost certainly contain a superset of the videos in the repo so it made more sense, but it does mean we are touching the older deployments so this could be destructive if we don't have the full repo history from now on.

A couple of points:
- SHA256 is not unique (multiple files could, in theory, have the same SHA256 sum). I _think_ this is unique enough for our purposes, but admitedly don't know much about its use in this way.
- I am only checking video files right now, but we could do the same to images, too.
- I only have superficial knowledge of bash so I could certainly use reviews on the script 😅 

Any feedback is appreciated!