### PR TITLE
Update version_switcher.json to remove trailing comma

### DIFF
--- a/dev/_static/version_switcher.json
+++ b/dev/_static/version_switcher.json
@@ -13,7 +13,7 @@
     {
         "name": "0.6.4",
         "version": "0.6.4",
-        "url": "https://napari.org/0.6.4/",
+        "url": "https://napari.org/0.6.4/"
     },
     {
         "name": "0.6.3",


### PR DESCRIPTION
Same as https://github.com/napari/docs/pull/862
I suspect the deployment will fail in that one.