### PR TITLE
Add community folder to unversioned_pages.yml

### DIFF
--- a/.github/workflows/unversioned_pages.yml
+++ b/.github/workflows/unversioned_pages.yml
@@ -23,6 +23,8 @@ jobs:
       - name: Copy pages
         run: |
           ls -la
+          rm -rf ./stable/community
+          cp -Rv ./dev/community/ ./stable/
           rm -rf ./stable/developers
           cp -Rv ./dev/developers/ ./stable/
           rm -rf ./stable/naps
@@ -32,6 +34,7 @@ jobs:
           rm -rf ./stable/roadmaps
           cp -Rv ./dev/roadmaps/ ./stable/
           cp -v ./dev/index.html ./stable/
+          find stable/community/ -type f -exec sed -i 's+/_static+/../dev/_static+g' {} +
           find stable/developers/ -type f -exec sed -i 's+/_static+/../dev/_static+g' {} +
           find stable/naps/ -type f -exec sed -i 's+/_static+/../dev/_static+g' {} +
           find stable/release/ -type f -exec sed -i 's+/_static+/../dev/_static+g' {} +


### PR DESCRIPTION
Closes napari/docs#594

Side note which doesn't belong here but I want to get it out of my brain and into the world:

Ultimately it would be good if the list of unversioned folders was in some yaml file or similar in the docs repo, and this action would simply read from that repo (or maybe it's deployed to _static, if we want to avoid extra clones) and act accordingly.