### PR TITLE
Update symlink-stable.yml to grant token write permission

### DIFF
--- a/.github/workflows/symlink-stable.yml
+++ b/.github/workflows/symlink-stable.yml
@@ -9,6 +9,8 @@ on:
 
 jobs:
   symlink-stable:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Clone artifacts repo


### PR DESCRIPTION
This should fix the failing action:
https://github.com/napari/napari.github.io/actions/runs/17001563346

The token needs write permissions to do `git commit`