### PR TITLE
Add Algolia search verification to main page

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,6 +45,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="docsearch:language" content="None">
 
+    <!-- Algolia search -->
+    <meta name="algolia-site-verification"  content="DF60ACAEE10E3F09" />
 
     <!-- Google Analytics -->
 


### PR DESCRIPTION
Related to [napari/docs 758](https://github.com/napari/docs/issues/758)

This adds meta tag for Algolia to verify napari prior to crawling the site for search