### PR TITLE
[HUGE DIFF] Update CSS link for copied files

### DIFF
--- a/0.4.19/developers/architecture/app_model.html
+++ b/0.4.19/developers/architecture/app_model.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari’s application model &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/architecture/app_model';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1297,8 +1297,8 @@ Qt is available.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/developers/architecture/dir_organization.html
+++ b/0.4.19/developers/architecture/dir_organization.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari directory organization &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/architecture/dir_organization';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -782,8 +782,8 @@ and the <a class="reference internal" href="../../guides/threading.html#multithr
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/developers/architecture/index.html
+++ b/0.4.19/developers/architecture/index.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari architecture guide &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/architecture/index';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -675,8 +675,8 @@ or plugins are automatically created, inputs updated and outputs added to the
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/developers/architecture/magicgui_type_reg.html
+++ b/0.4.19/developers/architecture/magicgui_type_reg.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>magicgui type registration &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/architecture/magicgui_type_reg';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -771,8 +771,8 @@ for details.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/developers/architecture/napari_models.html
+++ b/0.4.19/developers/architecture/napari_models.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari models and events &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/architecture/napari_models';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -903,8 +903,8 @@ the function <code class="docutils literal notranslate"><span class="pre">_on_nd
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/developers/contributing/dev_install.html
+++ b/0.4.19/developers/contributing/dev_install.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Setting up a development installation &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/contributing/dev_install';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -756,8 +756,8 @@ please do not ignore errors lightly.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/developers/contributing/documentation/docs_deployment.html
+++ b/0.4.19/developers/contributing/documentation/docs_deployment.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Documentation and website deployment &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/contributing/documentation/docs_deployment';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -783,8 +783,8 @@ previews for PRs. The relevant configuration files are:</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/developers/contributing/documentation/docs_template.html
+++ b/0.4.19/developers/contributing/documentation/docs_template.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Docs template &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/contributing/documentation/docs_template';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -660,7 +660,7 @@ they contrast well against the background of the image.</p>
 <div class="admonition important">
 <p class="admonition-title">Important</p>
 <p>Adding videos
-If you want to include videos in your documentation, you should use the .webm format and add a screenshot of the video as a fallback for browsers that don’t support the video tag. Both files should be added to <code class="docutils literal notranslate"><span class="pre">docs/../dev/_static/images</span></code>. When the documentation is built, a .mp4 version of the video will be automatically generated and included in the documentation. You can then use the .webm file in your documentation like so:</p>
+If you want to include videos in your documentation, you should use the .webm format and add a screenshot of the video as a fallback for browsers that don’t support the video tag. Both files should be added to <code class="docutils literal notranslate"><span class="pre">docs/../0.5.0/_static/images</span></code>. When the documentation is built, a .mp4 version of the video will be automatically generated and included in the documentation. You can then use the .webm file in your documentation like so:</p>
 <div class="highlight-default notranslate"><div class="highlight"><pre><span></span>```{raw} html
 &lt;figure&gt;
 &lt;video width=&quot;100%&quot; controls autoplay loop muted playsinline&gt;
@@ -856,8 +856,8 @@ or other relevant documentation</p></li>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/developers/contributing/documentation/index.html
+++ b/0.4.19/developers/contributing/documentation/index.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Contributing Documentation &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/contributing/documentation/index';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1233,8 +1233,8 @@ block is present in all contributed examples.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/developers/contributing/index.html
+++ b/0.4.19/developers/contributing/index.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Contributing guide &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/contributing/index';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -797,8 +797,8 @@ identify the cause and where to optimize.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/developers/contributing/performance/benchmarks.html
+++ b/0.4.19/developers/contributing/performance/benchmarks.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Benchmarks &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/contributing/performance/benchmarks';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -857,8 +857,8 @@ Every time you want the benchmark CI to run in a PR, you’ll need to remove and
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/developers/contributing/performance/index.html
+++ b/0.4.19/developers/contributing/performance/index.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Performance &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/contributing/performance/index';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -683,8 +683,8 @@ document.write(`
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/developers/contributing/performance/profiling.html
+++ b/0.4.19/developers/contributing/performance/profiling.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Profiling &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/contributing/performance/profiling';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -791,8 +791,8 @@ button to trigger profiling:</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/developers/contributing/testing.html
+++ b/0.4.19/developers/contributing/testing.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Testing &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/contributing/testing';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -981,8 +981,8 @@ so certain tests have been disabled from windows in CI, see
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/developers/contributing/translations.html
+++ b/0.4.19/developers/contributing/translations.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Translations &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/contributing/translations';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -899,8 +899,8 @@ and the napari user community.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/developers/coredev/core_dev_guide.html
+++ b/0.4.19/developers/coredev/core_dev_guide.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Core Developer guide &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/coredev/core_dev_guide';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -906,8 +906,8 @@ advance!</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/developers/coredev/maintenance.html
+++ b/0.4.19/developers/coredev/maintenance.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Maintenance &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/coredev/maintenance';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -739,8 +739,8 @@ to this page might be appropriate.</p></li>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/developers/coredev/packaging.html
+++ b/0.4.19/developers/coredev/packaging.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Packaging &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/coredev/packaging';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -920,8 +920,8 @@ that calls <code class="docutils literal notranslate"><span class="pre">menuinst
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/developers/coredev/release.html
+++ b/0.4.19/developers/coredev/release.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Release guide &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/coredev/release';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -932,8 +932,8 @@ To do so, we can submit a PR to <code class="docutils literal notranslate"><span
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/developers/index.html
+++ b/0.4.19/developers/index.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Contributing &#8212; napari</title>
   
   
@@ -20,44 +20,44 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>window.MathJax = {"options": {"processHtmlClass": "tex2jax_process|mathjax_process|math|output_area"}}</script>
     <script defer="defer" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/index';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -118,7 +118,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -144,8 +144,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -731,8 +731,8 @@ the tag “napari”.</p></li>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/index.html
+++ b/0.4.19/index.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari: a fast, interactive viewer for multi-dimensional images in Python &#8212; napari</title>
   
   
@@ -20,44 +20,44 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>window.MathJax = {"options": {"processHtmlClass": "tex2jax_process|mathjax_process|math|output_area"}}</script>
     <script defer="defer" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'index';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -117,7 +117,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -143,8 +143,8 @@
     
     
     
-    <img src="../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -481,9 +481,9 @@ document.write(`
 <figure>
 
   <video width="90%" controls autoplay loop muted playsinline>
-    <source src="../dev/_static/images/tribolium.webm" type="video/webm" />
-    <source src="../dev/_static/images/tribolium.mp4" type="video/mp4" />
-    <img src="../dev/_static/images/tribolium.jpg"
+    <source src="../0.5.0/_static/images/tribolium.webm" type="video/webm" />
+    <source src="../0.5.0/_static/images/tribolium.mp4" type="video/mp4" />
+    <img src="../0.5.0/_static/images/tribolium.jpg"
       title="your browser does not support the video tag"
       alt="napari viewer showing a 4D image of a developing Tribolium embryo.  Dataset Fluo-N3DL-TRIF from the [cell tracking challenge](http://celltrackingchallenge.net/3d-datasets/) by Dr. A. Jain, MPI-CBG, Dresden, Germany."
     >
