### PR TITLE
Update unversioned_pages.yml to search replace showing of the banner

### DIFF
--- a/.github/workflows/unversioned_pages.yml
+++ b/.github/workflows/unversioned_pages.yml
@@ -39,6 +39,7 @@ jobs:
           sed -i 's+_static+../dev/_static+g' stable/index.html
           STABLE=$(basename $(readlink -f ./stable))
           find stable/ -type f -exec sed -i "s+DOCUMENTATION_OPTIONS.theme_switcher_version_match = 'dev';+DOCUMENTATION_OPTIONS.theme_switcher_version_match = '${STABLE}';+g" {} +
+          # closes napari/docs#545 ensures that docs copied from dev don't show the unstable version warning
           find stable/ -type f -exec perl -0777 -i -pe "s/DOCUMENTATION_OPTIONS.show_version_warning_banner =\s*true;/DOCUMENTATION_OPTIONS.show_version_warning_banner = false;/sg" {} +
 
       - name: Commit files

--- a/.github/workflows/unversioned_pages.yml
+++ b/.github/workflows/unversioned_pages.yml
@@ -39,6 +39,7 @@ jobs:
           sed -i 's+_static+../dev/_static+g' stable/index.html
           STABLE=$(basename $(readlink -f ./stable))
           find stable/ -type f -exec sed -i "s+DOCUMENTATION_OPTIONS.theme_switcher_version_match = 'dev';+DOCUMENTATION_OPTIONS.theme_switcher_version_match = '${STABLE}';+g" {} +
+          find stable/ -type f -exec perl -0777 -i -pe "s/DOCUMENTATION_OPTIONS.show_version_warning_banner =\s*true;/DOCUMENTATION_OPTIONS.show_version_warning_banner = false;/sg" {} +
 
       - name: Commit files
         run: |


### PR DESCRIPTION
Closes:
https://github.com/napari/docs/issues/545

As noted in the issue, when we copy over the dev pages to stable, they bring over:
```
        DOCUMENTATION_OPTIONS.show_version_warning_banner =
            true;
```
In contrast, the usage pages, which are not copied, have:
`DOCUMENTATION_OPTIONS.show_version_warning_banner = false;`

So in this PR I do search/replace to set the variable to `false`. I've tested this on local version of the docs (just change stable/ to html/) and it prevents the banner from showing -- the local built is `dev` so the banner shows by default, but the script makes it not show.

I started with sed, but the line break made that not work. I consulted copilot and it suggested perl. I've not used perl in many many years, here's the copilot explanation:

> perl: Using perl instead of sed for more advanced text processing.
> -0777: This option makes perl read the entire file as a single string, allowing it to match patterns across multiple lines.
> -i: Edits the file in place.
> -pe: Executes the given Perl code for each file.
>    s/.../.../sg: The substitution pattern:
>    s/.../.../ is the substitution command.
>    \s* matches any amount of whitespace.
>    g makes the substitution global (replaces all occurrences).
>    s allows the dot . to match newline characters, enabling multiline matching.
> This command should correctly match and replace the line, regardless of the whitespace or line breaks.