@@ -605,8 +605,8 @@ Plugins</div>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/naps/0-nap-process.html
+++ b/0.4.19/naps/0-nap-process.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>NAP 0 — Purpose and Process &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/0-nap-process';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1022,8 +1022,8 @@ for retrieving older revisions, and can also be browsed on
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/naps/1-institutional-funding-partners.html
+++ b/0.4.19/naps/1-institutional-funding-partners.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>NAP-1 — Institutional and Funding Partners &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/1-institutional-funding-partners';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -937,8 +937,8 @@ per CC0+BY<a class="footnote-reference brackets" href="#id5" id="id3" role="doc-
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/naps/2-conda-based-packaging.html
+++ b/0.4.19/naps/2-conda-based-packaging.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>NAP-2 — Distributing napari with conda-based packaging &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/2-conda-based-packaging';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1477,8 +1477,8 @@ CC0+BY <a class="footnote-reference brackets" href="#cc0by" id="id48" role="doc-
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/naps/3-spaces.html
+++ b/0.4.19/naps/3-spaces.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>NAP-3 — Spaces &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/3-spaces';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -890,8 +890,8 @@ CC0+BY <a class="footnote-reference brackets" href="#cc0by" id="id6" role="doc-n
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/naps/4-async-slicing.html
+++ b/0.4.19/naps/4-async-slicing.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>NAP-4 — Asynchronous slicing &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/4-async-slicing';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1703,8 +1703,8 @@ CC0+BY <a class="footnote-reference brackets" href="#cc0-by" id="id16" role="doc
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/naps/5-new-logo.html
+++ b/0.4.19/naps/5-new-logo.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>NAP-5 — New logo (2022) &#8212; napari</title>
   
   
@@ -20,44 +20,44 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>window.MathJax = {"options": {"processHtmlClass": "tex2jax_process|mathjax_process|math|output_area"}}</script>
     <script defer="defer" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/5-new-logo';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -118,7 +118,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -144,8 +144,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -882,8 +882,8 @@ CC0+BY <a class="footnote-reference brackets" href="#id4" id="id2" role="doc-not
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/naps/6-contributable-menus.html
+++ b/0.4.19/naps/6-contributable-menus.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>NAP-6 — Contributable Menus &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/6-contributable-menus';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1326,8 +1326,8 @@ CC0+BY <a class="footnote-reference brackets" href="#id7" id="id5" role="doc-not
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/naps/7-key-binding-dispatch.html
+++ b/0.4.19/naps/7-key-binding-dispatch.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>NAP-7 — Key Binding Dispatch &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/7-key-binding-dispatch';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1213,8 +1213,8 @@ CC0+BY <a class="footnote-reference brackets" href="#id11" id="id6" role="doc-no
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/naps/8-telemetry.html
+++ b/0.4.19/naps/8-telemetry.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>NAP-8 — Telemetry &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/8-telemetry';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1255,8 +1255,8 @@ CC0+BY <a class="footnote-reference brackets" href="#id6" id="id4" role="doc-not
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/naps/9-multiple-canvases.html
+++ b/0.4.19/naps/9-multiple-canvases.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>NAP-9 — Multiple Canvases &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/9-multiple-canvases';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1109,8 +1109,8 @@ CC0+BY <a class="footnote-reference brackets" href="#id8" id="id6" role="doc-not
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/naps/index.html
+++ b/0.4.19/naps/index.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari Advancement Proposals (NAPs) &#8212; napari</title>
   
   
@@ -20,44 +20,44 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>window.MathJax = {"options": {"processHtmlClass": "tex2jax_process|mathjax_process|math|output_area"}}</script>
     <script defer="defer" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/index';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -118,7 +118,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -144,8 +144,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -705,8 +705,8 @@ document.write(`
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/naps/template.html
+++ b/0.4.19/naps/template.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>NAP-X — Template and Instructions &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/template';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -805,8 +805,8 @@ CC0+BY <a class="footnote-reference brackets" href="#id6" id="id4" role="doc-not
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/release/index.html
+++ b/0.4.19/release/index.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Release notes &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/index';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -663,8 +663,8 @@ document.write(`
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/release/release_0_1_0.html
+++ b/0.4.19/release/release_0_1_0.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.1.0 &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_1_0';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -846,8 +846,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/release/release_0_1_3.html
+++ b/0.4.19/release/release_0_1_3.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.1.3 &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_1_3';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -748,8 +748,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/release/release_0_1_5.html
+++ b/0.4.19/release/release_0_1_5.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.1.5 &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_1_5';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -758,8 +758,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/release/release_0_2_0.html
+++ b/0.4.19/release/release_0_2_0.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.2.0 &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_0';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -824,8 +824,8 @@ labels and image layer.</p></li>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/release/release_0_2_1.html
+++ b/0.4.19/release/release_0_2_1.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.2.1 &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_1';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -748,8 +748,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/release/release_0_2_10.html
+++ b/0.4.19/release/release_0_2_10.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.2.10 &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_10';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -717,8 +717,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/release/release_0_2_11.html
+++ b/0.4.19/release/release_0_2_11.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.2.11 &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_11';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -767,8 +767,8 @@ for syntax details.</p></li>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/release/release_0_2_12.html
+++ b/0.4.19/release/release_0_2_12.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.2.12 &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_12';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -779,8 +779,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/release/release_0_2_3.html
+++ b/0.4.19/release/release_0_2_3.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.2.3 &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_3';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -739,8 +739,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/release/release_0_2_4.html
+++ b/0.4.19/release/release_0_2_4.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.2.4 &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_4';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -741,8 +741,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/release/release_0_2_5.html
+++ b/0.4.19/release/release_0_2_5.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.2.5 &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_5';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -736,8 +736,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/release/release_0_2_6.html
+++ b/0.4.19/release/release_0_2_6.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.2.6 &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_6';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -758,8 +758,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/release/release_0_2_7.html
+++ b/0.4.19/release/release_0_2_7.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.2.7 &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_7';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -792,8 +792,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/release/release_0_2_8.html
+++ b/0.4.19/release/release_0_2_8.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.2.8 &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_8';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -727,8 +727,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/release/release_0_2_9.html
+++ b/0.4.19/release/release_0_2_9.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.2.9 &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_9';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -759,8 +759,8 @@ colors currently selected in the GUI (#686)</p></li>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/release/release_0_3_0.html
+++ b/0.4.19/release/release_0_3_0.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.3.0 &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_3_0';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1018,8 +1018,8 @@ expression a.k.a. the walrus operator:</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/release/release_0_3_1.html
+++ b/0.4.19/release/release_0_3_1.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.3.1 &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_3_1';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -744,8 +744,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/release/release_0_3_2.html
+++ b/0.4.19/release/release_0_3_2.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.3.2 &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_3_2';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -772,8 +772,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/release/release_0_3_3.html
+++ b/0.4.19/release/release_0_3_3.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.3.3 &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_3_3';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -744,8 +744,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/release/release_0_3_4.html
+++ b/0.4.19/release/release_0_3_4.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.3.4 &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_3_4';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -724,8 +724,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/release/release_0_3_5.html
+++ b/0.4.19/release/release_0_3_5.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.3.5 &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_3_5';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -767,8 +767,8 @@ including plans for the future.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/release/release_0_3_6.html
+++ b/0.4.19/release/release_0_3_6.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.3.6 &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_3_6';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -811,8 +811,8 @@ room at https://napari.zulipchat.com!</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/release/release_0_3_7.html
+++ b/0.4.19/release/release_0_3_7.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.3.7 &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_3_7';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -820,8 +820,8 @@ for the full list! Thank you to everyone who contributed to this release!</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/release/release_0_3_8.html
+++ b/0.4.19/release/release_0_3_8.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.3.8 &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_3_8';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -757,8 +757,8 @@ and (#1643). This will also be our last release supporting Python3.6.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/release/release_0_4_0.html
+++ b/0.4.19/release/release_0_4_0.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.0 &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_0';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -876,8 +876,8 @@ issues at https://github.com/napari/napari/issues.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/release/release_0_4_1.html
+++ b/0.4.19/release/release_0_4_1.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.1 &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_1';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -845,8 +845,8 @@ use <code class="docutils literal notranslate"><span class="pre">Viewer.grid.str
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/release/release_0_4_10.html
+++ b/0.4.19/release/release_0_4_10.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.10 &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_10';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -770,8 +770,8 @@ the others would be ignored. Now they will be composed as <code class="docutils 
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/release/release_0_4_11.html
+++ b/0.4.19/release/release_0_4_11.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.11 &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_11';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -990,8 +990,8 @@ more! Thanks to our incredible user and contributor community.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/release/release_0_4_12.html
+++ b/0.4.19/release/release_0_4_12.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.12 &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_12';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -865,8 +865,8 @@ be converted from a context menu on the layer list (#3402).</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/release/release_0_4_13.html
+++ b/0.4.19/release/release_0_4_13.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.13 &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_13';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1020,8 +1020,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/release/release_0_4_14.html
+++ b/0.4.19/release/release_0_4_14.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.14 &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_14';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -792,8 +792,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/release/release_0_4_15.html
+++ b/0.4.19/release/release_0_4_15.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.15 &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_15';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -904,8 +904,8 @@ plugins on PyPI but have them not be listed in the app (#4074).</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/release/release_0_4_16.html
+++ b/0.4.19/release/release_0_4_16.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.16 &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_16';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1064,8 +1064,8 @@ console, so this is strictly an improvement!)</p></li>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/release/release_0_4_17.html
+++ b/0.4.19/release/release_0_4_17.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.17 &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_17';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1189,8 +1189,8 @@ or create issues on GitHub.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/release/release_0_4_18.html
+++ b/0.4.19/release/release_0_4_18.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.18 &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_18';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1262,8 +1262,8 @@ vectors layer! (<a class="reference external" href="https://github.com/napari/na
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/release/release_0_4_19.html
+++ b/0.4.19/release/release_0_4_19.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.19 &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_19';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1152,8 +1152,8 @@ superseded by <code class="docutils literal notranslate"><span class="pre">layer
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/release/release_0_4_2.html
+++ b/0.4.19/release/release_0_4_2.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.2 &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_2';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -781,8 +781,8 @@ part of the codebase.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/release/release_0_4_3.html
+++ b/0.4.19/release/release_0_4_3.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.3 &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_3';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -852,8 +852,8 @@ can still provide keymappings, but no longer handles keymappings from other obje
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/release/release_0_4_4.html
+++ b/0.4.19/release/release_0_4_4.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.4 &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_4';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -818,8 +818,8 @@ be required after 0.4.6. (#1985)</p></li>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/release/release_0_4_5.html
+++ b/0.4.19/release/release_0_4_5.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.5 &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_5';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -811,8 +811,8 @@ set matching contrast limits for multiple channels (#2226).</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/release/release_0_4_6.html
+++ b/0.4.19/release/release_0_4_6.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.6 &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_6';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -816,8 +816,8 @@ menu.)</p></li>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/release/release_0_4_7.html
+++ b/0.4.19/release/release_0_4_7.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.7 &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_7';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -880,8 +880,8 @@ coordinates.</p></li>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/release/release_0_4_8.html
+++ b/0.4.19/release/release_0_4_8.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.8 &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_8';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -977,8 +977,8 @@ recommended.</p></li>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/release/release_0_4_9.html
+++ b/0.4.19/release/release_0_4_9.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.9 &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_9';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -823,8 +823,8 @@ It also contains a variety of bug fixes and improvements.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/release/release_0_5_0.html
+++ b/0.4.19/release/release_0_5_0.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.5.0 &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_5_0';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1637,8 +1637,8 @@ improvements. Please see below for the full list of changes since 0.4.19.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/roadmaps/0_3.html
+++ b/0.4.19/roadmaps/0_3.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Roadmap 0.3 &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'roadmaps/0_3';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -749,8 +749,8 @@ document.write(`
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/roadmaps/0_3_retrospective.html
+++ b/0.4.19/roadmaps/0_3_retrospective.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Roadmap 0.3 Retrospective &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'roadmaps/0_3_retrospective';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -814,8 +814,8 @@ document.write(`
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/roadmaps/0_4.html
+++ b/0.4.19/roadmaps/0_4.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Roadmap 0.4 &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'roadmaps/0_4';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -800,8 +800,8 @@ details.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.4.19/roadmaps/index.html
+++ b/0.4.19/roadmaps/index.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.0/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.0/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.0/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Roadmaps &#8212; napari</title>
   
   
@@ -20,42 +20,42 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link href="../../0.5.0/_static/styles/theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/bootstrap.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+<link href="../../0.5.0/_static/styles/pydata-sphinx-theme.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.0/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=3ee479438cf8b5e0d341" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.0/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=53b30af0" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=61a4c737" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/css/napari-sphinx-theme.css?v=53b30af0" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery.css?v=61a4c737" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.0/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
+  <link rel="preload" as="script" href="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341" />
+<link rel="preload" as="script" href="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341" />
+  <script src="../../0.5.0/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=3ee479438cf8b5e0d341"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=cf40f8c0"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.0/_static/documentation_options.js?v=cf40f8c0"></script>
+    <script src="../../0.5.0/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.0/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.0/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.0/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.0/_static/design-tabs.js?v=f930bc37"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'roadmaps/index';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.3';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.0/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -116,7 +116,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.0/_static/announcement.html"></aside>
 </div>
 
   
@@ -142,8 +142,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.0/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.0/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -671,8 +671,8 @@ document.write(`
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
+  <script src="../../0.5.0/_static/scripts/bootstrap.js?digest=3ee479438cf8b5e0d341"></script>
+<script src="../../0.5.0/_static/scripts/pydata-sphinx-theme.js?digest=3ee479438cf8b5e0d341"></script>
 <footer class="napari-footer">
   
     <div class="footer-item">

--- a/0.5.0/developers/architecture/app_model.html
+++ b/0.5.0/developers/architecture/app_model.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari’s application model &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/architecture/app_model';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1295,8 +1295,8 @@ Qt is available.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/developers/architecture/dir_organization.html
+++ b/0.5.0/developers/architecture/dir_organization.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari directory organization &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/architecture/dir_organization';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -780,8 +780,8 @@ and the <a class="reference internal" href="../../guides/threading.html#multithr
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/developers/architecture/index.html
+++ b/0.5.0/developers/architecture/index.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari architecture guide &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/architecture/index';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -673,8 +673,8 @@ or plugins are automatically created, inputs updated and outputs added to the
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/developers/architecture/magicgui_type_reg.html
+++ b/0.5.0/developers/architecture/magicgui_type_reg.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>magicgui type registration &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/architecture/magicgui_type_reg';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -769,8 +769,8 @@ for details.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/developers/architecture/napari_models.html
+++ b/0.5.0/developers/architecture/napari_models.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari models and events &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/architecture/napari_models';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -901,8 +901,8 @@ the function <code class="docutils literal notranslate"><span class="pre">_on_nd
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/developers/contributing/dev_install.html
+++ b/0.5.0/developers/contributing/dev_install.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Setting up a development installation &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/contributing/dev_install';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -754,8 +754,8 @@ please do not ignore errors lightly.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/developers/contributing/documentation/docs_deployment.html
+++ b/0.5.0/developers/contributing/documentation/docs_deployment.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Documentation and website deployment &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/contributing/documentation/docs_deployment';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -781,8 +781,8 @@ previews for PRs. The relevant configuration files are:</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/developers/contributing/documentation/docs_template.html
+++ b/0.5.0/developers/contributing/documentation/docs_template.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Docs template &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/contributing/documentation/docs_template';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -658,7 +658,7 @@ they contrast well against the background of the image.</p>
 <div class="admonition important">
 <p class="admonition-title">Important</p>
 <p>Adding videos
-If you want to include videos in your documentation, you should use the .webm format and add a screenshot of the video as a fallback for browsers that don’t support the video tag. Both files should be added to <code class="docutils literal notranslate"><span class="pre">docs/../dev/_static/images</span></code>. When the documentation is built, a .mp4 version of the video will be automatically generated and included in the documentation. You can then use the .webm file in your documentation like so:</p>
+If you want to include videos in your documentation, you should use the .webm format and add a screenshot of the video as a fallback for browsers that don’t support the video tag. Both files should be added to <code class="docutils literal notranslate"><span class="pre">docs/../0.5.1/_static/images</span></code>. When the documentation is built, a .mp4 version of the video will be automatically generated and included in the documentation. You can then use the .webm file in your documentation like so:</p>
 <div class="highlight-default notranslate"><div class="highlight"><pre><span></span>```{raw} html
 &lt;figure&gt;
 &lt;video width=&quot;100%&quot; controls autoplay loop muted playsinline&gt;
@@ -854,8 +854,8 @@ or other relevant documentation</p></li>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/developers/contributing/documentation/index.html
+++ b/0.5.0/developers/contributing/documentation/index.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Contributing Documentation &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/contributing/documentation/index';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1231,8 +1231,8 @@ block is present in all contributed examples.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/developers/contributing/index.html
+++ b/0.5.0/developers/contributing/index.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Contributing guide &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/contributing/index';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -795,8 +795,8 @@ identify the cause and where to optimize.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/developers/contributing/performance/benchmarks.html
+++ b/0.5.0/developers/contributing/performance/benchmarks.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Benchmarks &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/contributing/performance/benchmarks';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -855,8 +855,8 @@ Every time you want the benchmark CI to run in a PR, you’ll need to remove and
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/developers/contributing/performance/index.html
+++ b/0.5.0/developers/contributing/performance/index.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Performance &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/contributing/performance/index';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -681,8 +681,8 @@ document.write(`
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/developers/contributing/performance/profiling.html
+++ b/0.5.0/developers/contributing/performance/profiling.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Profiling &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/contributing/performance/profiling';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -789,8 +789,8 @@ button to trigger profiling:</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/developers/contributing/testing.html
+++ b/0.5.0/developers/contributing/testing.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Testing &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/contributing/testing';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -979,8 +979,8 @@ so certain tests have been disabled from windows in CI, see
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/developers/contributing/translations.html
+++ b/0.5.0/developers/contributing/translations.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Translations &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/contributing/translations';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -897,8 +897,8 @@ and the napari user community.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/developers/coredev/core_dev_guide.html
+++ b/0.5.0/developers/coredev/core_dev_guide.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Core Developer guide &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/coredev/core_dev_guide';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -904,8 +904,8 @@ advance!</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/developers/coredev/maintenance.html
+++ b/0.5.0/developers/coredev/maintenance.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Maintenance &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/coredev/maintenance';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -737,8 +737,8 @@ to this page might be appropriate.</p></li>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/developers/coredev/packaging.html
+++ b/0.5.0/developers/coredev/packaging.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Packaging &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/coredev/packaging';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -938,8 +938,8 @@ that calls <code class="docutils literal notranslate"><span class="pre">menuinst
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/developers/coredev/release.html
+++ b/0.5.0/developers/coredev/release.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Release guide &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/coredev/release';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -930,8 +930,8 @@ To do so, we can submit a PR to <code class="docutils literal notranslate"><span
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/developers/index.html
+++ b/0.5.0/developers/index.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Contributing &#8212; napari</title>
   
   
@@ -20,45 +20,45 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>window.MathJax = {"options": {"processHtmlClass": "tex2jax_process|mathjax_process|math|output_area"}}</script>
     <script defer="defer" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/index';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -113,7 +113,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -141,8 +141,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -729,8 +729,8 @@ the tag “napari”.</p></li>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/index.html
+++ b/0.5.0/index.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari: a fast, interactive viewer for multi-dimensional images in Python &#8212; napari</title>
   
   
@@ -20,45 +20,45 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>window.MathJax = {"options": {"processHtmlClass": "tex2jax_process|mathjax_process|math|output_area"}}</script>
     <script defer="defer" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'index';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -112,7 +112,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -140,8 +140,8 @@
     
     
     
-    <img src="../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -478,9 +478,9 @@ document.write(`
 <figure>
 
   <video width="90%" controls autoplay loop muted playsinline>
-    <source src="../dev/_static/images/tribolium.webm" type="video/webm" />
-    <source src="../dev/_static/images/tribolium.mp4" type="video/mp4" />
-    <img src="../dev/_static/images/tribolium.jpg"
+    <source src="../0.5.1/_static/images/tribolium.webm" type="video/webm" />
+    <source src="../0.5.1/_static/images/tribolium.mp4" type="video/mp4" />
+    <img src="../0.5.1/_static/images/tribolium.jpg"
       title="your browser does not support the video tag"
       alt="napari viewer showing a 4D image of a developing Tribolium embryo.  Dataset Fluo-N3DL-TRIF from the [cell tracking challenge](http://celltrackingchallenge.net/3d-datasets/) by Dr. A. Jain, MPI-CBG, Dresden, Germany."
     >
@@ -602,8 +602,8 @@ Plugins</div>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/naps/0-nap-process.html
+++ b/0.5.0/naps/0-nap-process.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>NAP 0 — Purpose and Process &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/0-nap-process';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1020,8 +1020,8 @@ for retrieving older revisions, and can also be browsed on
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/naps/1-institutional-funding-partners.html
+++ b/0.5.0/naps/1-institutional-funding-partners.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>NAP-1 — Institutional and Funding Partners &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/1-institutional-funding-partners';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -935,8 +935,8 @@ per CC0+BY<a class="footnote-reference brackets" href="#id5" id="id3" role="doc-
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/naps/2-conda-based-packaging.html
+++ b/0.5.0/naps/2-conda-based-packaging.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>NAP-2 — Distributing napari with conda-based packaging &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/2-conda-based-packaging';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1475,8 +1475,8 @@ CC0+BY <a class="footnote-reference brackets" href="#cc0by" id="id48" role="doc-
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/naps/3-spaces.html
+++ b/0.5.0/naps/3-spaces.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>NAP-3 — Spaces &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/3-spaces';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -888,8 +888,8 @@ CC0+BY <a class="footnote-reference brackets" href="#cc0by" id="id6" role="doc-n
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/naps/4-async-slicing.html
+++ b/0.5.0/naps/4-async-slicing.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>NAP-4 — Asynchronous slicing &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/4-async-slicing';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1701,8 +1701,8 @@ CC0+BY <a class="footnote-reference brackets" href="#cc0-by" id="id16" role="doc
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/naps/5-new-logo.html
+++ b/0.5.0/naps/5-new-logo.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>NAP-5 — New logo (2022) &#8212; napari</title>
   
   
@@ -20,45 +20,45 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>window.MathJax = {"options": {"processHtmlClass": "tex2jax_process|mathjax_process|math|output_area"}}</script>
     <script defer="defer" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/5-new-logo';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -113,7 +113,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -141,8 +141,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -880,8 +880,8 @@ CC0+BY <a class="footnote-reference brackets" href="#id4" id="id2" role="doc-not
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/naps/6-contributable-menus.html
+++ b/0.5.0/naps/6-contributable-menus.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>NAP-6 — Contributable Menus &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/6-contributable-menus';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1324,8 +1324,8 @@ CC0+BY <a class="footnote-reference brackets" href="#id7" id="id5" role="doc-not
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/naps/7-key-binding-dispatch.html
+++ b/0.5.0/naps/7-key-binding-dispatch.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>NAP-7 — Key Binding Dispatch &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/7-key-binding-dispatch';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1211,8 +1211,8 @@ CC0+BY <a class="footnote-reference brackets" href="#id11" id="id6" role="doc-no
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/naps/8-telemetry.html
+++ b/0.5.0/naps/8-telemetry.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>NAP-8 — Telemetry &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/8-telemetry';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1253,8 +1253,8 @@ CC0+BY <a class="footnote-reference brackets" href="#id6" id="id4" role="doc-not
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/naps/9-multiple-canvases.html
+++ b/0.5.0/naps/9-multiple-canvases.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>NAP-9 — Multiple Canvases &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/9-multiple-canvases';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1107,8 +1107,8 @@ CC0+BY <a class="footnote-reference brackets" href="#id8" id="id6" role="doc-not
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/naps/index.html
+++ b/0.5.0/naps/index.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari Advancement Proposals (NAPs) &#8212; napari</title>
   
   
@@ -20,45 +20,45 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>window.MathJax = {"options": {"processHtmlClass": "tex2jax_process|mathjax_process|math|output_area"}}</script>
     <script defer="defer" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/index';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -113,7 +113,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -141,8 +141,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -703,8 +703,8 @@ document.write(`
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/naps/template.html
+++ b/0.5.0/naps/template.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>NAP-X — Template and Instructions &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/template';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -803,8 +803,8 @@ CC0+BY <a class="footnote-reference brackets" href="#id6" id="id4" role="doc-not
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/release/index.html
+++ b/0.5.0/release/index.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Release notes &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/index';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -661,8 +661,8 @@ document.write(`
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/release/release_0_1_0.html
+++ b/0.5.0/release/release_0_1_0.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.1.0 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_1_0';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -844,8 +844,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/release/release_0_1_3.html
+++ b/0.5.0/release/release_0_1_3.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.1.3 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_1_3';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -746,8 +746,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/release/release_0_1_5.html
+++ b/0.5.0/release/release_0_1_5.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.1.5 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_1_5';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -756,8 +756,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/release/release_0_2_0.html
+++ b/0.5.0/release/release_0_2_0.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.2.0 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_0';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -822,8 +822,8 @@ labels and image layer.</p></li>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/release/release_0_2_1.html
+++ b/0.5.0/release/release_0_2_1.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.2.1 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_1';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -746,8 +746,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/release/release_0_2_10.html
+++ b/0.5.0/release/release_0_2_10.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.2.10 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_10';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -715,8 +715,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/release/release_0_2_11.html
+++ b/0.5.0/release/release_0_2_11.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.2.11 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_11';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -765,8 +765,8 @@ for syntax details.</p></li>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/release/release_0_2_12.html
+++ b/0.5.0/release/release_0_2_12.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.2.12 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_12';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -777,8 +777,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/release/release_0_2_3.html
+++ b/0.5.0/release/release_0_2_3.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.2.3 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_3';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -737,8 +737,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/release/release_0_2_4.html
+++ b/0.5.0/release/release_0_2_4.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.2.4 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_4';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -739,8 +739,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/release/release_0_2_5.html
+++ b/0.5.0/release/release_0_2_5.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.2.5 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_5';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -734,8 +734,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/release/release_0_2_6.html
+++ b/0.5.0/release/release_0_2_6.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.2.6 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_6';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -756,8 +756,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/release/release_0_2_7.html
+++ b/0.5.0/release/release_0_2_7.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.2.7 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_7';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -790,8 +790,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/release/release_0_2_8.html
+++ b/0.5.0/release/release_0_2_8.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.2.8 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_8';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -725,8 +725,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/release/release_0_2_9.html
+++ b/0.5.0/release/release_0_2_9.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.2.9 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_9';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -757,8 +757,8 @@ colors currently selected in the GUI (#686)</p></li>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/release/release_0_3_0.html
+++ b/0.5.0/release/release_0_3_0.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.3.0 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_3_0';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1016,8 +1016,8 @@ expression a.k.a. the walrus operator:</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/release/release_0_3_1.html
+++ b/0.5.0/release/release_0_3_1.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.3.1 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_3_1';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -742,8 +742,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/release/release_0_3_2.html
+++ b/0.5.0/release/release_0_3_2.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.3.2 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_3_2';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -770,8 +770,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/release/release_0_3_3.html
+++ b/0.5.0/release/release_0_3_3.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.3.3 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_3_3';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -742,8 +742,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/release/release_0_3_4.html
+++ b/0.5.0/release/release_0_3_4.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.3.4 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_3_4';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -722,8 +722,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/release/release_0_3_5.html
+++ b/0.5.0/release/release_0_3_5.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.3.5 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_3_5';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -765,8 +765,8 @@ including plans for the future.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/release/release_0_3_6.html
+++ b/0.5.0/release/release_0_3_6.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.3.6 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_3_6';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -809,8 +809,8 @@ room at https://napari.zulipchat.com!</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/release/release_0_3_7.html
+++ b/0.5.0/release/release_0_3_7.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.3.7 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_3_7';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -818,8 +818,8 @@ for the full list! Thank you to everyone who contributed to this release!</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/release/release_0_3_8.html
+++ b/0.5.0/release/release_0_3_8.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.3.8 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_3_8';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -755,8 +755,8 @@ and (#1643). This will also be our last release supporting Python3.6.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/release/release_0_4_0.html
+++ b/0.5.0/release/release_0_4_0.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.0 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_0';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -874,8 +874,8 @@ issues at https://github.com/napari/napari/issues.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/release/release_0_4_1.html
+++ b/0.5.0/release/release_0_4_1.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.1 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_1';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -843,8 +843,8 @@ use <code class="docutils literal notranslate"><span class="pre">Viewer.grid.str
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/release/release_0_4_10.html
+++ b/0.5.0/release/release_0_4_10.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.10 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_10';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -768,8 +768,8 @@ the others would be ignored. Now they will be composed as <code class="docutils 
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/release/release_0_4_11.html
+++ b/0.5.0/release/release_0_4_11.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.11 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_11';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -988,8 +988,8 @@ more! Thanks to our incredible user and contributor community.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/release/release_0_4_12.html
+++ b/0.5.0/release/release_0_4_12.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.12 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_12';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -863,8 +863,8 @@ be converted from a context menu on the layer list (#3402).</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/release/release_0_4_13.html
+++ b/0.5.0/release/release_0_4_13.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.13 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_13';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1018,8 +1018,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/release/release_0_4_14.html
+++ b/0.5.0/release/release_0_4_14.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.14 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_14';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -790,8 +790,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/release/release_0_4_15.html
+++ b/0.5.0/release/release_0_4_15.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.15 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_15';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -902,8 +902,8 @@ plugins on PyPI but have them not be listed in the app (#4074).</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/release/release_0_4_16.html
+++ b/0.5.0/release/release_0_4_16.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.16 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_16';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1062,8 +1062,8 @@ console, so this is strictly an improvement!)</p></li>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/release/release_0_4_17.html
+++ b/0.5.0/release/release_0_4_17.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.17 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_17';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1187,8 +1187,8 @@ or create issues on GitHub.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/release/release_0_4_18.html
+++ b/0.5.0/release/release_0_4_18.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.18 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_18';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1260,8 +1260,8 @@ vectors layer! (<a class="reference external" href="https://github.com/napari/na
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/release/release_0_4_19.html
+++ b/0.5.0/release/release_0_4_19.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.19 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_19';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1150,8 +1150,8 @@ superseded by <code class="docutils literal notranslate"><span class="pre">layer
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/release/release_0_4_2.html
+++ b/0.5.0/release/release_0_4_2.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.2 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_2';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -779,8 +779,8 @@ part of the codebase.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/release/release_0_4_3.html
+++ b/0.5.0/release/release_0_4_3.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.3 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_3';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -850,8 +850,8 @@ can still provide keymappings, but no longer handles keymappings from other obje
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/release/release_0_4_4.html
+++ b/0.5.0/release/release_0_4_4.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.4 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_4';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -816,8 +816,8 @@ be required after 0.4.6. (#1985)</p></li>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/release/release_0_4_5.html
+++ b/0.5.0/release/release_0_4_5.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.5 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_5';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -809,8 +809,8 @@ set matching contrast limits for multiple channels (#2226).</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/release/release_0_4_6.html
+++ b/0.5.0/release/release_0_4_6.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.6 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_6';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -814,8 +814,8 @@ menu.)</p></li>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/release/release_0_4_7.html
+++ b/0.5.0/release/release_0_4_7.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.7 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_7';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -878,8 +878,8 @@ coordinates.</p></li>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/release/release_0_4_8.html
+++ b/0.5.0/release/release_0_4_8.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.8 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_8';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -975,8 +975,8 @@ recommended.</p></li>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/release/release_0_4_9.html
+++ b/0.5.0/release/release_0_4_9.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.9 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_9';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -821,8 +821,8 @@ It also contains a variety of bug fixes and improvements.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/release/release_0_5_0.html
+++ b/0.5.0/release/release_0_5_0.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.5.0 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_5_0';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1636,8 +1636,8 @@ improvements. Please see below for the full list of changes since 0.4.19.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/release/release_0_5_1.html
+++ b/0.5.0/release/release_0_5_1.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.5.1 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_5_1';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -802,8 +802,8 @@ ago!</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/roadmaps/0_3.html
+++ b/0.5.0/roadmaps/0_3.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Roadmap 0.3 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'roadmaps/0_3';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -747,8 +747,8 @@ document.write(`
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/roadmaps/0_3_retrospective.html
+++ b/0.5.0/roadmaps/0_3_retrospective.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Roadmap 0.3 Retrospective &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'roadmaps/0_3_retrospective';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -812,8 +812,8 @@ document.write(`
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/roadmaps/0_4.html
+++ b/0.5.0/roadmaps/0_4.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Roadmap 0.4 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'roadmaps/0_4';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -798,8 +798,8 @@ details.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.0/roadmaps/index.html
+++ b/0.5.0/roadmaps/index.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.1/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.1/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.1/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Roadmaps &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.1/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.1/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.1/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.1/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=87e54e7c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/sphinx-design.min.css?v=87e54e7c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.1/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.1/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=002b6000"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.1/_static/documentation_options.js?v=002b6000"></script>
+    <script src="../../0.5.1/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.1/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.1/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.1/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.1/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'roadmaps/index';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.1/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.1/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.1/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.1/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -669,8 +669,8 @@ document.write(`
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.1/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.1/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/developers/architecture/app_model.html
+++ b/0.5.1/developers/architecture/app_model.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari’s application model &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/architecture/app_model';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1303,8 +1303,8 @@ Qt is available.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/developers/architecture/dir_organization.html
+++ b/0.5.1/developers/architecture/dir_organization.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari directory organization &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/architecture/dir_organization';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -781,8 +781,8 @@ and the <a class="reference internal" href="../../guides/threading.html#multithr
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/developers/architecture/index.html
+++ b/0.5.1/developers/architecture/index.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari architecture guide &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/architecture/index';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -674,8 +674,8 @@ or plugins are automatically created, inputs updated and outputs added to the
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/developers/architecture/magicgui_type_reg.html
+++ b/0.5.1/developers/architecture/magicgui_type_reg.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>magicgui type registration &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/architecture/magicgui_type_reg';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -770,8 +770,8 @@ for details.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/developers/architecture/napari_models.html
+++ b/0.5.1/developers/architecture/napari_models.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari models and events &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/architecture/napari_models';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -902,8 +902,8 @@ the function <code class="docutils literal notranslate"><span class="pre">_on_nd
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/developers/contributing/dev_install.html
+++ b/0.5.1/developers/contributing/dev_install.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Setting up a development installation &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/contributing/dev_install';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -755,8 +755,8 @@ please do not ignore errors lightly.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/developers/contributing/documentation/docs_deployment.html
+++ b/0.5.1/developers/contributing/documentation/docs_deployment.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Documentation and website deployment &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/contributing/documentation/docs_deployment';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -782,8 +782,8 @@ previews for PRs. The relevant configuration files are:</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/developers/contributing/documentation/docs_template.html
+++ b/0.5.1/developers/contributing/documentation/docs_template.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Docs template &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/contributing/documentation/docs_template';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -659,7 +659,7 @@ they contrast well against the background of the image.</p>
 <div class="admonition important">
 <p class="admonition-title">Important</p>
 <p>Adding videos
-If you want to include videos in your documentation, you should use the .webm format and add a screenshot of the video as a fallback for browsers that don’t support the video tag. Both files should be added to <code class="docutils literal notranslate"><span class="pre">docs/../dev/_static/images</span></code>. When the documentation is built, a .mp4 version of the video will be automatically generated and included in the documentation. You can then use the .webm file in your documentation like so:</p>
+If you want to include videos in your documentation, you should use the .webm format and add a screenshot of the video as a fallback for browsers that don’t support the video tag. Both files should be added to <code class="docutils literal notranslate"><span class="pre">docs/../0.5.2/_static/images</span></code>. When the documentation is built, a .mp4 version of the video will be automatically generated and included in the documentation. You can then use the .webm file in your documentation like so:</p>
 <div class="highlight-default notranslate"><div class="highlight"><pre><span></span>```{raw} html
 &lt;figure&gt;
 &lt;video width=&quot;100%&quot; controls autoplay loop muted playsinline&gt;
@@ -855,8 +855,8 @@ or other relevant documentation</p></li>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/developers/contributing/documentation/index.html
+++ b/0.5.1/developers/contributing/documentation/index.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Contributing Documentation &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/contributing/documentation/index';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1232,8 +1232,8 @@ block is present in all contributed examples.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/developers/contributing/index.html
+++ b/0.5.1/developers/contributing/index.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Contributing guide &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/contributing/index';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -796,8 +796,8 @@ identify the cause and where to optimize.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/developers/contributing/performance/benchmarks.html
+++ b/0.5.1/developers/contributing/performance/benchmarks.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Benchmarks &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/contributing/performance/benchmarks';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -877,8 +877,8 @@ Every time you want the benchmark CI to run in a PR, you’ll need to remove and
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/developers/contributing/performance/index.html
+++ b/0.5.1/developers/contributing/performance/index.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Performance &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/contributing/performance/index';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -683,8 +683,8 @@ document.write(`
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/developers/contributing/performance/profiling.html
+++ b/0.5.1/developers/contributing/performance/profiling.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Profiling &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/contributing/performance/profiling';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -790,8 +790,8 @@ button to trigger profiling:</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/developers/contributing/testing.html
+++ b/0.5.1/developers/contributing/testing.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Testing &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/contributing/testing';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1039,8 +1039,8 @@ so certain tests have been disabled from windows in CI, see
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/developers/contributing/translations.html
+++ b/0.5.1/developers/contributing/translations.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Translations &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/contributing/translations';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -898,8 +898,8 @@ and the napari user community.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/developers/coredev/core_dev_guide.html
+++ b/0.5.1/developers/coredev/core_dev_guide.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Core Developer guide &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/coredev/core_dev_guide';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -905,8 +905,8 @@ advance!</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/developers/coredev/maintenance.html
+++ b/0.5.1/developers/coredev/maintenance.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Maintenance &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/coredev/maintenance';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -738,8 +738,8 @@ to this page might be appropriate.</p></li>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/developers/coredev/packaging.html
+++ b/0.5.1/developers/coredev/packaging.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Packaging &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/coredev/packaging';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -939,8 +939,8 @@ that calls <code class="docutils literal notranslate"><span class="pre">menuinst
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/developers/coredev/release.html
+++ b/0.5.1/developers/coredev/release.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Release guide &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/coredev/release';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -931,8 +931,8 @@ To do so, we can submit a PR to <code class="docutils literal notranslate"><span
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/developers/index.html
+++ b/0.5.1/developers/index.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Contributing &#8212; napari</title>
   
   
@@ -20,45 +20,45 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>window.MathJax = {"options": {"processHtmlClass": "tex2jax_process|mathjax_process|math|output_area"}}</script>
     <script defer="defer" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/index';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -113,7 +113,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -141,8 +141,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -730,8 +730,8 @@ the tag “napari”.</p></li>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/index.html
+++ b/0.5.1/index.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari: a fast, interactive viewer for multi-dimensional images in Python &#8212; napari</title>
   
   
@@ -20,45 +20,45 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>window.MathJax = {"options": {"processHtmlClass": "tex2jax_process|mathjax_process|math|output_area"}}</script>
     <script defer="defer" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'index';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -112,7 +112,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -140,8 +140,8 @@
     
     
     
-    <img src="../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -478,9 +478,9 @@ document.write(`
 <figure>
 
   <video width="90%" controls autoplay loop muted playsinline>
-    <source src="../dev/_static/images/tribolium.webm" type="video/webm" />
-    <source src="../dev/_static/images/tribolium.mp4" type="video/mp4" />
-    <img src="../dev/_static/images/tribolium.jpg"
+    <source src="../0.5.2/_static/images/tribolium.webm" type="video/webm" />
+    <source src="../0.5.2/_static/images/tribolium.mp4" type="video/mp4" />
+    <img src="../0.5.2/_static/images/tribolium.jpg"
       title="your browser does not support the video tag"
       alt="napari viewer showing a 4D image of a developing Tribolium embryo.  Dataset Fluo-N3DL-TRIF from the [cell tracking challenge](http://celltrackingchallenge.net/3d-datasets/) by Dr. A. Jain, MPI-CBG, Dresden, Germany."
     >
@@ -602,8 +602,8 @@ Plugins</div>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/naps/0-nap-process.html
+++ b/0.5.1/naps/0-nap-process.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>NAP 0 — Purpose and Process &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/0-nap-process';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1021,8 +1021,8 @@ for retrieving older revisions, and can also be browsed on
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/naps/1-institutional-funding-partners.html
+++ b/0.5.1/naps/1-institutional-funding-partners.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>NAP-1 — Institutional and Funding Partners &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/1-institutional-funding-partners';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -936,8 +936,8 @@ per CC0+BY<a class="footnote-reference brackets" href="#id5" id="id3" role="doc-
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/naps/2-conda-based-packaging.html
+++ b/0.5.1/naps/2-conda-based-packaging.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>NAP-2 — Distributing napari with conda-based packaging &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/2-conda-based-packaging';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1480,8 +1480,8 @@ CC0+BY <a class="footnote-reference brackets" href="#cc0by" id="id49" role="doc-
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/naps/3-spaces.html
+++ b/0.5.1/naps/3-spaces.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>NAP-3 — Spaces &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/3-spaces';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -889,8 +889,8 @@ CC0+BY <a class="footnote-reference brackets" href="#cc0by" id="id6" role="doc-n
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/naps/4-async-slicing.html
+++ b/0.5.1/naps/4-async-slicing.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>NAP-4 — Asynchronous slicing &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/4-async-slicing';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1702,8 +1702,8 @@ CC0+BY <a class="footnote-reference brackets" href="#cc0-by" id="id16" role="doc
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/naps/5-new-logo.html
+++ b/0.5.1/naps/5-new-logo.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>NAP-5 — New logo (2022) &#8212; napari</title>
   
   
@@ -20,45 +20,45 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>window.MathJax = {"options": {"processHtmlClass": "tex2jax_process|mathjax_process|math|output_area"}}</script>
     <script defer="defer" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/5-new-logo';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -113,7 +113,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -141,8 +141,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -881,8 +881,8 @@ CC0+BY <a class="footnote-reference brackets" href="#id4" id="id2" role="doc-not
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/naps/6-contributable-menus.html
+++ b/0.5.1/naps/6-contributable-menus.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>NAP-6 — Contributable Menus &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/6-contributable-menus';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1325,8 +1325,8 @@ CC0+BY <a class="footnote-reference brackets" href="#id5" id="id7" role="doc-not
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/naps/7-key-binding-dispatch.html
+++ b/0.5.1/naps/7-key-binding-dispatch.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>NAP-7 — Key Binding Dispatch &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/7-key-binding-dispatch';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1212,8 +1212,8 @@ CC0+BY <a class="footnote-reference brackets" href="#id11" id="id6" role="doc-no
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/naps/8-telemetry.html
+++ b/0.5.1/naps/8-telemetry.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>NAP-8 — Telemetry &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/8-telemetry';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1254,8 +1254,8 @@ CC0+BY <a class="footnote-reference brackets" href="#id4" id="id6" role="doc-not
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/naps/9-multiple-canvases.html
+++ b/0.5.1/naps/9-multiple-canvases.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>NAP-9 — Multiple Canvases &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/9-multiple-canvases';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1108,8 +1108,8 @@ CC0+BY <a class="footnote-reference brackets" href="#id8" id="id6" role="doc-not
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/naps/index.html
+++ b/0.5.1/naps/index.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari Advancement Proposals (NAPs) &#8212; napari</title>
   
   
@@ -20,45 +20,45 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>window.MathJax = {"options": {"processHtmlClass": "tex2jax_process|mathjax_process|math|output_area"}}</script>
     <script defer="defer" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/index';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -113,7 +113,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -141,8 +141,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -704,8 +704,8 @@ document.write(`
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/naps/template.html
+++ b/0.5.1/naps/template.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>NAP-X — Template and Instructions &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/template';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -804,8 +804,8 @@ CC0+BY <a class="footnote-reference brackets" href="#id4" id="id6" role="doc-not
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/release/index.html
+++ b/0.5.1/release/index.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Release notes &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/index';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -662,8 +662,8 @@ document.write(`
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/release/release_0_1_0.html
+++ b/0.5.1/release/release_0_1_0.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.1.0 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_1_0';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -845,8 +845,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/release/release_0_1_3.html
+++ b/0.5.1/release/release_0_1_3.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.1.3 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_1_3';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -747,8 +747,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/release/release_0_1_5.html
+++ b/0.5.1/release/release_0_1_5.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.1.5 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_1_5';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -757,8 +757,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/release/release_0_2_0.html
+++ b/0.5.1/release/release_0_2_0.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.2.0 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_0';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -823,8 +823,8 @@ labels and image layer.</p></li>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/release/release_0_2_1.html
+++ b/0.5.1/release/release_0_2_1.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.2.1 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_1';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -747,8 +747,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/release/release_0_2_10.html
+++ b/0.5.1/release/release_0_2_10.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.2.10 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_10';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -716,8 +716,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/release/release_0_2_11.html
+++ b/0.5.1/release/release_0_2_11.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.2.11 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_11';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -766,8 +766,8 @@ for syntax details.</p></li>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/release/release_0_2_12.html
+++ b/0.5.1/release/release_0_2_12.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.2.12 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_12';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -778,8 +778,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/release/release_0_2_3.html
+++ b/0.5.1/release/release_0_2_3.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.2.3 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_3';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -738,8 +738,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/release/release_0_2_4.html
+++ b/0.5.1/release/release_0_2_4.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.2.4 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_4';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -740,8 +740,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/release/release_0_2_5.html
+++ b/0.5.1/release/release_0_2_5.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.2.5 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_5';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -735,8 +735,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/release/release_0_2_6.html
+++ b/0.5.1/release/release_0_2_6.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.2.6 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_6';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -757,8 +757,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/release/release_0_2_7.html
+++ b/0.5.1/release/release_0_2_7.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.2.7 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_7';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -791,8 +791,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/release/release_0_2_8.html
+++ b/0.5.1/release/release_0_2_8.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.2.8 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_8';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -726,8 +726,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/release/release_0_2_9.html
+++ b/0.5.1/release/release_0_2_9.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.2.9 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_9';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -758,8 +758,8 @@ colors currently selected in the GUI (#686)</p></li>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/release/release_0_3_0.html
+++ b/0.5.1/release/release_0_3_0.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.3.0 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_3_0';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1017,8 +1017,8 @@ expression a.k.a. the walrus operator:</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/release/release_0_3_1.html
+++ b/0.5.1/release/release_0_3_1.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.3.1 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_3_1';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -743,8 +743,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/release/release_0_3_2.html
+++ b/0.5.1/release/release_0_3_2.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.3.2 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_3_2';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -771,8 +771,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/release/release_0_3_3.html
+++ b/0.5.1/release/release_0_3_3.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.3.3 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_3_3';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -743,8 +743,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/release/release_0_3_4.html
+++ b/0.5.1/release/release_0_3_4.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.3.4 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_3_4';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -723,8 +723,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/release/release_0_3_5.html
+++ b/0.5.1/release/release_0_3_5.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.3.5 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_3_5';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -766,8 +766,8 @@ including plans for the future.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/release/release_0_3_6.html
+++ b/0.5.1/release/release_0_3_6.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.3.6 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_3_6';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -810,8 +810,8 @@ room at https://napari.zulipchat.com!</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/release/release_0_3_7.html
+++ b/0.5.1/release/release_0_3_7.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.3.7 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_3_7';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -819,8 +819,8 @@ for the full list! Thank you to everyone who contributed to this release!</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/release/release_0_3_8.html
+++ b/0.5.1/release/release_0_3_8.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.3.8 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_3_8';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -756,8 +756,8 @@ and (#1643). This will also be our last release supporting Python3.6.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/release/release_0_4_0.html
+++ b/0.5.1/release/release_0_4_0.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.0 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_0';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -875,8 +875,8 @@ issues at https://github.com/napari/napari/issues.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/release/release_0_4_1.html
+++ b/0.5.1/release/release_0_4_1.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.1 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_1';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -844,8 +844,8 @@ use <code class="docutils literal notranslate"><span class="pre">Viewer.grid.str
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/release/release_0_4_10.html
+++ b/0.5.1/release/release_0_4_10.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.10 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_10';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -769,8 +769,8 @@ the others would be ignored. Now they will be composed as <code class="docutils 
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/release/release_0_4_11.html
+++ b/0.5.1/release/release_0_4_11.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.11 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_11';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -989,8 +989,8 @@ more! Thanks to our incredible user and contributor community.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/release/release_0_4_12.html
+++ b/0.5.1/release/release_0_4_12.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.12 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_12';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -864,8 +864,8 @@ be converted from a context menu on the layer list (#3402).</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/release/release_0_4_13.html
+++ b/0.5.1/release/release_0_4_13.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.13 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_13';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1019,8 +1019,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/release/release_0_4_14.html
+++ b/0.5.1/release/release_0_4_14.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.14 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_14';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -791,8 +791,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/release/release_0_4_15.html
+++ b/0.5.1/release/release_0_4_15.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.15 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_15';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -903,8 +903,8 @@ plugins on PyPI but have them not be listed in the app (#4074).</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/release/release_0_4_16.html
+++ b/0.5.1/release/release_0_4_16.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.16 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_16';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1063,8 +1063,8 @@ console, so this is strictly an improvement!)</p></li>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/release/release_0_4_17.html
+++ b/0.5.1/release/release_0_4_17.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.17 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_17';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1188,8 +1188,8 @@ or create issues on GitHub.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/release/release_0_4_18.html
+++ b/0.5.1/release/release_0_4_18.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.18 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_18';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1261,8 +1261,8 @@ vectors layer! (<a class="reference external" href="https://github.com/napari/na
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/release/release_0_4_19.html
+++ b/0.5.1/release/release_0_4_19.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.19 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_19';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1151,8 +1151,8 @@ superseded by <code class="docutils literal notranslate"><span class="pre">layer
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/release/release_0_4_2.html
+++ b/0.5.1/release/release_0_4_2.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.2 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_2';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -780,8 +780,8 @@ part of the codebase.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/release/release_0_4_3.html
+++ b/0.5.1/release/release_0_4_3.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.3 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_3';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -851,8 +851,8 @@ can still provide keymappings, but no longer handles keymappings from other obje
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/release/release_0_4_4.html
+++ b/0.5.1/release/release_0_4_4.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.4 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_4';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -817,8 +817,8 @@ be required after 0.4.6. (#1985)</p></li>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/release/release_0_4_5.html
+++ b/0.5.1/release/release_0_4_5.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.5 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_5';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -810,8 +810,8 @@ set matching contrast limits for multiple channels (#2226).</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/release/release_0_4_6.html
+++ b/0.5.1/release/release_0_4_6.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.6 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_6';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -815,8 +815,8 @@ menu.)</p></li>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/release/release_0_4_7.html
+++ b/0.5.1/release/release_0_4_7.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.7 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_7';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -879,8 +879,8 @@ coordinates.</p></li>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/release/release_0_4_8.html
+++ b/0.5.1/release/release_0_4_8.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.8 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_8';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -976,8 +976,8 @@ recommended.</p></li>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/release/release_0_4_9.html
+++ b/0.5.1/release/release_0_4_9.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.9 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_9';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -822,8 +822,8 @@ It also contains a variety of bug fixes and improvements.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/release/release_0_5_0.html
+++ b/0.5.1/release/release_0_5_0.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.5.0 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_5_0';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1637,8 +1637,8 @@ improvements. Please see below for the full list of changes since 0.4.19.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/release/release_0_5_1.html
+++ b/0.5.1/release/release_0_5_1.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.5.1 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_5_1';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -803,8 +803,8 @@ ago!</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/release/release_0_5_2.html
+++ b/0.5.1/release/release_0_5_2.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.5.2 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_5_2';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -810,8 +810,8 @@ resize dynamically to take up a small part of the screen
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/roadmaps/0_3.html
+++ b/0.5.1/roadmaps/0_3.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Roadmap 0.3 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'roadmaps/0_3';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -748,8 +748,8 @@ document.write(`
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/roadmaps/0_3_retrospective.html
+++ b/0.5.1/roadmaps/0_3_retrospective.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Roadmap 0.3 Retrospective &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'roadmaps/0_3_retrospective';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -813,8 +813,8 @@ document.write(`
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/roadmaps/0_4.html
+++ b/0.5.1/roadmaps/0_4.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Roadmap 0.4 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'roadmaps/0_4';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -799,8 +799,8 @@ details.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.1/roadmaps/index.html
+++ b/0.5.1/roadmaps/index.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.2/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.2/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.2/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Roadmaps &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.2/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.2/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.2/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.2/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.2/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.2/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=c315459e"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.2/_static/documentation_options.js?v=c315459e"></script>
+    <script src="../../0.5.2/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.2/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.2/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.2/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.2/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'roadmaps/index';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.2/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.2/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.2/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.2/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -670,8 +670,8 @@ document.write(`
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.2/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.2/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/developers/architecture/app_model.html
+++ b/0.5.2/developers/architecture/app_model.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari’s application model &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/architecture/app_model';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1304,8 +1304,8 @@ Qt is available.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/developers/architecture/dir_organization.html
+++ b/0.5.2/developers/architecture/dir_organization.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari directory organization &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/architecture/dir_organization';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -782,8 +782,8 @@ and the <a class="reference internal" href="../../guides/threading.html#multithr
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/developers/architecture/index.html
+++ b/0.5.2/developers/architecture/index.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari architecture guide &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/architecture/index';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -675,8 +675,8 @@ or plugins are automatically created, inputs updated and outputs added to the
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/developers/architecture/magicgui_type_reg.html
+++ b/0.5.2/developers/architecture/magicgui_type_reg.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>magicgui type registration &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/architecture/magicgui_type_reg';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -771,8 +771,8 @@ for details.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/developers/architecture/napari_models.html
+++ b/0.5.2/developers/architecture/napari_models.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari models and events &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/architecture/napari_models';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -903,8 +903,8 @@ the function <code class="docutils literal notranslate"><span class="pre">_on_nd
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/developers/contributing/dev_install.html
+++ b/0.5.2/developers/contributing/dev_install.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Setting up a development installation &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/contributing/dev_install';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -756,8 +756,8 @@ please do not ignore errors lightly.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/developers/contributing/documentation/docs_deployment.html
+++ b/0.5.2/developers/contributing/documentation/docs_deployment.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Documentation and website deployment &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/contributing/documentation/docs_deployment';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -783,8 +783,8 @@ previews for PRs. The relevant configuration files are:</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/developers/contributing/documentation/docs_template.html
+++ b/0.5.2/developers/contributing/documentation/docs_template.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Docs template &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/contributing/documentation/docs_template';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -660,7 +660,7 @@ they contrast well against the background of the image.</p>
 <div class="admonition important">
 <p class="admonition-title">Important</p>
 <p>Adding videos
-If you want to include videos in your documentation, you should use the .webm format and add a screenshot of the video as a fallback for browsers that don’t support the video tag. Both files should be added to <code class="docutils literal notranslate"><span class="pre">docs/../dev/_static/images</span></code>. When the documentation is built, a .mp4 version of the video will be automatically generated and included in the documentation. You can then use the .webm file in your documentation like so:</p>
+If you want to include videos in your documentation, you should use the .webm format and add a screenshot of the video as a fallback for browsers that don’t support the video tag. Both files should be added to <code class="docutils literal notranslate"><span class="pre">docs/../0.5.3/_static/images</span></code>. When the documentation is built, a .mp4 version of the video will be automatically generated and included in the documentation. You can then use the .webm file in your documentation like so:</p>
 <div class="highlight-default notranslate"><div class="highlight"><pre><span></span>```{raw} html
 &lt;figure&gt;
 &lt;video width=&quot;100%&quot; controls autoplay loop muted playsinline&gt;
@@ -856,8 +856,8 @@ or other relevant documentation</p></li>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/developers/contributing/documentation/index.html
+++ b/0.5.2/developers/contributing/documentation/index.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Contributing Documentation &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/contributing/documentation/index';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1233,8 +1233,8 @@ block is present in all contributed examples.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/developers/contributing/index.html
+++ b/0.5.2/developers/contributing/index.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Contributing guide &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/contributing/index';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -797,8 +797,8 @@ identify the cause and where to optimize.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/developers/contributing/performance/benchmarks.html
+++ b/0.5.2/developers/contributing/performance/benchmarks.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Benchmarks &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/contributing/performance/benchmarks';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -878,8 +878,8 @@ Every time you want the benchmark CI to run in a PR, you’ll need to remove and
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/developers/contributing/performance/index.html
+++ b/0.5.2/developers/contributing/performance/index.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Performance &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/contributing/performance/index';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -684,8 +684,8 @@ document.write(`
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/developers/contributing/performance/profiling.html
+++ b/0.5.2/developers/contributing/performance/profiling.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Profiling &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/contributing/performance/profiling';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -791,8 +791,8 @@ button to trigger profiling:</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/developers/contributing/testing.html
+++ b/0.5.2/developers/contributing/testing.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Testing &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/contributing/testing';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1057,8 +1057,8 @@ so certain tests have been disabled from windows in CI, see
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/developers/contributing/translations.html
+++ b/0.5.2/developers/contributing/translations.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Translations &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/contributing/translations';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -899,8 +899,8 @@ and the napari user community.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/developers/coredev/core_dev_guide.html
+++ b/0.5.2/developers/coredev/core_dev_guide.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Core Developer guide &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/coredev/core_dev_guide';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -906,8 +906,8 @@ advance!</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/developers/coredev/maintenance.html
+++ b/0.5.2/developers/coredev/maintenance.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Maintenance &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/coredev/maintenance';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -739,8 +739,8 @@ to this page might be appropriate.</p></li>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/developers/coredev/packaging.html
+++ b/0.5.2/developers/coredev/packaging.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Packaging &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/coredev/packaging';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -940,8 +940,8 @@ that calls <code class="docutils literal notranslate"><span class="pre">menuinst
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/developers/coredev/release.html
+++ b/0.5.2/developers/coredev/release.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Release guide &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/coredev/release';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -948,8 +948,8 @@ To do so, we can submit a PR to <code class="docutils literal notranslate"><span
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/developers/index.html
+++ b/0.5.2/developers/index.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Contributing &#8212; napari</title>
   
   
@@ -20,45 +20,45 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>window.MathJax = {"options": {"processHtmlClass": "tex2jax_process|mathjax_process|math|output_area"}}</script>
     <script defer="defer" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/index';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -113,7 +113,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -141,8 +141,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -731,8 +731,8 @@ the tag “napari”.</p></li>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/index.html
+++ b/0.5.2/index.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari: a fast, interactive viewer for multi-dimensional images in Python &#8212; napari</title>
   
   
@@ -20,45 +20,45 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>window.MathJax = {"options": {"processHtmlClass": "tex2jax_process|mathjax_process|math|output_area"}}</script>
     <script defer="defer" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'index';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -112,7 +112,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -140,8 +140,8 @@
     
     
     
-    <img src="../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -478,9 +478,9 @@ document.write(`
 <figure>
 
   <video width="90%" controls autoplay loop muted playsinline>
-    <source src="../dev/_static/images/tribolium.webm" type="video/webm" />
-    <source src="../dev/_static/images/tribolium.mp4" type="video/mp4" />
-    <img src="../dev/_static/images/tribolium.jpg"
+    <source src="../0.5.3/_static/images/tribolium.webm" type="video/webm" />
+    <source src="../0.5.3/_static/images/tribolium.mp4" type="video/mp4" />
+    <img src="../0.5.3/_static/images/tribolium.jpg"
       title="your browser does not support the video tag"
       alt="napari viewer showing a 4D image of a developing Tribolium embryo.  Dataset Fluo-N3DL-TRIF from the [cell tracking challenge](http://celltrackingchallenge.net/3d-datasets/) by Dr. A. Jain, MPI-CBG, Dresden, Germany."
     >
@@ -602,8 +602,8 @@ Plugins</div>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/naps/0-nap-process.html
+++ b/0.5.2/naps/0-nap-process.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>NAP 0 — Purpose and Process &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/0-nap-process';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1022,8 +1022,8 @@ for retrieving older revisions, and can also be browsed on
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/naps/1-institutional-funding-partners.html
+++ b/0.5.2/naps/1-institutional-funding-partners.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>NAP-1 — Institutional and Funding Partners &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/1-institutional-funding-partners';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -937,8 +937,8 @@ per CC0+BY<a class="footnote-reference brackets" href="#id5" id="id3" role="doc-
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/naps/2-conda-based-packaging.html
+++ b/0.5.2/naps/2-conda-based-packaging.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>NAP-2 — Distributing napari with conda-based packaging &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/2-conda-based-packaging';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1481,8 +1481,8 @@ CC0+BY <a class="footnote-reference brackets" href="#cc0by" id="id49" role="doc-
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/naps/3-spaces.html
+++ b/0.5.2/naps/3-spaces.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>NAP-3 — Spaces &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/3-spaces';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -890,8 +890,8 @@ CC0+BY <a class="footnote-reference brackets" href="#cc0by" id="id6" role="doc-n
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/naps/4-async-slicing.html
+++ b/0.5.2/naps/4-async-slicing.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>NAP-4 — Asynchronous slicing &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/4-async-slicing';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1703,8 +1703,8 @@ CC0+BY <a class="footnote-reference brackets" href="#cc0-by" id="id16" role="doc
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/naps/5-new-logo.html
+++ b/0.5.2/naps/5-new-logo.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>NAP-5 — New logo (2022) &#8212; napari</title>
   
   
@@ -20,45 +20,45 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>window.MathJax = {"options": {"processHtmlClass": "tex2jax_process|mathjax_process|math|output_area"}}</script>
     <script defer="defer" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/5-new-logo';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -113,7 +113,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -141,8 +141,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -882,8 +882,8 @@ CC0+BY <a class="footnote-reference brackets" href="#id4" id="id2" role="doc-not
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/naps/6-contributable-menus.html
+++ b/0.5.2/naps/6-contributable-menus.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>NAP-6 — Contributable Menus &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/6-contributable-menus';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1326,8 +1326,8 @@ CC0+BY <a class="footnote-reference brackets" href="#id5" id="id7" role="doc-not
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/naps/7-key-binding-dispatch.html
+++ b/0.5.2/naps/7-key-binding-dispatch.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>NAP-7 — Key Binding Dispatch &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/7-key-binding-dispatch';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1213,8 +1213,8 @@ CC0+BY <a class="footnote-reference brackets" href="#id11" id="id6" role="doc-no
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/naps/8-telemetry.html
+++ b/0.5.2/naps/8-telemetry.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>NAP-8 — Telemetry &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/8-telemetry';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1255,8 +1255,8 @@ CC0+BY <a class="footnote-reference brackets" href="#id4" id="id6" role="doc-not
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/naps/9-multiple-canvases.html
+++ b/0.5.2/naps/9-multiple-canvases.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>NAP-9 — Multiple Canvases &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/9-multiple-canvases';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1109,8 +1109,8 @@ CC0+BY <a class="footnote-reference brackets" href="#id8" id="id6" role="doc-not
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/naps/index.html
+++ b/0.5.2/naps/index.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari Advancement Proposals (NAPs) &#8212; napari</title>
   
   
@@ -20,45 +20,45 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>window.MathJax = {"options": {"processHtmlClass": "tex2jax_process|mathjax_process|math|output_area"}}</script>
     <script defer="defer" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/index';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -113,7 +113,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -141,8 +141,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -705,8 +705,8 @@ document.write(`
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/naps/template.html
+++ b/0.5.2/naps/template.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>NAP-X — Template and Instructions &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/template';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -805,8 +805,8 @@ CC0+BY <a class="footnote-reference brackets" href="#id4" id="id6" role="doc-not
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/release/index.html
+++ b/0.5.2/release/index.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Release notes &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/index';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -663,8 +663,8 @@ document.write(`
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/release/release_0_1_0.html
+++ b/0.5.2/release/release_0_1_0.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.1.0 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_1_0';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -846,8 +846,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/release/release_0_1_3.html
+++ b/0.5.2/release/release_0_1_3.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.1.3 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_1_3';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -748,8 +748,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/release/release_0_1_5.html
+++ b/0.5.2/release/release_0_1_5.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.1.5 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_1_5';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -758,8 +758,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/release/release_0_2_0.html
+++ b/0.5.2/release/release_0_2_0.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.2.0 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_0';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -824,8 +824,8 @@ labels and image layer.</p></li>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/release/release_0_2_1.html
+++ b/0.5.2/release/release_0_2_1.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.2.1 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_1';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -748,8 +748,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/release/release_0_2_10.html
+++ b/0.5.2/release/release_0_2_10.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.2.10 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_10';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -717,8 +717,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/release/release_0_2_11.html
+++ b/0.5.2/release/release_0_2_11.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.2.11 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_11';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -767,8 +767,8 @@ for syntax details.</p></li>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/release/release_0_2_12.html
+++ b/0.5.2/release/release_0_2_12.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.2.12 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_12';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -779,8 +779,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/release/release_0_2_3.html
+++ b/0.5.2/release/release_0_2_3.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.2.3 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_3';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -739,8 +739,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/release/release_0_2_4.html
+++ b/0.5.2/release/release_0_2_4.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.2.4 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_4';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -741,8 +741,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/release/release_0_2_5.html
+++ b/0.5.2/release/release_0_2_5.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.2.5 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_5';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -736,8 +736,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/release/release_0_2_6.html
+++ b/0.5.2/release/release_0_2_6.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.2.6 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_6';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -758,8 +758,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/release/release_0_2_7.html
+++ b/0.5.2/release/release_0_2_7.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.2.7 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_7';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -792,8 +792,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/release/release_0_2_8.html
+++ b/0.5.2/release/release_0_2_8.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.2.8 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_8';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -727,8 +727,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/release/release_0_2_9.html
+++ b/0.5.2/release/release_0_2_9.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.2.9 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_9';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -759,8 +759,8 @@ colors currently selected in the GUI (#686)</p></li>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/release/release_0_3_0.html
+++ b/0.5.2/release/release_0_3_0.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.3.0 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_3_0';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1018,8 +1018,8 @@ expression a.k.a. the walrus operator:</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/release/release_0_3_1.html
+++ b/0.5.2/release/release_0_3_1.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.3.1 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_3_1';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -744,8 +744,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/release/release_0_3_2.html
+++ b/0.5.2/release/release_0_3_2.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.3.2 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_3_2';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -772,8 +772,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/release/release_0_3_3.html
+++ b/0.5.2/release/release_0_3_3.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.3.3 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_3_3';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -744,8 +744,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/release/release_0_3_4.html
+++ b/0.5.2/release/release_0_3_4.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.3.4 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_3_4';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -724,8 +724,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/release/release_0_3_5.html
+++ b/0.5.2/release/release_0_3_5.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.3.5 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_3_5';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -767,8 +767,8 @@ including plans for the future.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/release/release_0_3_6.html
+++ b/0.5.2/release/release_0_3_6.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.3.6 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_3_6';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -811,8 +811,8 @@ room at https://napari.zulipchat.com!</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/release/release_0_3_7.html
+++ b/0.5.2/release/release_0_3_7.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.3.7 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_3_7';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -820,8 +820,8 @@ for the full list! Thank you to everyone who contributed to this release!</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/release/release_0_3_8.html
+++ b/0.5.2/release/release_0_3_8.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.3.8 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_3_8';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -757,8 +757,8 @@ and (#1643). This will also be our last release supporting Python3.6.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/release/release_0_4_0.html
+++ b/0.5.2/release/release_0_4_0.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.0 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_0';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -876,8 +876,8 @@ issues at https://github.com/napari/napari/issues.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/release/release_0_4_1.html
+++ b/0.5.2/release/release_0_4_1.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.1 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_1';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -845,8 +845,8 @@ use <code class="docutils literal notranslate"><span class="pre">Viewer.grid.str
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/release/release_0_4_10.html
+++ b/0.5.2/release/release_0_4_10.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.10 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_10';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -770,8 +770,8 @@ the others would be ignored. Now they will be composed as <code class="docutils 
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/release/release_0_4_11.html
+++ b/0.5.2/release/release_0_4_11.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.11 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_11';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -990,8 +990,8 @@ more! Thanks to our incredible user and contributor community.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/release/release_0_4_12.html
+++ b/0.5.2/release/release_0_4_12.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.12 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_12';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -865,8 +865,8 @@ be converted from a context menu on the layer list (#3402).</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/release/release_0_4_13.html
+++ b/0.5.2/release/release_0_4_13.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.13 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_13';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1020,8 +1020,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/release/release_0_4_14.html
+++ b/0.5.2/release/release_0_4_14.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.14 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_14';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -792,8 +792,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/release/release_0_4_15.html
+++ b/0.5.2/release/release_0_4_15.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.15 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_15';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -904,8 +904,8 @@ plugins on PyPI but have them not be listed in the app (#4074).</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/release/release_0_4_16.html
+++ b/0.5.2/release/release_0_4_16.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.16 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_16';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1064,8 +1064,8 @@ console, so this is strictly an improvement!)</p></li>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/release/release_0_4_17.html
+++ b/0.5.2/release/release_0_4_17.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.17 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_17';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1189,8 +1189,8 @@ or create issues on GitHub.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/release/release_0_4_18.html
+++ b/0.5.2/release/release_0_4_18.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.18 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_18';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1262,8 +1262,8 @@ vectors layer! (<a class="reference external" href="https://github.com/napari/na
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/release/release_0_4_19.html
+++ b/0.5.2/release/release_0_4_19.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.19 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_19';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1152,8 +1152,8 @@ superseded by <code class="docutils literal notranslate"><span class="pre">layer
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/release/release_0_4_2.html
+++ b/0.5.2/release/release_0_4_2.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.2 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_2';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -781,8 +781,8 @@ part of the codebase.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/release/release_0_4_3.html
+++ b/0.5.2/release/release_0_4_3.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.3 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_3';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -852,8 +852,8 @@ can still provide keymappings, but no longer handles keymappings from other obje
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/release/release_0_4_4.html
+++ b/0.5.2/release/release_0_4_4.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.4 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_4';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -818,8 +818,8 @@ be required after 0.4.6. (#1985)</p></li>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/release/release_0_4_5.html
+++ b/0.5.2/release/release_0_4_5.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.5 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_5';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -811,8 +811,8 @@ set matching contrast limits for multiple channels (#2226).</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/release/release_0_4_6.html
+++ b/0.5.2/release/release_0_4_6.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.6 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_6';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -816,8 +816,8 @@ menu.)</p></li>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/release/release_0_4_7.html
+++ b/0.5.2/release/release_0_4_7.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.7 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_7';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -880,8 +880,8 @@ coordinates.</p></li>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/release/release_0_4_8.html
+++ b/0.5.2/release/release_0_4_8.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.8 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_8';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -977,8 +977,8 @@ recommended.</p></li>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/release/release_0_4_9.html
+++ b/0.5.2/release/release_0_4_9.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.9 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_9';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -823,8 +823,8 @@ It also contains a variety of bug fixes and improvements.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/release/release_0_5_0.html
+++ b/0.5.2/release/release_0_5_0.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.5.0 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_5_0';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1638,8 +1638,8 @@ improvements. Please see below for the full list of changes since 0.4.19.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/release/release_0_5_1.html
+++ b/0.5.2/release/release_0_5_1.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.5.1 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_5_1';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -804,8 +804,8 @@ ago!</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/release/release_0_5_2.html
+++ b/0.5.2/release/release_0_5_2.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.5.2 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_5_2';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -811,8 +811,8 @@ resize dynamically to take up a small part of the screen
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/release/release_0_5_3.html
+++ b/0.5.2/release/release_0_5_3.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.5.3 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_5_3';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -815,8 +815,8 @@ changes!</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/roadmaps/0_3.html
+++ b/0.5.2/roadmaps/0_3.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Roadmap 0.3 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'roadmaps/0_3';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -749,8 +749,8 @@ document.write(`
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/roadmaps/0_3_retrospective.html
+++ b/0.5.2/roadmaps/0_3_retrospective.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Roadmap 0.3 Retrospective &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'roadmaps/0_3_retrospective';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -814,8 +814,8 @@ document.write(`
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/roadmaps/0_4.html
+++ b/0.5.2/roadmaps/0_4.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Roadmap 0.4 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'roadmaps/0_4';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -800,8 +800,8 @@ details.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.2/roadmaps/index.html
+++ b/0.5.2/roadmaps/index.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.3/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.3/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.3/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Roadmaps &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.3/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.3/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.3/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.3/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.3/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.3/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=243f1df4"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.3/_static/documentation_options.js?v=243f1df4"></script>
+    <script src="../../0.5.3/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.3/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.3/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.3/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.3/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'roadmaps/index';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.3/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.3/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.3/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.3/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -671,8 +671,8 @@ document.write(`
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.3/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.3/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/developers/architecture/app_model.html
+++ b/0.5.3/developers/architecture/app_model.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari’s application model &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/architecture/app_model';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1253,8 +1253,8 @@ Qt is available.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/developers/architecture/dir_organization.html
+++ b/0.5.3/developers/architecture/dir_organization.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari directory organization &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/architecture/dir_organization';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -731,8 +731,8 @@ and the <a class="reference internal" href="../../guides/threading.html#multithr
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/developers/architecture/index.html
+++ b/0.5.3/developers/architecture/index.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari architecture guide &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/architecture/index';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -624,8 +624,8 @@ or plugins are automatically created, inputs updated and outputs added to the
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/developers/architecture/magicgui_type_reg.html
+++ b/0.5.3/developers/architecture/magicgui_type_reg.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>magicgui type registration &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/architecture/magicgui_type_reg';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -720,8 +720,8 @@ for details.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/developers/architecture/napari_models.html
+++ b/0.5.3/developers/architecture/napari_models.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari models and events &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/architecture/napari_models';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -852,8 +852,8 @@ the function <code class="docutils literal notranslate"><span class="pre">_on_nd
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/developers/contributing/dev_install.html
+++ b/0.5.3/developers/contributing/dev_install.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Setting up a development installation &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/contributing/dev_install';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -705,8 +705,8 @@ please do not ignore errors lightly.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/developers/contributing/documentation/docs_deployment.html
+++ b/0.5.3/developers/contributing/documentation/docs_deployment.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Documentation and website deployment &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/contributing/documentation/docs_deployment';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -732,8 +732,8 @@ previews for PRs. The relevant configuration files are:</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/developers/contributing/documentation/docs_template.html
+++ b/0.5.3/developers/contributing/documentation/docs_template.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Docs template &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/contributing/documentation/docs_template';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -609,7 +609,7 @@ they contrast well against the background of the image.</p>
 <div class="admonition important">
 <p class="admonition-title">Important</p>
 <p>Adding videos
-If you want to include videos in your documentation, you should use the .webm format and add a screenshot of the video as a fallback for browsers that don’t support the video tag. Both files should be added to <code class="docutils literal notranslate"><span class="pre">docs/../dev/_static/images</span></code>. When the documentation is built, a .mp4 version of the video will be automatically generated and included in the documentation. You can then use the .webm file in your documentation like so:</p>
+If you want to include videos in your documentation, you should use the .webm format and add a screenshot of the video as a fallback for browsers that don’t support the video tag. Both files should be added to <code class="docutils literal notranslate"><span class="pre">docs/../0.5.4/_static/images</span></code>. When the documentation is built, a .mp4 version of the video will be automatically generated and included in the documentation. You can then use the .webm file in your documentation like so:</p>
 <div class="highlight-default notranslate"><div class="highlight"><pre><span></span>```{raw} html
 &lt;figure&gt;
 &lt;video width=&quot;100%&quot; controls autoplay loop muted playsinline&gt;
@@ -805,8 +805,8 @@ or other relevant documentation</p></li>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/developers/contributing/documentation/index.html
+++ b/0.5.3/developers/contributing/documentation/index.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Contributing Documentation &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/contributing/documentation/index';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1182,8 +1182,8 @@ block is present in all contributed examples.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/developers/contributing/index.html
+++ b/0.5.3/developers/contributing/index.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Contributing guide &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/contributing/index';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -746,8 +746,8 @@ identify the cause and where to optimize.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/developers/contributing/performance/benchmarks.html
+++ b/0.5.3/developers/contributing/performance/benchmarks.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Benchmarks &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/contributing/performance/benchmarks';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -827,8 +827,8 @@ Every time you want the benchmark CI to run in a PR, you’ll need to remove and
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/developers/contributing/performance/index.html
+++ b/0.5.3/developers/contributing/performance/index.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Performance &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/contributing/performance/index';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -633,8 +633,8 @@ document.write(`
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/developers/contributing/performance/profiling.html
+++ b/0.5.3/developers/contributing/performance/profiling.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Profiling &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/contributing/performance/profiling';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -740,8 +740,8 @@ button to trigger profiling:</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/developers/contributing/testing.html
+++ b/0.5.3/developers/contributing/testing.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Testing &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/contributing/testing';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1006,8 +1006,8 @@ so certain tests have been disabled from windows in CI, see
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/developers/contributing/translations.html
+++ b/0.5.3/developers/contributing/translations.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Translations &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/contributing/translations';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -848,8 +848,8 @@ and the napari user community.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/developers/coredev/core_dev_guide.html
+++ b/0.5.3/developers/coredev/core_dev_guide.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Core Developer guide &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/coredev/core_dev_guide';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -855,8 +855,8 @@ advance!</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/developers/coredev/maintenance.html
+++ b/0.5.3/developers/coredev/maintenance.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Maintenance &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/coredev/maintenance';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -712,8 +712,8 @@ on the <code class="docutils literal notranslate"><span class="pre">stdout</span
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/developers/coredev/packaging.html
+++ b/0.5.3/developers/coredev/packaging.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Packaging &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/coredev/packaging';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -889,8 +889,8 @@ that calls <code class="docutils literal notranslate"><span class="pre">menuinst
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/developers/coredev/release.html
+++ b/0.5.3/developers/coredev/release.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Release guide &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/coredev/release';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -800,7 +800,7 @@ git<span class="w"> </span>push
 </pre></div>
 </div>
 <ol class="arabic simple" start="2">
-<li><p>In the <code class="docutils literal notranslate"><span class="pre">napari/docs</span></code> repo, update the <a class="reference external" href="https://github.com/napari/docs/blob/main/docs/../dev/_static/version_switcher.json"><code class="docutils literal notranslate"><span class="pre">docs/../dev/_static/version_switcher.json</span></code> file</a> so that <code class="docutils literal notranslate"><span class="pre">stable</span></code> points to the right version. The active version switcher is read from the file in the <code class="docutils literal notranslate"><span class="pre">dev</span></code> folder, so this can be done as the last step in the process.</p></li>
+<li><p>In the <code class="docutils literal notranslate"><span class="pre">napari/docs</span></code> repo, update the <a class="reference external" href="https://github.com/napari/docs/blob/main/docs/../0.5.4/_static/version_switcher.json"><code class="docutils literal notranslate"><span class="pre">docs/../0.5.4/_static/version_switcher.json</span></code> file</a> so that <code class="docutils literal notranslate"><span class="pre">stable</span></code> points to the right version. The active version switcher is read from the file in the <code class="docutils literal notranslate"><span class="pre">dev</span></code> folder, so this can be done as the last step in the process.</p></li>
 </ol>
 </section>
 </section>
@@ -893,8 +893,8 @@ git<span class="w"> </span>push
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/developers/index.html
+++ b/0.5.3/developers/index.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Contributing &#8212; napari</title>
   
   
@@ -20,45 +20,45 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>window.MathJax = {"options": {"processHtmlClass": "tex2jax_process|mathjax_process|math|output_area"}}</script>
     <script defer="defer" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/index';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -113,7 +113,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -141,8 +141,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -680,8 +680,8 @@ the tag “napari”.</p></li>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/index.html
+++ b/0.5.3/index.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari: a fast, interactive viewer for multi-dimensional images in Python &#8212; napari</title>
   
   
@@ -20,45 +20,45 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>window.MathJax = {"options": {"processHtmlClass": "tex2jax_process|mathjax_process|math|output_area"}}</script>
     <script defer="defer" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'index';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -112,7 +112,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -140,8 +140,8 @@
     
     
     
-    <img src="../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -478,9 +478,9 @@ document.write(`
 <figure>
 
   <video width="90%" controls autoplay loop muted playsinline>
-    <source src="../dev/_static/images/tribolium.webm" type="video/webm" />
-    <source src="../dev/_static/images/tribolium.mp4" type="video/mp4" />
-    <img src="../dev/_static/images/tribolium.jpg"
+    <source src="../0.5.4/_static/images/tribolium.webm" type="video/webm" />
+    <source src="../0.5.4/_static/images/tribolium.mp4" type="video/mp4" />
+    <img src="../0.5.4/_static/images/tribolium.jpg"
       title="your browser does not support the video tag"
       alt="napari viewer showing a 4D image of a developing Tribolium embryo.  Dataset Fluo-N3DL-TRIF from the [cell tracking challenge](http://celltrackingchallenge.net/3d-datasets/) by Dr. A. Jain, MPI-CBG, Dresden, Germany."
     >
@@ -602,8 +602,8 @@ Plugins</div>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/naps/0-nap-process.html
+++ b/0.5.3/naps/0-nap-process.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>NAP 0 — Purpose and Process &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/0-nap-process';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -971,8 +971,8 @@ for retrieving older revisions, and can also be browsed on
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/naps/1-institutional-funding-partners.html
+++ b/0.5.3/naps/1-institutional-funding-partners.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>NAP-1 — Institutional and Funding Partners &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/1-institutional-funding-partners';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -886,8 +886,8 @@ per CC0+BY<a class="footnote-reference brackets" href="#id5" id="id3" role="doc-
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/naps/2-conda-based-packaging.html
+++ b/0.5.3/naps/2-conda-based-packaging.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>NAP-2 — Distributing napari with conda-based packaging &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/2-conda-based-packaging';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1430,8 +1430,8 @@ CC0+BY <a class="footnote-reference brackets" href="#cc0by" id="id49" role="doc-
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/naps/3-spaces.html
+++ b/0.5.3/naps/3-spaces.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>NAP-3 — Spaces &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/3-spaces';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -839,8 +839,8 @@ CC0+BY <a class="footnote-reference brackets" href="#cc0by" id="id6" role="doc-n
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/naps/4-async-slicing.html
+++ b/0.5.3/naps/4-async-slicing.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>NAP-4 — Asynchronous slicing &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/4-async-slicing';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1652,8 +1652,8 @@ CC0+BY <a class="footnote-reference brackets" href="#cc0-by" id="id16" role="doc
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/naps/5-new-logo.html
+++ b/0.5.3/naps/5-new-logo.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>NAP-5 — New logo (2022) &#8212; napari</title>
   
   
@@ -20,45 +20,45 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>window.MathJax = {"options": {"processHtmlClass": "tex2jax_process|mathjax_process|math|output_area"}}</script>
     <script defer="defer" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/5-new-logo';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -113,7 +113,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -141,8 +141,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -831,8 +831,8 @@ CC0+BY <a class="footnote-reference brackets" href="#id4" id="id2" role="doc-not
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/naps/6-contributable-menus.html
+++ b/0.5.3/naps/6-contributable-menus.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>NAP-6 — Contributable Menus &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/6-contributable-menus';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1275,8 +1275,8 @@ CC0+BY <a class="footnote-reference brackets" href="#id5" id="id7" role="doc-not
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/naps/7-key-binding-dispatch.html
+++ b/0.5.3/naps/7-key-binding-dispatch.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>NAP-7 — Key Binding Dispatch &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/7-key-binding-dispatch';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1162,8 +1162,8 @@ CC0+BY <a class="footnote-reference brackets" href="#id11" id="id6" role="doc-no
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/naps/8-telemetry.html
+++ b/0.5.3/naps/8-telemetry.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>NAP-8 — Telemetry &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/8-telemetry';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1204,8 +1204,8 @@ CC0+BY <a class="footnote-reference brackets" href="#id4" id="id6" role="doc-not
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/naps/9-multiple-canvases.html
+++ b/0.5.3/naps/9-multiple-canvases.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>NAP-9 — Multiple Canvases &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/9-multiple-canvases';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1058,8 +1058,8 @@ CC0+BY <a class="footnote-reference brackets" href="#id8" id="id6" role="doc-not
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/naps/index.html
+++ b/0.5.3/naps/index.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari Advancement Proposals (NAPs) &#8212; napari</title>
   
   
@@ -20,45 +20,45 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>window.MathJax = {"options": {"processHtmlClass": "tex2jax_process|mathjax_process|math|output_area"}}</script>
     <script defer="defer" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/index';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -113,7 +113,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -141,8 +141,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -654,8 +654,8 @@ document.write(`
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/naps/template.html
+++ b/0.5.3/naps/template.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>NAP-X — Template and Instructions &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/template';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -754,8 +754,8 @@ CC0+BY <a class="footnote-reference brackets" href="#id4" id="id6" role="doc-not
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/release/index.html
+++ b/0.5.3/release/index.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Release notes &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/index';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -810,8 +810,8 @@ document.write(`
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/release/release_0_1_0.html
+++ b/0.5.3/release/release_0_1_0.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.1.0 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_1_0';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -993,8 +993,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/release/release_0_1_3.html
+++ b/0.5.3/release/release_0_1_3.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.1.3 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_1_3';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -895,8 +895,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/release/release_0_1_5.html
+++ b/0.5.3/release/release_0_1_5.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.1.5 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_1_5';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -905,8 +905,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/release/release_0_2_0.html
+++ b/0.5.3/release/release_0_2_0.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.2.0 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_0';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -971,8 +971,8 @@ labels and image layer.</p></li>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/release/release_0_2_1.html
+++ b/0.5.3/release/release_0_2_1.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.2.1 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_1';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -895,8 +895,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/release/release_0_2_10.html
+++ b/0.5.3/release/release_0_2_10.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.2.10 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_10';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -864,8 +864,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/release/release_0_2_11.html
+++ b/0.5.3/release/release_0_2_11.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.2.11 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_11';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -914,8 +914,8 @@ for syntax details.</p></li>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/release/release_0_2_12.html
+++ b/0.5.3/release/release_0_2_12.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.2.12 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_12';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -926,8 +926,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/release/release_0_2_3.html
+++ b/0.5.3/release/release_0_2_3.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.2.3 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_3';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -886,8 +886,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/release/release_0_2_4.html
+++ b/0.5.3/release/release_0_2_4.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.2.4 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_4';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -888,8 +888,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/release/release_0_2_5.html
+++ b/0.5.3/release/release_0_2_5.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.2.5 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_5';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -883,8 +883,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/release/release_0_2_6.html
+++ b/0.5.3/release/release_0_2_6.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.2.6 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_6';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -905,8 +905,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/release/release_0_2_7.html
+++ b/0.5.3/release/release_0_2_7.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.2.7 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_7';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -939,8 +939,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/release/release_0_2_8.html
+++ b/0.5.3/release/release_0_2_8.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.2.8 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_8';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -874,8 +874,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/release/release_0_2_9.html
+++ b/0.5.3/release/release_0_2_9.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.2.9 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_9';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -906,8 +906,8 @@ colors currently selected in the GUI (#686)</p></li>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/release/release_0_3_0.html
+++ b/0.5.3/release/release_0_3_0.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.3.0 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_3_0';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1165,8 +1165,8 @@ expression a.k.a. the walrus operator:</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/release/release_0_3_1.html
+++ b/0.5.3/release/release_0_3_1.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.3.1 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_3_1';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -891,8 +891,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/release/release_0_3_2.html
+++ b/0.5.3/release/release_0_3_2.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.3.2 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_3_2';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -919,8 +919,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/release/release_0_3_3.html
+++ b/0.5.3/release/release_0_3_3.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.3.3 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_3_3';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -891,8 +891,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/release/release_0_3_4.html
+++ b/0.5.3/release/release_0_3_4.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.3.4 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_3_4';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -871,8 +871,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/release/release_0_3_5.html
+++ b/0.5.3/release/release_0_3_5.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.3.5 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_3_5';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -914,8 +914,8 @@ including plans for the future.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/release/release_0_3_6.html
+++ b/0.5.3/release/release_0_3_6.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.3.6 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_3_6';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -958,8 +958,8 @@ room at https://napari.zulipchat.com!</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/release/release_0_3_7.html
+++ b/0.5.3/release/release_0_3_7.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.3.7 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_3_7';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -967,8 +967,8 @@ for the full list! Thank you to everyone who contributed to this release!</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/release/release_0_3_8.html
+++ b/0.5.3/release/release_0_3_8.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.3.8 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_3_8';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -904,8 +904,8 @@ and (#1643). This will also be our last release supporting Python3.6.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/release/release_0_4_0.html
+++ b/0.5.3/release/release_0_4_0.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.0 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_0';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1023,8 +1023,8 @@ issues at https://github.com/napari/napari/issues.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/release/release_0_4_1.html
+++ b/0.5.3/release/release_0_4_1.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.1 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_1';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -992,8 +992,8 @@ use <code class="docutils literal notranslate"><span class="pre">Viewer.grid.str
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/release/release_0_4_10.html
+++ b/0.5.3/release/release_0_4_10.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.10 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_10';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -917,8 +917,8 @@ the others would be ignored. Now they will be composed as <code class="docutils 
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/release/release_0_4_11.html
+++ b/0.5.3/release/release_0_4_11.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.11 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_11';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1137,8 +1137,8 @@ more! Thanks to our incredible user and contributor community.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/release/release_0_4_12.html
+++ b/0.5.3/release/release_0_4_12.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.12 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_12';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1012,8 +1012,8 @@ be converted from a context menu on the layer list (#3402).</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/release/release_0_4_13.html
+++ b/0.5.3/release/release_0_4_13.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.13 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_13';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1167,8 +1167,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/release/release_0_4_14.html
+++ b/0.5.3/release/release_0_4_14.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.14 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_14';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -939,8 +939,8 @@ https://github.com/napari/napari</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/release/release_0_4_15.html
+++ b/0.5.3/release/release_0_4_15.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.15 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_15';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1051,8 +1051,8 @@ plugins on PyPI but have them not be listed in the app (#4074).</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/release/release_0_4_16.html
+++ b/0.5.3/release/release_0_4_16.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.16 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_16';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1211,8 +1211,8 @@ console, so this is strictly an improvement!)</p></li>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/release/release_0_4_17.html
+++ b/0.5.3/release/release_0_4_17.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.17 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_17';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1336,8 +1336,8 @@ or create issues on GitHub.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/release/release_0_4_18.html
+++ b/0.5.3/release/release_0_4_18.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.18 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_18';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1409,8 +1409,8 @@ vectors layer! (<a class="reference external" href="https://github.com/napari/na
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/release/release_0_4_19.html
+++ b/0.5.3/release/release_0_4_19.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.19 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_19';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1299,8 +1299,8 @@ superseded by <code class="docutils literal notranslate"><span class="pre">layer
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/release/release_0_4_2.html
+++ b/0.5.3/release/release_0_4_2.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.2 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_2';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -928,8 +928,8 @@ part of the codebase.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/release/release_0_4_3.html
+++ b/0.5.3/release/release_0_4_3.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.3 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_3';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -999,8 +999,8 @@ can still provide keymappings, but no longer handles keymappings from other obje
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/release/release_0_4_4.html
+++ b/0.5.3/release/release_0_4_4.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.4 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_4';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -965,8 +965,8 @@ be required after 0.4.6. (#1985)</p></li>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/release/release_0_4_5.html
+++ b/0.5.3/release/release_0_4_5.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.5 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_5';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -958,8 +958,8 @@ set matching contrast limits for multiple channels (#2226).</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/release/release_0_4_6.html
+++ b/0.5.3/release/release_0_4_6.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.6 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_6';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -963,8 +963,8 @@ menu.)</p></li>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/release/release_0_4_7.html
+++ b/0.5.3/release/release_0_4_7.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.7 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_7';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1027,8 +1027,8 @@ coordinates.</p></li>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/release/release_0_4_8.html
+++ b/0.5.3/release/release_0_4_8.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.8 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_8';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1124,8 +1124,8 @@ recommended.</p></li>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/release/release_0_4_9.html
+++ b/0.5.3/release/release_0_4_9.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.4.9 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_9';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -970,8 +970,8 @@ It also contains a variety of bug fixes and improvements.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/release/release_0_5_0.html
+++ b/0.5.3/release/release_0_5_0.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.5.0 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_5_0';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -1785,8 +1785,8 @@ improvements. Please see below for the full list of changes since 0.4.19.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/release/release_0_5_1.html
+++ b/0.5.3/release/release_0_5_1.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.5.1 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_5_1';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -951,8 +951,8 @@ ago!</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/release/release_0_5_2.html
+++ b/0.5.3/release/release_0_5_2.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.5.2 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_5_2';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -958,8 +958,8 @@ resize dynamically to take up a small part of the screen
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/release/release_0_5_3.html
+++ b/0.5.3/release/release_0_5_3.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.5.3 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_5_3';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -962,8 +962,8 @@ changes!</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/release/release_0_5_4.html
+++ b/0.5.3/release/release_0_5_4.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>napari 0.5.4 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_5_4';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -985,8 +985,8 @@ other in the UI (<a class="reference external" href="https://github.com/napari/n
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/roadmaps/0_3.html
+++ b/0.5.3/roadmaps/0_3.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Roadmap 0.3 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'roadmaps/0_3';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -698,8 +698,8 @@ document.write(`
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/roadmaps/0_3_retrospective.html
+++ b/0.5.3/roadmaps/0_3_retrospective.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Roadmap 0.3 Retrospective &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'roadmaps/0_3_retrospective';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -763,8 +763,8 @@ document.write(`
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/roadmaps/0_4.html
+++ b/0.5.3/roadmaps/0_4.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Roadmap 0.4 &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'roadmaps/0_4';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -749,8 +749,8 @@ details.</p>
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">

--- a/0.5.3/roadmaps/index.html
+++ b/0.5.3/roadmaps/index.html
@@ -7,9 +7,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link type="image/svg+xml" href="../../dev/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
-    <link sizes="any" href="../../dev/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
-    <link rel="apple-touch-icon" sizes="180x180" href="../../dev/_static/favicon/logo-noborder-180.png" type="image/png">
+    <link type="image/svg+xml" href="../../0.5.4/_static/favicon/logo-silhouette-dark-light.svg" rel="icon">
+    <link sizes="any" href="../../0.5.4/_static/favicon/logo-silhouette-192.png" rel="icon" type="image/png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../../0.5.4/_static/favicon/logo-noborder-180.png" type="image/png">
     <title>Roadmaps &#8212; napari</title>
   
   
@@ -20,43 +20,43 @@
   </script>
   
   <!-- Loaded before other Sphinx assets -->
-  <link href="../../dev/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-<link href="../../dev/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link href="../../0.5.4/_static/styles/theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/bootstrap.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+<link href="../../0.5.4/_static/styles/pydata-sphinx-theme.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
 
   
-  <link href="../../dev/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
-  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
-<link rel="preload" as="font" type="font/woff2" crossorigin href="../../dev/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
+  <link href="../../0.5.4/_static/vendor/fontawesome/6.5.2/css/all.min.css?digest=dfe6caa3a7d634c4db9b" rel="stylesheet" />
+  <link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2" />
+<link rel="preload" as="font" type="font/woff2" crossorigin href="../../0.5.4/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2" />
 
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/pygments.css?v=8f9ffe49" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/copybutton.css?v=76b2166b" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery.css?v=d2d258e8" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-binder.css?v=f4aeca0c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-dataframe.css?v=2082cf3c" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/sphinx-design.min.css?v=95c83b7e" />
-    <link rel="stylesheet" type="text/css" href="../../dev/_static/custom.css?v=6a8a2890" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/pygments.css?v=8f9ffe49" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/css/napari-sphinx-theme.css?v=5b765ca9" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/mystnb.4510f1fc1dee50b3e5859aac5469c37c29e427902b24a333a5f9fcb2f0b3ac41.css" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/copybutton.css?v=76b2166b" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery.css?v=d2d258e8" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-binder.css?v=f4aeca0c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-dataframe.css?v=2082cf3c" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sg_gallery-rendered-html.css?v=1277b6f3" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/sphinx-design.min.css?v=95c83b7e" />
+    <link rel="stylesheet" type="text/css" href="../../0.5.4/_static/custom.css?v=6a8a2890" />
   
   <!-- Pre-loaded scripts that we'll load fully later -->
-  <link rel="preload" as="script" href="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
-<link rel="preload" as="script" href="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
-  <script src="../../dev/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <link rel="preload" as="script" href="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b" />
+<link rel="preload" as="script" href="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b" />
+  <script src="../../0.5.4/_static/vendor/fontawesome/6.5.2/js/all.min.js?digest=dfe6caa3a7d634c4db9b"></script>
 
-    <script src="../../dev/_static/documentation_options.js?v=9d29ee89"></script>
-    <script src="../../dev/_static/doctools.js?v=9a2dae69"></script>
-    <script src="../../dev/_static/sphinx_highlight.js?v=dc90522c"></script>
-    <script src="../../dev/_static/clipboard.min.js?v=a7894cd8"></script>
-    <script src="../../dev/_static/copybutton.js?v=f281be69"></script>
-    <script src="../../dev/_static/design-tabs.js?v=f930bc37"></script>
+    <script src="../../0.5.4/_static/documentation_options.js?v=9d29ee89"></script>
+    <script src="../../0.5.4/_static/doctools.js?v=9a2dae69"></script>
+    <script src="../../0.5.4/_static/sphinx_highlight.js?v=dc90522c"></script>
+    <script src="../../0.5.4/_static/clipboard.min.js?v=a7894cd8"></script>
+    <script src="../../0.5.4/_static/copybutton.js?v=f281be69"></script>
+    <script src="../../0.5.4/_static/design-tabs.js?v=f930bc37"></script>
     <script data-domain="napari.org" defer="defer" src="https://plausible.io/js/plausible.js"></script>
     <script>DOCUMENTATION_OPTIONS.pagename = 'roadmaps/index';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.15.4';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../dev/_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/../0.5.4/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.3';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
         </script>
@@ -111,7 +111,7 @@
 
   <div class="pst-async-banner-revealer d-none">
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="Version warning"></aside>
-  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../dev/_static/announcement.html"></aside>
+  <aside class="bd-header-announcement d-print-none d-none" aria-label="Announcement" data-pst-announcement-url="https://napari.org/dev/../0.5.4/_static/announcement.html"></aside>
 </div>
 
   
@@ -139,8 +139,8 @@
     
     
     
-    <img src="../../dev/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
-    <script>document.write(`<img src="../../dev/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
+    <img src="../../0.5.4/_static/logo.png" class="logo__image only-light" alt="napari - Home"/>
+    <script>document.write(`<img src="../../0.5.4/_static/logo.png" class="logo__image only-dark" alt="napari - Home"/>`);</script>
   
   
 </a></div>
@@ -620,8 +620,8 @@ document.write(`
   </div>
   
   <!-- Scripts loaded after <body> so the DOM is not blocked -->
-  <script src="../../dev/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
-<script src="../../dev/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
+  <script src="../../0.5.4/_static/scripts/bootstrap.js?digest=dfe6caa3a7d634c4db9b"></script>
+<script src="../../0.5.4/_static/scripts/pydata-sphinx-theme.js?digest=dfe6caa3a7d634c4db9b"></script>
 
   <footer class="napari-footer">
 <div class="bd-footer__inner bd-page-width">


### PR DESCRIPTION
This PR fixes a current issue with the CSS in copied over pages. 

To prevent breakage between two consecutive version, our copy unversioned files workflow _cleverly_ overwrites the html output to use the CSS file living on the dev folder. That makes sense for stable/dev, but once stable becomes an old version, it will still try to read the dev CSS files resulting in errors. See https://napari.org/0.5.0/index.html, for example.

This PR fixes all links to point to the correct version of the CSS files in the unversioned pages: CSS version =  current_version+1.