### PR TITLE
[HUGE DIFF] Fix version warning for stable & all previous versions

### DIFF
--- a/0.4.19/developers/architecture/app_model.html
+++ b/0.4.19/developers/architecture/app_model.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.4.19/developers/architecture/dir_organization.html
+++ b/0.4.19/developers/architecture/dir_organization.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.4.19/developers/architecture/index.html
+++ b/0.4.19/developers/architecture/index.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.4.19/developers/architecture/magicgui_type_reg.html
+++ b/0.4.19/developers/architecture/magicgui_type_reg.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.4.19/developers/architecture/napari_models.html
+++ b/0.4.19/developers/architecture/napari_models.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.4.19/developers/contributing/dev_install.html
+++ b/0.4.19/developers/contributing/dev_install.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.4.19/developers/contributing/documentation/docs_deployment.html
+++ b/0.4.19/developers/contributing/documentation/docs_deployment.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.4.19/developers/contributing/documentation/docs_template.html
+++ b/0.4.19/developers/contributing/documentation/docs_template.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.4.19/developers/contributing/documentation/index.html
+++ b/0.4.19/developers/contributing/documentation/index.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.4.19/developers/contributing/index.html
+++ b/0.4.19/developers/contributing/index.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.4.19/developers/contributing/performance/benchmarks.html
+++ b/0.4.19/developers/contributing/performance/benchmarks.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.4.19/developers/contributing/performance/index.html
+++ b/0.4.19/developers/contributing/performance/index.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.4.19/developers/contributing/performance/profiling.html
+++ b/0.4.19/developers/contributing/performance/profiling.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.4.19/developers/contributing/testing.html
+++ b/0.4.19/developers/contributing/testing.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.4.19/developers/contributing/translations.html
+++ b/0.4.19/developers/contributing/translations.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.4.19/developers/coredev/core_dev_guide.html
+++ b/0.4.19/developers/coredev/core_dev_guide.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.4.19/developers/coredev/maintenance.html
+++ b/0.4.19/developers/coredev/maintenance.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.4.19/developers/coredev/packaging.html
+++ b/0.4.19/developers/coredev/packaging.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.4.19/developers/coredev/release.html
+++ b/0.4.19/developers/coredev/release.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.4.19/developers/index.html
+++ b/0.4.19/developers/index.html
@@ -60,6 +60,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.4.19/index.html
+++ b/0.4.19/index.html
@@ -60,6 +60,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="genindex.html" />
     <link rel="search" title="Search" href="search.html" />

--- a/0.4.19/naps/0-nap-process.html
+++ b/0.4.19/naps/0-nap-process.html
@@ -58,6 +58,8 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
+
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.4.19/naps/1-institutional-funding-partners.html
+++ b/0.4.19/naps/1-institutional-funding-partners.html
@@ -58,6 +58,8 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
+
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.4.19/naps/2-conda-based-packaging.html
+++ b/0.4.19/naps/2-conda-based-packaging.html
@@ -58,6 +58,8 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
+
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.4.19/naps/3-spaces.html
+++ b/0.4.19/naps/3-spaces.html
@@ -58,6 +58,8 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
+
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.4.19/naps/4-async-slicing.html
+++ b/0.4.19/naps/4-async-slicing.html
@@ -58,6 +58,8 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
+
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.4.19/naps/5-new-logo.html
+++ b/0.4.19/naps/5-new-logo.html
@@ -60,6 +60,8 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
+
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.4.19/naps/6-contributable-menus.html
+++ b/0.4.19/naps/6-contributable-menus.html
@@ -58,6 +58,8 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
+
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.4.19/naps/7-key-binding-dispatch.html
+++ b/0.4.19/naps/7-key-binding-dispatch.html
@@ -58,6 +58,8 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
+
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.4.19/naps/8-telemetry.html
+++ b/0.4.19/naps/8-telemetry.html
@@ -58,6 +58,8 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
+
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.4.19/naps/9-multiple-canvases.html
+++ b/0.4.19/naps/9-multiple-canvases.html
@@ -58,6 +58,8 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
+
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.4.19/naps/index.html
+++ b/0.4.19/naps/index.html
@@ -60,6 +60,8 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
+
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.4.19/naps/template.html
+++ b/0.4.19/naps/template.html
@@ -58,6 +58,8 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
+
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.4.19/release/index.html
+++ b/0.4.19/release/index.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.4.19/release/release_0_1_0.html
+++ b/0.4.19/release/release_0_1_0.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.4.19/release/release_0_1_3.html
+++ b/0.4.19/release/release_0_1_3.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.4.19/release/release_0_1_5.html
+++ b/0.4.19/release/release_0_1_5.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.4.19/release/release_0_2_0.html
+++ b/0.4.19/release/release_0_2_0.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.4.19/release/release_0_2_1.html
+++ b/0.4.19/release/release_0_2_1.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.4.19/release/release_0_2_10.html
+++ b/0.4.19/release/release_0_2_10.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.4.19/release/release_0_2_11.html
+++ b/0.4.19/release/release_0_2_11.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.4.19/release/release_0_2_12.html
+++ b/0.4.19/release/release_0_2_12.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.4.19/release/release_0_2_3.html
+++ b/0.4.19/release/release_0_2_3.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.4.19/release/release_0_2_4.html
+++ b/0.4.19/release/release_0_2_4.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.4.19/release/release_0_2_5.html
+++ b/0.4.19/release/release_0_2_5.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.4.19/release/release_0_2_6.html
+++ b/0.4.19/release/release_0_2_6.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.4.19/release/release_0_2_7.html
+++ b/0.4.19/release/release_0_2_7.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.4.19/release/release_0_2_8.html
+++ b/0.4.19/release/release_0_2_8.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.4.19/release/release_0_2_9.html
+++ b/0.4.19/release/release_0_2_9.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.4.19/release/release_0_3_0.html
+++ b/0.4.19/release/release_0_3_0.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.4.19/release/release_0_3_1.html
+++ b/0.4.19/release/release_0_3_1.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.4.19/release/release_0_3_2.html
+++ b/0.4.19/release/release_0_3_2.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.4.19/release/release_0_3_3.html
+++ b/0.4.19/release/release_0_3_3.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.4.19/release/release_0_3_4.html
+++ b/0.4.19/release/release_0_3_4.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.4.19/release/release_0_3_5.html
+++ b/0.4.19/release/release_0_3_5.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.4.19/release/release_0_3_6.html
+++ b/0.4.19/release/release_0_3_6.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.4.19/release/release_0_3_7.html
+++ b/0.4.19/release/release_0_3_7.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.4.19/release/release_0_3_8.html
+++ b/0.4.19/release/release_0_3_8.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.4.19/release/release_0_4_0.html
+++ b/0.4.19/release/release_0_4_0.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.4.19/release/release_0_4_1.html
+++ b/0.4.19/release/release_0_4_1.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.4.19/release/release_0_4_10.html
+++ b/0.4.19/release/release_0_4_10.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.4.19/release/release_0_4_11.html
+++ b/0.4.19/release/release_0_4_11.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.4.19/release/release_0_4_12.html
+++ b/0.4.19/release/release_0_4_12.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.4.19/release/release_0_4_13.html
+++ b/0.4.19/release/release_0_4_13.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.4.19/release/release_0_4_14.html
+++ b/0.4.19/release/release_0_4_14.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.4.19/release/release_0_4_15.html
+++ b/0.4.19/release/release_0_4_15.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.4.19/release/release_0_4_16.html
+++ b/0.4.19/release/release_0_4_16.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.4.19/release/release_0_4_17.html
+++ b/0.4.19/release/release_0_4_17.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.4.19/release/release_0_4_18.html
+++ b/0.4.19/release/release_0_4_18.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.4.19/release/release_0_4_19.html
+++ b/0.4.19/release/release_0_4_19.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.4.19/release/release_0_4_2.html
+++ b/0.4.19/release/release_0_4_2.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.4.19/release/release_0_4_3.html
+++ b/0.4.19/release/release_0_4_3.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.4.19/release/release_0_4_4.html
+++ b/0.4.19/release/release_0_4_4.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.4.19/release/release_0_4_5.html
+++ b/0.4.19/release/release_0_4_5.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.4.19/release/release_0_4_6.html
+++ b/0.4.19/release/release_0_4_6.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.4.19/release/release_0_4_7.html
+++ b/0.4.19/release/release_0_4_7.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.4.19/release/release_0_4_8.html
+++ b/0.4.19/release/release_0_4_8.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.4.19/release/release_0_4_9.html
+++ b/0.4.19/release/release_0_4_9.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.4.19/release/release_0_5_0.html
+++ b/0.4.19/release/release_0_5_0.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.4.19/roadmaps/0_3.html
+++ b/0.4.19/roadmaps/0_3.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.4.19/roadmaps/0_3_retrospective.html
+++ b/0.4.19/roadmaps/0_3_retrospective.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.4.19/roadmaps/0_4.html
+++ b/0.4.19/roadmaps/0_4.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.4.19/roadmaps/index.html
+++ b/0.4.19/roadmaps/index.html
@@ -58,6 +58,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.4.19';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.4.19";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/_modules/index.html
+++ b/0.5.4/_modules/index.html
@@ -56,6 +56,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/_modules/napari/_qt/qt_event_loop.html
+++ b/0.5.4/_modules/napari/_qt/qt_event_loop.html
@@ -56,6 +56,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.5.4/_modules/napari/_qt/qt_main_window.html
+++ b/0.5.4/_modules/napari/_qt/qt_main_window.html
@@ -56,6 +56,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.5.4/_modules/napari/_qt/qt_resources.html
+++ b/0.5.4/_modules/napari/_qt/qt_resources.html
@@ -56,6 +56,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.5.4/_modules/napari/_qt/qt_viewer.html
+++ b/0.5.4/_modules/napari/_qt/qt_viewer.html
@@ -56,6 +56,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.5.4/_modules/napari/_qt/qthreading.html
+++ b/0.5.4/_modules/napari/_qt/qthreading.html
@@ -56,6 +56,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.5.4/_modules/napari/_qt/widgets/qt_tooltip.html
+++ b/0.5.4/_modules/napari/_qt/widgets/qt_tooltip.html
@@ -56,6 +56,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.5.4/_modules/napari/_qt/widgets/qt_viewer_buttons.html
+++ b/0.5.4/_modules/napari/_qt/widgets/qt_viewer_buttons.html
@@ -56,6 +56,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.5.4/_modules/napari/components/camera.html
+++ b/0.5.4/_modules/napari/components/camera.html
@@ -56,6 +56,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.5.4/_modules/napari/components/dims.html
+++ b/0.5.4/_modules/napari/components/dims.html
@@ -56,6 +56,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.5.4/_modules/napari/components/layerlist.html
+++ b/0.5.4/_modules/napari/components/layerlist.html
@@ -56,6 +56,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.5.4/_modules/napari/components/viewer_model.html
+++ b/0.5.4/_modules/napari/components/viewer_model.html
@@ -56,6 +56,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.5.4/_modules/napari/layers/base/base.html
+++ b/0.5.4/_modules/napari/layers/base/base.html
@@ -56,6 +56,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.5.4/_modules/napari/layers/image/image.html
+++ b/0.5.4/_modules/napari/layers/image/image.html
@@ -56,6 +56,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.5.4/_modules/napari/layers/labels/labels.html
+++ b/0.5.4/_modules/napari/layers/labels/labels.html
@@ -56,6 +56,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.5.4/_modules/napari/layers/points/points.html
+++ b/0.5.4/_modules/napari/layers/points/points.html
@@ -56,6 +56,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.5.4/_modules/napari/layers/shapes/shapes.html
+++ b/0.5.4/_modules/napari/layers/shapes/shapes.html
@@ -56,6 +56,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.5.4/_modules/napari/layers/surface/surface.html
+++ b/0.5.4/_modules/napari/layers/surface/surface.html
@@ -56,6 +56,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.5.4/_modules/napari/layers/tracks/tracks.html
+++ b/0.5.4/_modules/napari/layers/tracks/tracks.html
@@ -56,6 +56,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.5.4/_modules/napari/layers/vectors/vectors.html
+++ b/0.5.4/_modules/napari/layers/vectors/vectors.html
@@ -56,6 +56,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.5.4/_modules/napari/plugins/hook_specifications.html
+++ b/0.5.4/_modules/napari/plugins/hook_specifications.html
@@ -56,6 +56,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.5.4/_modules/napari/plugins/io.html
+++ b/0.5.4/_modules/napari/plugins/io.html
@@ -56,6 +56,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.5.4/_modules/napari/types.html
+++ b/0.5.4/_modules/napari/types.html
@@ -56,6 +56,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/_modules/napari/utils/_dask_utils.html
+++ b/0.5.4/_modules/napari/utils/_dask_utils.html
@@ -56,6 +56,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.5.4/_modules/napari/utils/_testsupport.html
+++ b/0.5.4/_modules/napari/utils/_testsupport.html
@@ -56,6 +56,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.5.4/_modules/napari/utils/colormaps/colormap.html
+++ b/0.5.4/_modules/napari/utils/colormaps/colormap.html
@@ -56,6 +56,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.5.4/_modules/napari/utils/events/containers/_evented_dict.html
+++ b/0.5.4/_modules/napari/utils/events/containers/_evented_dict.html
@@ -56,6 +56,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../../search.html" />

--- a/0.5.4/_modules/napari/utils/events/containers/_evented_list.html
+++ b/0.5.4/_modules/napari/utils/events/containers/_evented_list.html
@@ -56,6 +56,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../../search.html" />

--- a/0.5.4/_modules/napari/utils/events/containers/_nested_list.html
+++ b/0.5.4/_modules/napari/utils/events/containers/_nested_list.html
@@ -56,6 +56,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../../search.html" />

--- a/0.5.4/_modules/napari/utils/events/containers/_selectable_list.html
+++ b/0.5.4/_modules/napari/utils/events/containers/_selectable_list.html
@@ -56,6 +56,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../../search.html" />

--- a/0.5.4/_modules/napari/utils/events/containers/_selection.html
+++ b/0.5.4/_modules/napari/utils/events/containers/_selection.html
@@ -56,6 +56,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../../search.html" />

--- a/0.5.4/_modules/napari/utils/events/containers/_set.html
+++ b/0.5.4/_modules/napari/utils/events/containers/_set.html
@@ -56,6 +56,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../../search.html" />

--- a/0.5.4/_modules/napari/utils/events/containers/_typed.html
+++ b/0.5.4/_modules/napari/utils/events/containers/_typed.html
@@ -56,6 +56,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../../search.html" />

--- a/0.5.4/_modules/napari/utils/events/event.html
+++ b/0.5.4/_modules/napari/utils/events/event.html
@@ -56,6 +56,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.5.4/_modules/napari/utils/events/event_utils.html
+++ b/0.5.4/_modules/napari/utils/events/event_utils.html
@@ -56,6 +56,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.5.4/_modules/napari/utils/events/evented_model.html
+++ b/0.5.4/_modules/napari/utils/events/evented_model.html
@@ -56,6 +56,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.5.4/_modules/napari/utils/events/types.html
+++ b/0.5.4/_modules/napari/utils/events/types.html
@@ -56,6 +56,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.5.4/_modules/napari/utils/info.html
+++ b/0.5.4/_modules/napari/utils/info.html
@@ -56,6 +56,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.5.4/_modules/napari/utils/notebook_display.html
+++ b/0.5.4/_modules/napari/utils/notebook_display.html
@@ -56,6 +56,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.5.4/_modules/napari/utils/notifications.html
+++ b/0.5.4/_modules/napari/utils/notifications.html
@@ -56,6 +56,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.5.4/_modules/napari/utils/perf/_event.html
+++ b/0.5.4/_modules/napari/utils/perf/_event.html
@@ -56,6 +56,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.5.4/_modules/napari/utils/perf/_timers.html
+++ b/0.5.4/_modules/napari/utils/perf/_timers.html
@@ -56,6 +56,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.5.4/_modules/napari/utils/progress.html
+++ b/0.5.4/_modules/napari/utils/progress.html
@@ -56,6 +56,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.5.4/_modules/napari/utils/transforms/transform_utils.html
+++ b/0.5.4/_modules/napari/utils/transforms/transform_utils.html
@@ -56,6 +56,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.5.4/_modules/napari/utils/transforms/transforms.html
+++ b/0.5.4/_modules/napari/utils/transforms/transforms.html
@@ -56,6 +56,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.5.4/_modules/napari/view_layers.html
+++ b/0.5.4/_modules/napari/view_layers.html
@@ -56,6 +56,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/_modules/napari/viewer.html
+++ b/0.5.4/_modules/napari/viewer.html
@@ -56,6 +56,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/_modules/superqt/utils/_qthreading.html
+++ b/0.5.4/_modules/superqt/utils/_qthreading.html
@@ -56,6 +56,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.5.4/_tags/analysis.html
+++ b/0.5.4/_tags/analysis.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/_tags/experimental.html
+++ b/0.5.4/_tags/experimental.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/_tags/gui.html
+++ b/0.5.4/_tags/gui.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/_tags/historical.html
+++ b/0.5.4/_tags/historical.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/_tags/interactivity.html
+++ b/0.5.4/_tags/interactivity.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/_tags/layers.html
+++ b/0.5.4/_tags/layers.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/_tags/tagsindex.html
+++ b/0.5.4/_tags/tagsindex.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/_tags/visualization-advanced.html
+++ b/0.5.4/_tags/visualization-advanced.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/_tags/visualization-basic.html
+++ b/0.5.4/_tags/visualization-basic.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/_tags/visualization-nd.html
+++ b/0.5.4/_tags/visualization-nd.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/event_loop.html
+++ b/0.5.4/api/event_loop.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/index.html
+++ b/0.5.4/api/index.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/misc.html
+++ b/0.5.4/api/misc.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/modules.html
+++ b/0.5.4/api/modules.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.Viewer.html
+++ b/0.5.4/api/napari.Viewer.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.components.Camera.html
+++ b/0.5.4/api/napari.components.Camera.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.components.Dims.html
+++ b/0.5.4/api/napari.components.Dims.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.components.LayerList.html
+++ b/0.5.4/api/napari.components.LayerList.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.components.ViewerModel.html
+++ b/0.5.4/api/napari.components.ViewerModel.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.components.html
+++ b/0.5.4/api/napari.components.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.html
+++ b/0.5.4/api/napari.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.layers.Image.html
+++ b/0.5.4/api/napari.layers.Image.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.layers.Labels.html
+++ b/0.5.4/api/napari.layers.Labels.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.layers.Layer.html
+++ b/0.5.4/api/napari.layers.Layer.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.layers.Points.html
+++ b/0.5.4/api/napari.layers.Points.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.layers.Shapes.html
+++ b/0.5.4/api/napari.layers.Shapes.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.layers.Surface.html
+++ b/0.5.4/api/napari.layers.Surface.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.layers.Tracks.html
+++ b/0.5.4/api/napari.layers.Tracks.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.layers.Vectors.html
+++ b/0.5.4/api/napari.layers.Vectors.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.layers.html
+++ b/0.5.4/api/napari.layers.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.plugins.html
+++ b/0.5.4/api/napari.plugins.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.qt.QtToolTipLabel.html
+++ b/0.5.4/api/napari.qt.QtToolTipLabel.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.qt.QtViewer.html
+++ b/0.5.4/api/napari.qt.QtViewer.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.qt.QtViewerButtons.html
+++ b/0.5.4/api/napari.qt.QtViewerButtons.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.qt.Window.html
+++ b/0.5.4/api/napari.qt.Window.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.qt.html
+++ b/0.5.4/api/napari.qt.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.qt.threading.FunctionWorker.html
+++ b/0.5.4/api/napari.qt.threading.FunctionWorker.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.qt.threading.GeneratorWorker.html
+++ b/0.5.4/api/napari.qt.threading.GeneratorWorker.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.qt.threading.GeneratorWorkerSignals.html
+++ b/0.5.4/api/napari.qt.threading.GeneratorWorkerSignals.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.qt.threading.WorkerBase.html
+++ b/0.5.4/api/napari.qt.threading.WorkerBase.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.qt.threading.WorkerBaseSignals.html
+++ b/0.5.4/api/napari.qt.threading.WorkerBaseSignals.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.qt.threading.html
+++ b/0.5.4/api/napari.qt.threading.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.types.ArrayBase.html
+++ b/0.5.4/api/napari.types.ArrayBase.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.types.FullLayerData.html
+++ b/0.5.4/api/napari.types.FullLayerData.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.types.SampleDict.html
+++ b/0.5.4/api/napari.types.SampleDict.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.types.html
+++ b/0.5.4/api/napari.types.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.utils.Colormap.html
+++ b/0.5.4/api/napari.utils.Colormap.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.utils.CyclicLabelColormap.html
+++ b/0.5.4/api/napari.utils.CyclicLabelColormap.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.utils.DirectLabelColormap.html
+++ b/0.5.4/api/napari.utils.DirectLabelColormap.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.utils.NotebookScreenshot.html
+++ b/0.5.4/api/napari.utils.NotebookScreenshot.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.utils.cancelable_progress.html
+++ b/0.5.4/api/napari.utils.cancelable_progress.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.utils.events.EmitterGroup.html
+++ b/0.5.4/api/napari.utils.events.EmitterGroup.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.utils.events.Event.html
+++ b/0.5.4/api/napari.utils.events.Event.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.utils.events.EventEmitter.html
+++ b/0.5.4/api/napari.utils.events.EventEmitter.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.utils.events.EventedDict.html
+++ b/0.5.4/api/napari.utils.events.EventedDict.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.utils.events.EventedList.html
+++ b/0.5.4/api/napari.utils.events.EventedList.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.utils.events.EventedModel.html
+++ b/0.5.4/api/napari.utils.events.EventedModel.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.utils.events.EventedSet.html
+++ b/0.5.4/api/napari.utils.events.EventedSet.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.utils.events.NestableEventedList.html
+++ b/0.5.4/api/napari.utils.events.NestableEventedList.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.utils.events.SelectableEventedList.html
+++ b/0.5.4/api/napari.utils.events.SelectableEventedList.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.utils.events.Selection.html
+++ b/0.5.4/api/napari.utils.events.Selection.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.utils.events.SupportsEvents.html
+++ b/0.5.4/api/napari.utils.events.SupportsEvents.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.utils.events.TypedMutableSequence.html
+++ b/0.5.4/api/napari.utils.events.TypedMutableSequence.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.utils.events.html
+++ b/0.5.4/api/napari.utils.events.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.utils.html
+++ b/0.5.4/api/napari.utils.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.utils.nbscreenshot.html
+++ b/0.5.4/api/napari.utils.nbscreenshot.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.utils.notifications.ErrorNotification.html
+++ b/0.5.4/api/napari.utils.notifications.ErrorNotification.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.utils.notifications.Notification.html
+++ b/0.5.4/api/napari.utils.notifications.Notification.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.utils.notifications.NotificationManager.html
+++ b/0.5.4/api/napari.utils.notifications.NotificationManager.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.utils.notifications.NotificationSeverity.html
+++ b/0.5.4/api/napari.utils.notifications.NotificationSeverity.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.utils.notifications.WarningNotification.html
+++ b/0.5.4/api/napari.utils.notifications.WarningNotification.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.utils.notifications.html
+++ b/0.5.4/api/napari.utils.notifications.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.utils.perf.PerfEvent.html
+++ b/0.5.4/api/napari.utils.perf.PerfEvent.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.utils.perf.html
+++ b/0.5.4/api/napari.utils.perf.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.utils.progress.html
+++ b/0.5.4/api/napari.utils.progress.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.utils.transforms.Affine.html
+++ b/0.5.4/api/napari.utils.transforms.Affine.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.utils.transforms.CompositeAffine.html
+++ b/0.5.4/api/napari.utils.transforms.CompositeAffine.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.utils.transforms.ScaleTranslate.html
+++ b/0.5.4/api/napari.utils.transforms.ScaleTranslate.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.utils.transforms.Transform.html
+++ b/0.5.4/api/napari.utils.transforms.Transform.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.utils.transforms.TransformChain.html
+++ b/0.5.4/api/napari.utils.transforms.TransformChain.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.utils.transforms.html
+++ b/0.5.4/api/napari.utils.transforms.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.view_layers.html
+++ b/0.5.4/api/napari.view_layers.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.window.Window.html
+++ b/0.5.4/api/napari.window.Window.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/napari.window.html
+++ b/0.5.4/api/napari.window.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/api/view_layer.html
+++ b/0.5.4/api/view_layer.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/community/code_of_conduct.html
+++ b/0.5.4/community/code_of_conduct.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/community/code_of_conduct_reporting.html
+++ b/0.5.4/community/code_of_conduct_reporting.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/community/governance.html
+++ b/0.5.4/community/governance.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/community/index.html
+++ b/0.5.4/community/index.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/community/licensing.html
+++ b/0.5.4/community/licensing.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/community/meeting_schedule.html
+++ b/0.5.4/community/meeting_schedule.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/community/mission_and_values.html
+++ b/0.5.4/community/mission_and_values.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/community/team.html
+++ b/0.5.4/community/team.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/community/working_groups.html
+++ b/0.5.4/community/working_groups.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/developers/architecture/app_model.html
+++ b/0.5.4/developers/architecture/app_model.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/developers/architecture/dir_organization.html
+++ b/0.5.4/developers/architecture/dir_organization.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/developers/architecture/index.html
+++ b/0.5.4/developers/architecture/index.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/developers/architecture/magicgui_type_reg.html
+++ b/0.5.4/developers/architecture/magicgui_type_reg.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/developers/architecture/napari_models.html
+++ b/0.5.4/developers/architecture/napari_models.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/developers/contributing/dev_install.html
+++ b/0.5.4/developers/contributing/dev_install.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/developers/contributing/documentation/docs_deployment.html
+++ b/0.5.4/developers/contributing/documentation/docs_deployment.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.5.4/developers/contributing/documentation/docs_template.html
+++ b/0.5.4/developers/contributing/documentation/docs_template.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.5.4/developers/contributing/documentation/index.html
+++ b/0.5.4/developers/contributing/documentation/index.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.5.4/developers/contributing/index.html
+++ b/0.5.4/developers/contributing/index.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/developers/contributing/performance/benchmarks.html
+++ b/0.5.4/developers/contributing/performance/benchmarks.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.5.4/developers/contributing/performance/index.html
+++ b/0.5.4/developers/contributing/performance/index.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.5.4/developers/contributing/performance/profiling.html
+++ b/0.5.4/developers/contributing/performance/profiling.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.5.4/developers/contributing/testing.html
+++ b/0.5.4/developers/contributing/testing.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/developers/contributing/translations.html
+++ b/0.5.4/developers/contributing/translations.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/developers/coredev/core_dev_guide.html
+++ b/0.5.4/developers/coredev/core_dev_guide.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/developers/coredev/maintenance.html
+++ b/0.5.4/developers/coredev/maintenance.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/developers/coredev/packaging.html
+++ b/0.5.4/developers/coredev/packaging.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/developers/coredev/release.html
+++ b/0.5.4/developers/coredev/release.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/developers/index.html
+++ b/0.5.4/developers/index.html
@@ -64,6 +64,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/further-resources/glossary.html
+++ b/0.5.4/further-resources/glossary.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/further-resources/napari-workshops.html
+++ b/0.5.4/further-resources/napari-workshops.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/further-resources/sample_data.html
+++ b/0.5.4/further-resources/sample_data.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery.html
+++ b/0.5.4/gallery.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="genindex.html" />
     <link rel="search" title="Search" href="search.html" />

--- a/0.5.4/gallery/3D_paths.html
+++ b/0.5.4/gallery/3D_paths.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/3Dimage_plane_rendering.html
+++ b/0.5.4/gallery/3Dimage_plane_rendering.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/action_manager.html
+++ b/0.5.4/gallery/action_manager.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/add-points-3d.html
+++ b/0.5.4/gallery/add-points-3d.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/add_3D_image.html
+++ b/0.5.4/gallery/add_3D_image.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/add_grayscale_image.html
+++ b/0.5.4/gallery/add_grayscale_image.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/add_image.html
+++ b/0.5.4/gallery/add_image.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/add_image_transformed.html
+++ b/0.5.4/gallery/add_image_transformed.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/add_labels.html
+++ b/0.5.4/gallery/add_labels.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/add_labels_with_features.html
+++ b/0.5.4/gallery/add_labels_with_features.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/add_multiscale_image.html
+++ b/0.5.4/gallery/add_multiscale_image.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/add_points.html
+++ b/0.5.4/gallery/add_points.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/add_points_on_nD_shapes.html
+++ b/0.5.4/gallery/add_points_on_nD_shapes.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/add_points_with_features.html
+++ b/0.5.4/gallery/add_points_with_features.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/add_points_with_multicolor_text.html
+++ b/0.5.4/gallery/add_points_with_multicolor_text.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/add_points_with_text.html
+++ b/0.5.4/gallery/add_points_with_text.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/add_shapes.html
+++ b/0.5.4/gallery/add_shapes.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/add_shapes_with_features.html
+++ b/0.5.4/gallery/add_shapes_with_features.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/add_shapes_with_text.html
+++ b/0.5.4/gallery/add_shapes_with_text.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/add_surface_2D.html
+++ b/0.5.4/gallery/add_surface_2D.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/add_vectors.html
+++ b/0.5.4/gallery/add_vectors.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/add_vectors_color_by_angle.html
+++ b/0.5.4/gallery/add_vectors_color_by_angle.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/add_vectors_image.html
+++ b/0.5.4/gallery/add_vectors_image.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/affine_transforms.html
+++ b/0.5.4/gallery/affine_transforms.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/annotate-2d.html
+++ b/0.5.4/gallery/annotate-2d.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/annotate_segmentation_with_text.html
+++ b/0.5.4/gallery/annotate_segmentation_with_text.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/bbox_annotator.html
+++ b/0.5.4/gallery/bbox_annotator.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/concentric-spheres.html
+++ b/0.5.4/gallery/concentric-spheres.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/cursor_position.html
+++ b/0.5.4/gallery/cursor_position.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/cursor_ray.html
+++ b/0.5.4/gallery/cursor_ray.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/custom_key_bindings.html
+++ b/0.5.4/gallery/custom_key_bindings.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/custom_mouse_functions.html
+++ b/0.5.4/gallery/custom_mouse_functions.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/dask_nD_image.html
+++ b/0.5.4/gallery/dask_nD_image.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/dynamic-projections-dask.html
+++ b/0.5.4/gallery/dynamic-projections-dask.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/export_figure.html
+++ b/0.5.4/gallery/export_figure.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/fourier_transform_playground.html
+++ b/0.5.4/gallery/fourier_transform_playground.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/get_current_viewer.html
+++ b/0.5.4/gallery/get_current_viewer.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/image-points-3d.html
+++ b/0.5.4/gallery/image-points-3d.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/image_custom_kernel.html
+++ b/0.5.4/gallery/image_custom_kernel.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/image_depth.html
+++ b/0.5.4/gallery/image_depth.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/inherit_viewer_style.html
+++ b/0.5.4/gallery/inherit_viewer_style.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/interaction_box_image.html
+++ b/0.5.4/gallery/interaction_box_image.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/interactive_move_rectangle_3d.html
+++ b/0.5.4/gallery/interactive_move_rectangle_3d.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/interactive_scripting.html
+++ b/0.5.4/gallery/interactive_scripting.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/labels-2d.html
+++ b/0.5.4/gallery/labels-2d.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/labels3d.html
+++ b/0.5.4/gallery/labels3d.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/layers.html
+++ b/0.5.4/gallery/layers.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/linked_layers.html
+++ b/0.5.4/gallery/linked_layers.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/magic_image_arithmetic.html
+++ b/0.5.4/gallery/magic_image_arithmetic.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/magic_parameter_sweep.html
+++ b/0.5.4/gallery/magic_parameter_sweep.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/magic_viewer.html
+++ b/0.5.4/gallery/magic_viewer.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/minimum_blending.html
+++ b/0.5.4/gallery/minimum_blending.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/mixed-dimensions-labels.html
+++ b/0.5.4/gallery/mixed-dimensions-labels.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/mouse_drag_callback.html
+++ b/0.5.4/gallery/mouse_drag_callback.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/multiple_viewer_widget.html
+++ b/0.5.4/gallery/multiple_viewer_widget.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/multiple_viewers.html
+++ b/0.5.4/gallery/multiple_viewers.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/nD_image.html
+++ b/0.5.4/gallery/nD_image.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/nD_labels.html
+++ b/0.5.4/gallery/nD_labels.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/nD_multiscale_image.html
+++ b/0.5.4/gallery/nD_multiscale_image.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/nD_multiscale_image_non_uniform.html
+++ b/0.5.4/gallery/nD_multiscale_image_non_uniform.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/nD_points.html
+++ b/0.5.4/gallery/nD_points.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/nD_points_with_features.html
+++ b/0.5.4/gallery/nD_points_with_features.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/nD_shapes.html
+++ b/0.5.4/gallery/nD_shapes.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/nD_shapes_with_text.html
+++ b/0.5.4/gallery/nD_shapes_with_text.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/nD_surface.html
+++ b/0.5.4/gallery/nD_surface.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/nD_vectors.html
+++ b/0.5.4/gallery/nD_vectors.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/nD_vectors_image.html
+++ b/0.5.4/gallery/nD_vectors_image.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/new_theme.html
+++ b/0.5.4/gallery/new_theme.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/paint-nd.html
+++ b/0.5.4/gallery/paint-nd.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/pass_colormaps.html
+++ b/0.5.4/gallery/pass_colormaps.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/point_cloud.html
+++ b/0.5.4/gallery/point_cloud.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/points-over-time.html
+++ b/0.5.4/gallery/points-over-time.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/reader_plugin.html
+++ b/0.5.4/gallery/reader_plugin.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/scale_bar.html
+++ b/0.5.4/gallery/scale_bar.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/set_colormaps.html
+++ b/0.5.4/gallery/set_colormaps.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/set_theme.html
+++ b/0.5.4/gallery/set_theme.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/sg_execution_times.html
+++ b/0.5.4/gallery/sg_execution_times.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/shapes_to_labels.html
+++ b/0.5.4/gallery/shapes_to_labels.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/show_points_based_on_feature.html
+++ b/0.5.4/gallery/show_points_based_on_feature.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/spherical_points.html
+++ b/0.5.4/gallery/spherical_points.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/surface_multi_texture.html
+++ b/0.5.4/gallery/surface_multi_texture.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/surface_normals_wireframe.html
+++ b/0.5.4/gallery/surface_normals_wireframe.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/surface_texture_and_colors.html
+++ b/0.5.4/gallery/surface_texture_and_colors.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/swap_dims.html
+++ b/0.5.4/gallery/swap_dims.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/to_screenshot.html
+++ b/0.5.4/gallery/to_screenshot.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/tracks_2d.html
+++ b/0.5.4/gallery/tracks_2d.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/tracks_3d.html
+++ b/0.5.4/gallery/tracks_3d.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/tracks_3d_with_graph.html
+++ b/0.5.4/gallery/tracks_3d_with_graph.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/update_console.html
+++ b/0.5.4/gallery/update_console.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/viewer_fps_label.html
+++ b/0.5.4/gallery/viewer_fps_label.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/vortex.html
+++ b/0.5.4/gallery/vortex.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/gallery/without_gui_qt.html
+++ b/0.5.4/gallery/without_gui_qt.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/genindex.html
+++ b/0.5.4/genindex.html
@@ -56,6 +56,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="#" />
     <link rel="search" title="Search" href="search.html" />

--- a/0.5.4/guides/3D_interactivity.html
+++ b/0.5.4/guides/3D_interactivity.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/guides/_layer_events.html
+++ b/0.5.4/guides/_layer_events.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/guides/_layerlist_events.html
+++ b/0.5.4/guides/_layerlist_events.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/guides/_viewer_events.html
+++ b/0.5.4/guides/_viewer_events.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/guides/contexts_expressions.html
+++ b/0.5.4/guides/contexts_expressions.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/guides/event_loop.html
+++ b/0.5.4/guides/event_loop.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/guides/events_reference.html
+++ b/0.5.4/guides/events_reference.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/guides/index.html
+++ b/0.5.4/guides/index.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/guides/layers.html
+++ b/0.5.4/guides/layers.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/guides/performance.html
+++ b/0.5.4/guides/performance.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/guides/preferences.html
+++ b/0.5.4/guides/preferences.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/guides/rendering.html
+++ b/0.5.4/guides/rendering.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/guides/threading.html
+++ b/0.5.4/guides/threading.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/howtos/docker.html
+++ b/0.5.4/howtos/docker.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/howtos/extending/connecting_events.html
+++ b/0.5.4/howtos/extending/connecting_events.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/howtos/extending/index.html
+++ b/0.5.4/howtos/extending/index.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/howtos/extending/magicgui.html
+++ b/0.5.4/howtos/extending/magicgui.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/howtos/headless.html
+++ b/0.5.4/howtos/headless.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/howtos/index.html
+++ b/0.5.4/howtos/index.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/howtos/layers/image.html
+++ b/0.5.4/howtos/layers/image.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/howtos/layers/index.html
+++ b/0.5.4/howtos/layers/index.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/howtos/layers/labels.html
+++ b/0.5.4/howtos/layers/labels.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/howtos/layers/points.html
+++ b/0.5.4/howtos/layers/points.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/howtos/layers/shapes.html
+++ b/0.5.4/howtos/layers/shapes.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/howtos/layers/surface.html
+++ b/0.5.4/howtos/layers/surface.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/howtos/layers/tracks.html
+++ b/0.5.4/howtos/layers/tracks.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/howtos/layers/vectors.html
+++ b/0.5.4/howtos/layers/vectors.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/howtos/napari_imageJ.html
+++ b/0.5.4/howtos/napari_imageJ.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/howtos/perfmon.html
+++ b/0.5.4/howtos/perfmon.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/howtos/themes.html
+++ b/0.5.4/howtos/themes.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/index.html
+++ b/0.5.4/index.html
@@ -64,6 +64,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="genindex.html" />
     <link rel="search" title="Search" href="search.html" />

--- a/0.5.4/naps/0-nap-process.html
+++ b/0.5.4/naps/0-nap-process.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/naps/1-institutional-funding-partners.html
+++ b/0.5.4/naps/1-institutional-funding-partners.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/naps/2-conda-based-packaging.html
+++ b/0.5.4/naps/2-conda-based-packaging.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/naps/3-spaces.html
+++ b/0.5.4/naps/3-spaces.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/naps/4-async-slicing.html
+++ b/0.5.4/naps/4-async-slicing.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/naps/5-new-logo.html
+++ b/0.5.4/naps/5-new-logo.html
@@ -64,6 +64,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/naps/6-contributable-menus.html
+++ b/0.5.4/naps/6-contributable-menus.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/naps/7-key-binding-dispatch.html
+++ b/0.5.4/naps/7-key-binding-dispatch.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/naps/8-telemetry.html
+++ b/0.5.4/naps/8-telemetry.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/naps/9-multiple-canvases.html
+++ b/0.5.4/naps/9-multiple-canvases.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/naps/index.html
+++ b/0.5.4/naps/index.html
@@ -64,6 +64,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/naps/template.html
+++ b/0.5.4/naps/template.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/plugins/advanced_topics/index.html
+++ b/0.5.4/plugins/advanced_topics/index.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/plugins/advanced_topics/npe1.html
+++ b/0.5.4/plugins/advanced_topics/npe1.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/plugins/advanced_topics/npe2_migration_guide.html
+++ b/0.5.4/plugins/advanced_topics/npe2_migration_guide.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/plugins/building_a_plugin/best_practices.html
+++ b/0.5.4/plugins/building_a_plugin/best_practices.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/plugins/building_a_plugin/debug_plugins.html
+++ b/0.5.4/plugins/building_a_plugin/debug_plugins.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/plugins/building_a_plugin/first_plugin.html
+++ b/0.5.4/plugins/building_a_plugin/first_plugin.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/plugins/building_a_plugin/guides.html
+++ b/0.5.4/plugins/building_a_plugin/guides.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/plugins/building_a_plugin/index.html
+++ b/0.5.4/plugins/building_a_plugin/index.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/plugins/index.html
+++ b/0.5.4/plugins/index.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/plugins/start_using_plugins/finding_and_installing_plugins.html
+++ b/0.5.4/plugins/start_using_plugins/finding_and_installing_plugins.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/plugins/start_using_plugins/index.html
+++ b/0.5.4/plugins/start_using_plugins/index.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/plugins/technical_references/contributions.html
+++ b/0.5.4/plugins/technical_references/contributions.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/plugins/technical_references/index.html
+++ b/0.5.4/plugins/technical_references/index.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/plugins/technical_references/manifest.html
+++ b/0.5.4/plugins/technical_references/manifest.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/plugins/testing_and_publishing/deploy.html
+++ b/0.5.4/plugins/testing_and_publishing/deploy.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/plugins/testing_and_publishing/index.html
+++ b/0.5.4/plugins/testing_and_publishing/index.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/plugins/testing_and_publishing/test.html
+++ b/0.5.4/plugins/testing_and_publishing/test.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/plugins/testing_workshop_docs/1-pythons-assert-keyword.html
+++ b/0.5.4/plugins/testing_workshop_docs/1-pythons-assert-keyword.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/plugins/testing_workshop_docs/2-pytest-testing-frameworks.html
+++ b/0.5.4/plugins/testing_workshop_docs/2-pytest-testing-frameworks.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/plugins/testing_workshop_docs/3-readers-and-fixtures.html
+++ b/0.5.4/plugins/testing_workshop_docs/3-readers-and-fixtures.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/plugins/testing_workshop_docs/4-test-coverage.html
+++ b/0.5.4/plugins/testing_workshop_docs/4-test-coverage.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/plugins/testing_workshop_docs/index.html
+++ b/0.5.4/plugins/testing_workshop_docs/index.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/plugins/testing_workshop_docs/testing-resources.html
+++ b/0.5.4/plugins/testing_workshop_docs/testing-resources.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/plugins/virtual_environment_docs/1-virtual-environments.html
+++ b/0.5.4/plugins/virtual_environment_docs/1-virtual-environments.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/plugins/virtual_environment_docs/2-deploying-your-plugin.html
+++ b/0.5.4/plugins/virtual_environment_docs/2-deploying-your-plugin.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/plugins/virtual_environment_docs/3-version-management.html
+++ b/0.5.4/plugins/virtual_environment_docs/3-version-management.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/plugins/virtual_environment_docs/4-developer-tools.html
+++ b/0.5.4/plugins/virtual_environment_docs/4-developer-tools.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/plugins/virtual_environment_docs/5-survey.html
+++ b/0.5.4/plugins/virtual_environment_docs/5-survey.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/plugins/virtual_environment_docs/index.html
+++ b/0.5.4/plugins/virtual_environment_docs/index.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/py-modindex.html
+++ b/0.5.4/py-modindex.html
@@ -56,6 +56,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="genindex.html" />
     <link rel="search" title="Search" href="search.html" />

--- a/0.5.4/release/index.html
+++ b/0.5.4/release/index.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/release/release_0_1_0.html
+++ b/0.5.4/release/release_0_1_0.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/release/release_0_1_3.html
+++ b/0.5.4/release/release_0_1_3.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/release/release_0_1_5.html
+++ b/0.5.4/release/release_0_1_5.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/release/release_0_2_0.html
+++ b/0.5.4/release/release_0_2_0.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/release/release_0_2_1.html
+++ b/0.5.4/release/release_0_2_1.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/release/release_0_2_10.html
+++ b/0.5.4/release/release_0_2_10.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/release/release_0_2_11.html
+++ b/0.5.4/release/release_0_2_11.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/release/release_0_2_12.html
+++ b/0.5.4/release/release_0_2_12.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/release/release_0_2_3.html
+++ b/0.5.4/release/release_0_2_3.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/release/release_0_2_4.html
+++ b/0.5.4/release/release_0_2_4.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/release/release_0_2_5.html
+++ b/0.5.4/release/release_0_2_5.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/release/release_0_2_6.html
+++ b/0.5.4/release/release_0_2_6.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/release/release_0_2_7.html
+++ b/0.5.4/release/release_0_2_7.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/release/release_0_2_8.html
+++ b/0.5.4/release/release_0_2_8.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/release/release_0_2_9.html
+++ b/0.5.4/release/release_0_2_9.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/release/release_0_3_0.html
+++ b/0.5.4/release/release_0_3_0.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/release/release_0_3_1.html
+++ b/0.5.4/release/release_0_3_1.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/release/release_0_3_2.html
+++ b/0.5.4/release/release_0_3_2.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/release/release_0_3_3.html
+++ b/0.5.4/release/release_0_3_3.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/release/release_0_3_4.html
+++ b/0.5.4/release/release_0_3_4.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/release/release_0_3_5.html
+++ b/0.5.4/release/release_0_3_5.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/release/release_0_3_6.html
+++ b/0.5.4/release/release_0_3_6.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/release/release_0_3_7.html
+++ b/0.5.4/release/release_0_3_7.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/release/release_0_3_8.html
+++ b/0.5.4/release/release_0_3_8.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/release/release_0_4_0.html
+++ b/0.5.4/release/release_0_4_0.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/release/release_0_4_1.html
+++ b/0.5.4/release/release_0_4_1.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/release/release_0_4_10.html
+++ b/0.5.4/release/release_0_4_10.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/release/release_0_4_11.html
+++ b/0.5.4/release/release_0_4_11.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/release/release_0_4_12.html
+++ b/0.5.4/release/release_0_4_12.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/release/release_0_4_13.html
+++ b/0.5.4/release/release_0_4_13.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/release/release_0_4_14.html
+++ b/0.5.4/release/release_0_4_14.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/release/release_0_4_15.html
+++ b/0.5.4/release/release_0_4_15.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/release/release_0_4_16.html
+++ b/0.5.4/release/release_0_4_16.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/release/release_0_4_17.html
+++ b/0.5.4/release/release_0_4_17.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/release/release_0_4_18.html
+++ b/0.5.4/release/release_0_4_18.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/release/release_0_4_19.html
+++ b/0.5.4/release/release_0_4_19.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/release/release_0_4_2.html
+++ b/0.5.4/release/release_0_4_2.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/release/release_0_4_3.html
+++ b/0.5.4/release/release_0_4_3.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/release/release_0_4_4.html
+++ b/0.5.4/release/release_0_4_4.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/release/release_0_4_5.html
+++ b/0.5.4/release/release_0_4_5.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/release/release_0_4_6.html
+++ b/0.5.4/release/release_0_4_6.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/release/release_0_4_7.html
+++ b/0.5.4/release/release_0_4_7.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/release/release_0_4_8.html
+++ b/0.5.4/release/release_0_4_8.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/release/release_0_4_9.html
+++ b/0.5.4/release/release_0_4_9.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/release/release_0_5_0.html
+++ b/0.5.4/release/release_0_5_0.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/release/release_0_5_1.html
+++ b/0.5.4/release/release_0_5_1.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/release/release_0_5_2.html
+++ b/0.5.4/release/release_0_5_2.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/release/release_0_5_3.html
+++ b/0.5.4/release/release_0_5_3.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/release/release_0_5_4.html
+++ b/0.5.4/release/release_0_5_4.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/release/release_0_5_5.html
+++ b/0.5.4/release/release_0_5_5.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/roadmaps/0_3.html
+++ b/0.5.4/roadmaps/0_3.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/roadmaps/0_3_retrospective.html
+++ b/0.5.4/roadmaps/0_3_retrospective.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/roadmaps/0_4.html
+++ b/0.5.4/roadmaps/0_4.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/roadmaps/index.html
+++ b/0.5.4/roadmaps/index.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/search.html
+++ b/0.5.4/search.html
@@ -55,6 +55,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
   <script src="_static/searchtools.js"></script>
   <script src="_static/language_data.js"></script>

--- a/0.5.4/sg_execution_times.html
+++ b/0.5.4/sg_execution_times.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="genindex.html" />
     <link rel="search" title="Search" href="search.html" />

--- a/0.5.4/tutorials/annotation/annotate_points.html
+++ b/0.5.4/tutorials/annotation/annotate_points.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/tutorials/annotation/index.html
+++ b/0.5.4/tutorials/annotation/index.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/tutorials/fundamentals/getting_started.html
+++ b/0.5.4/tutorials/fundamentals/getting_started.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/tutorials/fundamentals/installation.html
+++ b/0.5.4/tutorials/fundamentals/installation.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/tutorials/fundamentals/installation_bundle_conda.html
+++ b/0.5.4/tutorials/fundamentals/installation_bundle_conda.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/tutorials/fundamentals/quick_start.html
+++ b/0.5.4/tutorials/fundamentals/quick_start.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/tutorials/fundamentals/viewer.html
+++ b/0.5.4/tutorials/fundamentals/viewer.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/tutorials/index.html
+++ b/0.5.4/tutorials/index.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/tutorials/processing/dask.html
+++ b/0.5.4/tutorials/processing/dask.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/tutorials/processing/index.html
+++ b/0.5.4/tutorials/processing/index.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/tutorials/segmentation/annotate_segmentation.html
+++ b/0.5.4/tutorials/segmentation/annotate_segmentation.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/tutorials/segmentation/index.html
+++ b/0.5.4/tutorials/segmentation/index.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/tutorials/start_index.html
+++ b/0.5.4/tutorials/start_index.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.4/tutorials/tracking/cell_tracking.html
+++ b/0.5.4/tutorials/tracking/cell_tracking.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/tutorials/tracking/index.html
+++ b/0.5.4/tutorials/tracking/index.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.4/usage.html
+++ b/0.5.4/usage.html
@@ -59,6 +59,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.4';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.4";
         </script>
     <link rel="index" title="Index" href="genindex.html" />
     <link rel="search" title="Search" href="search.html" />

--- a/0.5.5/developers/architecture/app_model.html
+++ b/0.5.5/developers/architecture/app_model.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.5/developers/architecture/dir_organization.html
+++ b/0.5.5/developers/architecture/dir_organization.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.5/developers/architecture/index.html
+++ b/0.5.5/developers/architecture/index.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.5/developers/architecture/magicgui_type_reg.html
+++ b/0.5.5/developers/architecture/magicgui_type_reg.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.5/developers/architecture/napari_models.html
+++ b/0.5.5/developers/architecture/napari_models.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.5/developers/architecture/ui_sections/application_menus_ui.html
+++ b/0.5.5/developers/architecture/ui_sections/application_menus_ui.html
@@ -98,6 +98,7 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.5.5/developers/architecture/ui_sections/application_status_bar_ui.html
+++ b/0.5.5/developers/architecture/ui_sections/application_status_bar_ui.html
@@ -98,6 +98,7 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.5.5/developers/architecture/ui_sections/console_ui.html
+++ b/0.5.5/developers/architecture/ui_sections/console_ui.html
@@ -98,6 +98,7 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.5.5/developers/architecture/ui_sections/dialogs_ui.html
+++ b/0.5.5/developers/architecture/ui_sections/dialogs_ui.html
@@ -98,6 +98,7 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.5.5/developers/architecture/ui_sections/index.html
+++ b/0.5.5/developers/architecture/ui_sections/index.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.5.5/developers/architecture/ui_sections/layers_controls_ui.html
+++ b/0.5.5/developers/architecture/ui_sections/layers_controls_ui.html
@@ -98,6 +98,7 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.5.5/developers/architecture/ui_sections/layers_list_ui.html
+++ b/0.5.5/developers/architecture/ui_sections/layers_list_ui.html
@@ -98,6 +98,7 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.5.5/developers/architecture/ui_sections/viewer_ui.html
+++ b/0.5.5/developers/architecture/ui_sections/viewer_ui.html
@@ -98,6 +98,7 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.5.5/developers/contributing/dev_install.html
+++ b/0.5.5/developers/contributing/dev_install.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.5/developers/contributing/documentation/docs_deployment.html
+++ b/0.5.5/developers/contributing/documentation/docs_deployment.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.5.5/developers/contributing/documentation/docs_template.html
+++ b/0.5.5/developers/contributing/documentation/docs_template.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.5.5/developers/contributing/documentation/index.html
+++ b/0.5.5/developers/contributing/documentation/index.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.5.5/developers/contributing/index.html
+++ b/0.5.5/developers/contributing/index.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.5/developers/contributing/performance/benchmarks.html
+++ b/0.5.5/developers/contributing/performance/benchmarks.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.5.5/developers/contributing/performance/index.html
+++ b/0.5.5/developers/contributing/performance/index.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.5.5/developers/contributing/performance/profiling.html
+++ b/0.5.5/developers/contributing/performance/profiling.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.5.5/developers/contributing/testing.html
+++ b/0.5.5/developers/contributing/testing.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.5/developers/contributing/translations.html
+++ b/0.5.5/developers/contributing/translations.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.5/developers/coredev/core_dev_guide.html
+++ b/0.5.5/developers/coredev/core_dev_guide.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.5/developers/coredev/maintenance.html
+++ b/0.5.5/developers/coredev/maintenance.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.5/developers/coredev/packaging.html
+++ b/0.5.5/developers/coredev/packaging.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.5/developers/coredev/release.html
+++ b/0.5.5/developers/coredev/release.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.5/developers/index.html
+++ b/0.5.5/developers/index.html
@@ -64,6 +64,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/index.html
+++ b/0.5.5/index.html
@@ -64,6 +64,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="genindex.html" />
     <link rel="search" title="Search" href="search.html" />

--- a/0.5.5/naps/0-nap-process.html
+++ b/0.5.5/naps/0-nap-process.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/naps/1-institutional-funding-partners.html
+++ b/0.5.5/naps/1-institutional-funding-partners.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/naps/2-conda-based-packaging.html
+++ b/0.5.5/naps/2-conda-based-packaging.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/naps/3-spaces.html
+++ b/0.5.5/naps/3-spaces.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/naps/4-async-slicing.html
+++ b/0.5.5/naps/4-async-slicing.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/naps/5-new-logo.html
+++ b/0.5.5/naps/5-new-logo.html
@@ -64,6 +64,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/naps/6-contributable-menus.html
+++ b/0.5.5/naps/6-contributable-menus.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/naps/7-key-binding-dispatch.html
+++ b/0.5.5/naps/7-key-binding-dispatch.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/naps/8-telemetry.html
+++ b/0.5.5/naps/8-telemetry.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/naps/9-multiple-canvases.html
+++ b/0.5.5/naps/9-multiple-canvases.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/naps/index.html
+++ b/0.5.5/naps/index.html
@@ -64,6 +64,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/naps/template.html
+++ b/0.5.5/naps/template.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/release/index.html
+++ b/0.5.5/release/index.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/release/release_0_1_0.html
+++ b/0.5.5/release/release_0_1_0.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/release/release_0_1_3.html
+++ b/0.5.5/release/release_0_1_3.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/release/release_0_1_5.html
+++ b/0.5.5/release/release_0_1_5.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/release/release_0_2_0.html
+++ b/0.5.5/release/release_0_2_0.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/release/release_0_2_1.html
+++ b/0.5.5/release/release_0_2_1.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/release/release_0_2_10.html
+++ b/0.5.5/release/release_0_2_10.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/release/release_0_2_11.html
+++ b/0.5.5/release/release_0_2_11.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/release/release_0_2_12.html
+++ b/0.5.5/release/release_0_2_12.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/release/release_0_2_3.html
+++ b/0.5.5/release/release_0_2_3.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/release/release_0_2_4.html
+++ b/0.5.5/release/release_0_2_4.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/release/release_0_2_5.html
+++ b/0.5.5/release/release_0_2_5.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/release/release_0_2_6.html
+++ b/0.5.5/release/release_0_2_6.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/release/release_0_2_7.html
+++ b/0.5.5/release/release_0_2_7.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/release/release_0_2_8.html
+++ b/0.5.5/release/release_0_2_8.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/release/release_0_2_9.html
+++ b/0.5.5/release/release_0_2_9.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/release/release_0_3_0.html
+++ b/0.5.5/release/release_0_3_0.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/release/release_0_3_1.html
+++ b/0.5.5/release/release_0_3_1.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/release/release_0_3_2.html
+++ b/0.5.5/release/release_0_3_2.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/release/release_0_3_3.html
+++ b/0.5.5/release/release_0_3_3.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/release/release_0_3_4.html
+++ b/0.5.5/release/release_0_3_4.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/release/release_0_3_5.html
+++ b/0.5.5/release/release_0_3_5.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/release/release_0_3_6.html
+++ b/0.5.5/release/release_0_3_6.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/release/release_0_3_7.html
+++ b/0.5.5/release/release_0_3_7.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/release/release_0_3_8.html
+++ b/0.5.5/release/release_0_3_8.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/release/release_0_4_0.html
+++ b/0.5.5/release/release_0_4_0.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/release/release_0_4_1.html
+++ b/0.5.5/release/release_0_4_1.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/release/release_0_4_10.html
+++ b/0.5.5/release/release_0_4_10.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/release/release_0_4_11.html
+++ b/0.5.5/release/release_0_4_11.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/release/release_0_4_12.html
+++ b/0.5.5/release/release_0_4_12.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/release/release_0_4_13.html
+++ b/0.5.5/release/release_0_4_13.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/release/release_0_4_14.html
+++ b/0.5.5/release/release_0_4_14.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/release/release_0_4_15.html
+++ b/0.5.5/release/release_0_4_15.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/release/release_0_4_16.html
+++ b/0.5.5/release/release_0_4_16.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/release/release_0_4_17.html
+++ b/0.5.5/release/release_0_4_17.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/release/release_0_4_18.html
+++ b/0.5.5/release/release_0_4_18.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/release/release_0_4_19.html
+++ b/0.5.5/release/release_0_4_19.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/release/release_0_4_2.html
+++ b/0.5.5/release/release_0_4_2.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/release/release_0_4_3.html
+++ b/0.5.5/release/release_0_4_3.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/release/release_0_4_4.html
+++ b/0.5.5/release/release_0_4_4.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/release/release_0_4_5.html
+++ b/0.5.5/release/release_0_4_5.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/release/release_0_4_6.html
+++ b/0.5.5/release/release_0_4_6.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/release/release_0_4_7.html
+++ b/0.5.5/release/release_0_4_7.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/release/release_0_4_8.html
+++ b/0.5.5/release/release_0_4_8.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/release/release_0_4_9.html
+++ b/0.5.5/release/release_0_4_9.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/release/release_0_5_0.html
+++ b/0.5.5/release/release_0_5_0.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/release/release_0_5_1.html
+++ b/0.5.5/release/release_0_5_1.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/release/release_0_5_2.html
+++ b/0.5.5/release/release_0_5_2.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/release/release_0_5_3.html
+++ b/0.5.5/release/release_0_5_3.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/release/release_0_5_4.html
+++ b/0.5.5/release/release_0_5_4.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/release/release_0_5_5.html
+++ b/0.5.5/release/release_0_5_5.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/release/release_0_5_6.html
+++ b/0.5.5/release/release_0_5_6.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/roadmaps/0_3.html
+++ b/0.5.5/roadmaps/0_3.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/roadmaps/0_3_retrospective.html
+++ b/0.5.5/roadmaps/0_3_retrospective.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/roadmaps/0_4.html
+++ b/0.5.5/roadmaps/0_4.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.5/roadmaps/index.html
+++ b/0.5.5/roadmaps/index.html
@@ -62,6 +62,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.5';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/community/code_of_conduct.html
+++ b/0.5.6/community/code_of_conduct.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/community/code_of_conduct_reporting.html
+++ b/0.5.6/community/code_of_conduct_reporting.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/community/governance.html
+++ b/0.5.6/community/governance.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/community/index.html
+++ b/0.5.6/community/index.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/community/licensing.html
+++ b/0.5.6/community/licensing.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/community/meeting_schedule.html
+++ b/0.5.6/community/meeting_schedule.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/community/mission_and_values.html
+++ b/0.5.6/community/mission_and_values.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/community/resources.html
+++ b/0.5.6/community/resources.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/community/team.html
+++ b/0.5.6/community/team.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/community/working_groups.html
+++ b/0.5.6/community/working_groups.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/developers/architecture/app_model.html
+++ b/0.5.6/developers/architecture/app_model.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.6/developers/architecture/dir_organization.html
+++ b/0.5.6/developers/architecture/dir_organization.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.6/developers/architecture/index.html
+++ b/0.5.6/developers/architecture/index.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.6/developers/architecture/magicgui_type_reg.html
+++ b/0.5.6/developers/architecture/magicgui_type_reg.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.6/developers/architecture/napari_models.html
+++ b/0.5.6/developers/architecture/napari_models.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.6/developers/architecture/ui_sections/application_menus_ui.html
+++ b/0.5.6/developers/architecture/ui_sections/application_menus_ui.html
@@ -106,6 +106,7 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.5.6/developers/architecture/ui_sections/application_status_bar_ui.html
+++ b/0.5.6/developers/architecture/ui_sections/application_status_bar_ui.html
@@ -106,6 +106,7 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.5.6/developers/architecture/ui_sections/console_ui.html
+++ b/0.5.6/developers/architecture/ui_sections/console_ui.html
@@ -106,6 +106,7 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.5.6/developers/architecture/ui_sections/dialogs_ui.html
+++ b/0.5.6/developers/architecture/ui_sections/dialogs_ui.html
@@ -106,6 +106,7 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.5.6/developers/architecture/ui_sections/index.html
+++ b/0.5.6/developers/architecture/ui_sections/index.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.5.6/developers/architecture/ui_sections/layers_controls_ui.html
+++ b/0.5.6/developers/architecture/ui_sections/layers_controls_ui.html
@@ -106,6 +106,7 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.5.6/developers/architecture/ui_sections/layers_list_ui.html
+++ b/0.5.6/developers/architecture/ui_sections/layers_list_ui.html
@@ -106,6 +106,7 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.5.6/developers/architecture/ui_sections/viewer_ui.html
+++ b/0.5.6/developers/architecture/ui_sections/viewer_ui.html
@@ -106,6 +106,7 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.5.6/developers/contributing/dev_install.html
+++ b/0.5.6/developers/contributing/dev_install.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.6/developers/contributing/documentation/docs_deployment.html
+++ b/0.5.6/developers/contributing/documentation/docs_deployment.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.5.6/developers/contributing/documentation/docs_template.html
+++ b/0.5.6/developers/contributing/documentation/docs_template.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.5.6/developers/contributing/documentation/index.html
+++ b/0.5.6/developers/contributing/documentation/index.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.5.6/developers/contributing/index.html
+++ b/0.5.6/developers/contributing/index.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.6/developers/contributing/performance/benchmarks.html
+++ b/0.5.6/developers/contributing/performance/benchmarks.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.5.6/developers/contributing/performance/index.html
+++ b/0.5.6/developers/contributing/performance/index.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.5.6/developers/contributing/performance/profiling.html
+++ b/0.5.6/developers/contributing/performance/profiling.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.5.6/developers/contributing/testing.html
+++ b/0.5.6/developers/contributing/testing.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.6/developers/contributing/translations.html
+++ b/0.5.6/developers/contributing/translations.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.6/developers/coredev/core_dev_guide.html
+++ b/0.5.6/developers/coredev/core_dev_guide.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.6/developers/coredev/maintenance.html
+++ b/0.5.6/developers/coredev/maintenance.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.6/developers/coredev/packaging.html
+++ b/0.5.6/developers/coredev/packaging.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.6/developers/coredev/release.html
+++ b/0.5.6/developers/coredev/release.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.5.6/developers/index.html
+++ b/0.5.6/developers/index.html
@@ -72,6 +72,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/index.html
+++ b/0.5.6/index.html
@@ -72,6 +72,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="genindex.html" />
     <link rel="search" title="Search" href="search.html" />

--- a/0.5.6/naps/0-nap-process.html
+++ b/0.5.6/naps/0-nap-process.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/naps/1-institutional-funding-partners.html
+++ b/0.5.6/naps/1-institutional-funding-partners.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/naps/2-conda-based-packaging.html
+++ b/0.5.6/naps/2-conda-based-packaging.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/naps/3-spaces.html
+++ b/0.5.6/naps/3-spaces.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/naps/4-async-slicing.html
+++ b/0.5.6/naps/4-async-slicing.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/naps/5-new-logo.html
+++ b/0.5.6/naps/5-new-logo.html
@@ -72,6 +72,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/naps/6-contributable-menus.html
+++ b/0.5.6/naps/6-contributable-menus.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/naps/7-key-binding-dispatch.html
+++ b/0.5.6/naps/7-key-binding-dispatch.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/naps/8-telemetry.html
+++ b/0.5.6/naps/8-telemetry.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/naps/9-multiple-canvases.html
+++ b/0.5.6/naps/9-multiple-canvases.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/naps/index.html
+++ b/0.5.6/naps/index.html
@@ -72,6 +72,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/naps/template.html
+++ b/0.5.6/naps/template.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/release/index.html
+++ b/0.5.6/release/index.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/release/release_0_1_0.html
+++ b/0.5.6/release/release_0_1_0.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/release/release_0_1_3.html
+++ b/0.5.6/release/release_0_1_3.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/release/release_0_1_5.html
+++ b/0.5.6/release/release_0_1_5.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/release/release_0_2_0.html
+++ b/0.5.6/release/release_0_2_0.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/release/release_0_2_1.html
+++ b/0.5.6/release/release_0_2_1.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/release/release_0_2_10.html
+++ b/0.5.6/release/release_0_2_10.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/release/release_0_2_11.html
+++ b/0.5.6/release/release_0_2_11.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/release/release_0_2_12.html
+++ b/0.5.6/release/release_0_2_12.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/release/release_0_2_3.html
+++ b/0.5.6/release/release_0_2_3.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/release/release_0_2_4.html
+++ b/0.5.6/release/release_0_2_4.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/release/release_0_2_5.html
+++ b/0.5.6/release/release_0_2_5.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/release/release_0_2_6.html
+++ b/0.5.6/release/release_0_2_6.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/release/release_0_2_7.html
+++ b/0.5.6/release/release_0_2_7.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/release/release_0_2_8.html
+++ b/0.5.6/release/release_0_2_8.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/release/release_0_2_9.html
+++ b/0.5.6/release/release_0_2_9.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/release/release_0_3_0.html
+++ b/0.5.6/release/release_0_3_0.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/release/release_0_3_1.html
+++ b/0.5.6/release/release_0_3_1.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/release/release_0_3_2.html
+++ b/0.5.6/release/release_0_3_2.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/release/release_0_3_3.html
+++ b/0.5.6/release/release_0_3_3.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/release/release_0_3_4.html
+++ b/0.5.6/release/release_0_3_4.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/release/release_0_3_5.html
+++ b/0.5.6/release/release_0_3_5.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/release/release_0_3_6.html
+++ b/0.5.6/release/release_0_3_6.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/release/release_0_3_7.html
+++ b/0.5.6/release/release_0_3_7.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/release/release_0_3_8.html
+++ b/0.5.6/release/release_0_3_8.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/release/release_0_4_0.html
+++ b/0.5.6/release/release_0_4_0.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/release/release_0_4_1.html
+++ b/0.5.6/release/release_0_4_1.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/release/release_0_4_10.html
+++ b/0.5.6/release/release_0_4_10.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/release/release_0_4_11.html
+++ b/0.5.6/release/release_0_4_11.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/release/release_0_4_12.html
+++ b/0.5.6/release/release_0_4_12.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/release/release_0_4_13.html
+++ b/0.5.6/release/release_0_4_13.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/release/release_0_4_14.html
+++ b/0.5.6/release/release_0_4_14.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/release/release_0_4_15.html
+++ b/0.5.6/release/release_0_4_15.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/release/release_0_4_16.html
+++ b/0.5.6/release/release_0_4_16.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/release/release_0_4_17.html
+++ b/0.5.6/release/release_0_4_17.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/release/release_0_4_18.html
+++ b/0.5.6/release/release_0_4_18.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/release/release_0_4_19.html
+++ b/0.5.6/release/release_0_4_19.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/release/release_0_4_2.html
+++ b/0.5.6/release/release_0_4_2.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/release/release_0_4_3.html
+++ b/0.5.6/release/release_0_4_3.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/release/release_0_4_4.html
+++ b/0.5.6/release/release_0_4_4.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/release/release_0_4_5.html
+++ b/0.5.6/release/release_0_4_5.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/release/release_0_4_6.html
+++ b/0.5.6/release/release_0_4_6.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/release/release_0_4_7.html
+++ b/0.5.6/release/release_0_4_7.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/release/release_0_4_8.html
+++ b/0.5.6/release/release_0_4_8.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/release/release_0_4_9.html
+++ b/0.5.6/release/release_0_4_9.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/release/release_0_5_0.html
+++ b/0.5.6/release/release_0_5_0.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/release/release_0_5_1.html
+++ b/0.5.6/release/release_0_5_1.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/release/release_0_5_2.html
+++ b/0.5.6/release/release_0_5_2.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/release/release_0_5_3.html
+++ b/0.5.6/release/release_0_5_3.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/release/release_0_5_4.html
+++ b/0.5.6/release/release_0_5_4.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/release/release_0_5_5.html
+++ b/0.5.6/release/release_0_5_5.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/release/release_0_5_6.html
+++ b/0.5.6/release/release_0_5_6.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/release/release_0_6_0.html
+++ b/0.5.6/release/release_0_6_0.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/roadmaps/0_3.html
+++ b/0.5.6/roadmaps/0_3.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/roadmaps/0_3_retrospective.html
+++ b/0.5.6/roadmaps/0_3_retrospective.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/roadmaps/0_4.html
+++ b/0.5.6/roadmaps/0_4.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.5.6/roadmaps/index.html
+++ b/0.5.6/roadmaps/index.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.5.6';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.5.6";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/community/code_of_conduct.html
+++ b/0.6.0/community/code_of_conduct.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/community/code_of_conduct_reporting.html
+++ b/0.6.0/community/code_of_conduct_reporting.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/community/governance.html
+++ b/0.6.0/community/governance.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/community/index.html
+++ b/0.6.0/community/index.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/community/licensing.html
+++ b/0.6.0/community/licensing.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/community/meeting_schedule.html
+++ b/0.6.0/community/meeting_schedule.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/community/mission_and_values.html
+++ b/0.6.0/community/mission_and_values.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/community/resources.html
+++ b/0.6.0/community/resources.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/community/team.html
+++ b/0.6.0/community/team.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/community/working_groups.html
+++ b/0.6.0/community/working_groups.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/developers/architecture/app_model.html
+++ b/0.6.0/developers/architecture/app_model.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.0/developers/architecture/dir_organization.html
+++ b/0.6.0/developers/architecture/dir_organization.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.0/developers/architecture/index.html
+++ b/0.6.0/developers/architecture/index.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.0/developers/architecture/magicgui_type_reg.html
+++ b/0.6.0/developers/architecture/magicgui_type_reg.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.0/developers/architecture/napari_models.html
+++ b/0.6.0/developers/architecture/napari_models.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.0/developers/architecture/ui_sections/application_menus_ui.html
+++ b/0.6.0/developers/architecture/ui_sections/application_menus_ui.html
@@ -106,6 +106,7 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.0/developers/architecture/ui_sections/application_status_bar_ui.html
+++ b/0.6.0/developers/architecture/ui_sections/application_status_bar_ui.html
@@ -106,6 +106,7 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.0/developers/architecture/ui_sections/console_ui.html
+++ b/0.6.0/developers/architecture/ui_sections/console_ui.html
@@ -106,6 +106,7 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.0/developers/architecture/ui_sections/dialogs_ui.html
+++ b/0.6.0/developers/architecture/ui_sections/dialogs_ui.html
@@ -106,6 +106,7 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.0/developers/architecture/ui_sections/index.html
+++ b/0.6.0/developers/architecture/ui_sections/index.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.0/developers/architecture/ui_sections/layers_controls_ui.html
+++ b/0.6.0/developers/architecture/ui_sections/layers_controls_ui.html
@@ -106,6 +106,7 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.0/developers/architecture/ui_sections/layers_list_ui.html
+++ b/0.6.0/developers/architecture/ui_sections/layers_list_ui.html
@@ -106,6 +106,7 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.0/developers/architecture/ui_sections/viewer_ui.html
+++ b/0.6.0/developers/architecture/ui_sections/viewer_ui.html
@@ -106,6 +106,7 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.0/developers/contributing/dev_install.html
+++ b/0.6.0/developers/contributing/dev_install.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.0/developers/contributing/documentation/docs_deployment.html
+++ b/0.6.0/developers/contributing/documentation/docs_deployment.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.0/developers/contributing/documentation/docs_template.html
+++ b/0.6.0/developers/contributing/documentation/docs_template.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.0/developers/contributing/documentation/index.html
+++ b/0.6.0/developers/contributing/documentation/index.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.0/developers/contributing/index.html
+++ b/0.6.0/developers/contributing/index.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.0/developers/contributing/performance/benchmarks.html
+++ b/0.6.0/developers/contributing/performance/benchmarks.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.0/developers/contributing/performance/index.html
+++ b/0.6.0/developers/contributing/performance/index.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.0/developers/contributing/performance/profiling.html
+++ b/0.6.0/developers/contributing/performance/profiling.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.0/developers/contributing/testing.html
+++ b/0.6.0/developers/contributing/testing.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.0/developers/contributing/translations.html
+++ b/0.6.0/developers/contributing/translations.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.0/developers/coredev/core_dev_guide.html
+++ b/0.6.0/developers/coredev/core_dev_guide.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.0/developers/coredev/maintenance.html
+++ b/0.6.0/developers/coredev/maintenance.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.0/developers/coredev/packaging.html
+++ b/0.6.0/developers/coredev/packaging.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.0/developers/coredev/release.html
+++ b/0.6.0/developers/coredev/release.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.0/developers/index.html
+++ b/0.6.0/developers/index.html
@@ -72,6 +72,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/index.html
+++ b/0.6.0/index.html
@@ -72,6 +72,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="genindex.html" />
     <link rel="search" title="Search" href="search.html" />

--- a/0.6.0/naps/0-nap-process.html
+++ b/0.6.0/naps/0-nap-process.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/naps/1-institutional-funding-partners.html
+++ b/0.6.0/naps/1-institutional-funding-partners.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/naps/2-conda-based-packaging.html
+++ b/0.6.0/naps/2-conda-based-packaging.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/naps/3-spaces.html
+++ b/0.6.0/naps/3-spaces.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/naps/4-async-slicing.html
+++ b/0.6.0/naps/4-async-slicing.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/naps/5-new-logo.html
+++ b/0.6.0/naps/5-new-logo.html
@@ -72,6 +72,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/naps/6-contributable-menus.html
+++ b/0.6.0/naps/6-contributable-menus.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/naps/7-key-binding-dispatch.html
+++ b/0.6.0/naps/7-key-binding-dispatch.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/naps/8-telemetry.html
+++ b/0.6.0/naps/8-telemetry.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/naps/9-multiple-canvases.html
+++ b/0.6.0/naps/9-multiple-canvases.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/naps/index.html
+++ b/0.6.0/naps/index.html
@@ -72,6 +72,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/naps/template.html
+++ b/0.6.0/naps/template.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/release/index.html
+++ b/0.6.0/release/index.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/release/release_0_1_0.html
+++ b/0.6.0/release/release_0_1_0.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/release/release_0_1_3.html
+++ b/0.6.0/release/release_0_1_3.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/release/release_0_1_5.html
+++ b/0.6.0/release/release_0_1_5.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/release/release_0_2_0.html
+++ b/0.6.0/release/release_0_2_0.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/release/release_0_2_1.html
+++ b/0.6.0/release/release_0_2_1.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/release/release_0_2_10.html
+++ b/0.6.0/release/release_0_2_10.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/release/release_0_2_11.html
+++ b/0.6.0/release/release_0_2_11.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/release/release_0_2_12.html
+++ b/0.6.0/release/release_0_2_12.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/release/release_0_2_3.html
+++ b/0.6.0/release/release_0_2_3.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/release/release_0_2_4.html
+++ b/0.6.0/release/release_0_2_4.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/release/release_0_2_5.html
+++ b/0.6.0/release/release_0_2_5.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/release/release_0_2_6.html
+++ b/0.6.0/release/release_0_2_6.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/release/release_0_2_7.html
+++ b/0.6.0/release/release_0_2_7.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/release/release_0_2_8.html
+++ b/0.6.0/release/release_0_2_8.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/release/release_0_2_9.html
+++ b/0.6.0/release/release_0_2_9.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/release/release_0_3_0.html
+++ b/0.6.0/release/release_0_3_0.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/release/release_0_3_1.html
+++ b/0.6.0/release/release_0_3_1.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/release/release_0_3_2.html
+++ b/0.6.0/release/release_0_3_2.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/release/release_0_3_3.html
+++ b/0.6.0/release/release_0_3_3.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/release/release_0_3_4.html
+++ b/0.6.0/release/release_0_3_4.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/release/release_0_3_5.html
+++ b/0.6.0/release/release_0_3_5.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/release/release_0_3_6.html
+++ b/0.6.0/release/release_0_3_6.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/release/release_0_3_7.html
+++ b/0.6.0/release/release_0_3_7.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/release/release_0_3_8.html
+++ b/0.6.0/release/release_0_3_8.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/release/release_0_4_0.html
+++ b/0.6.0/release/release_0_4_0.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/release/release_0_4_1.html
+++ b/0.6.0/release/release_0_4_1.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/release/release_0_4_10.html
+++ b/0.6.0/release/release_0_4_10.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/release/release_0_4_11.html
+++ b/0.6.0/release/release_0_4_11.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/release/release_0_4_12.html
+++ b/0.6.0/release/release_0_4_12.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/release/release_0_4_13.html
+++ b/0.6.0/release/release_0_4_13.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/release/release_0_4_14.html
+++ b/0.6.0/release/release_0_4_14.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/release/release_0_4_15.html
+++ b/0.6.0/release/release_0_4_15.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/release/release_0_4_16.html
+++ b/0.6.0/release/release_0_4_16.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/release/release_0_4_17.html
+++ b/0.6.0/release/release_0_4_17.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/release/release_0_4_18.html
+++ b/0.6.0/release/release_0_4_18.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/release/release_0_4_19.html
+++ b/0.6.0/release/release_0_4_19.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/release/release_0_4_2.html
+++ b/0.6.0/release/release_0_4_2.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/release/release_0_4_3.html
+++ b/0.6.0/release/release_0_4_3.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/release/release_0_4_4.html
+++ b/0.6.0/release/release_0_4_4.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/release/release_0_4_5.html
+++ b/0.6.0/release/release_0_4_5.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/release/release_0_4_6.html
+++ b/0.6.0/release/release_0_4_6.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/release/release_0_4_7.html
+++ b/0.6.0/release/release_0_4_7.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/release/release_0_4_8.html
+++ b/0.6.0/release/release_0_4_8.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/release/release_0_4_9.html
+++ b/0.6.0/release/release_0_4_9.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/release/release_0_5_0.html
+++ b/0.6.0/release/release_0_5_0.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/release/release_0_5_1.html
+++ b/0.6.0/release/release_0_5_1.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/release/release_0_5_2.html
+++ b/0.6.0/release/release_0_5_2.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/release/release_0_5_3.html
+++ b/0.6.0/release/release_0_5_3.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/release/release_0_5_4.html
+++ b/0.6.0/release/release_0_5_4.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/release/release_0_5_5.html
+++ b/0.6.0/release/release_0_5_5.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/release/release_0_5_6.html
+++ b/0.6.0/release/release_0_5_6.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/release/release_0_6_0.html
+++ b/0.6.0/release/release_0_6_0.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/release/release_0_6_1.html
+++ b/0.6.0/release/release_0_6_1.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/roadmaps/0_3.html
+++ b/0.6.0/roadmaps/0_3.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/roadmaps/0_3_retrospective.html
+++ b/0.6.0/roadmaps/0_3_retrospective.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/roadmaps/0_4.html
+++ b/0.6.0/roadmaps/0_4.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.0/roadmaps/index.html
+++ b/0.6.0/roadmaps/index.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.0';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.0";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/community/code_of_conduct.html
+++ b/0.6.1/community/code_of_conduct.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/community/code_of_conduct_reporting.html
+++ b/0.6.1/community/code_of_conduct_reporting.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/community/governance.html
+++ b/0.6.1/community/governance.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/community/index.html
+++ b/0.6.1/community/index.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/community/licensing.html
+++ b/0.6.1/community/licensing.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/community/meeting_schedule.html
+++ b/0.6.1/community/meeting_schedule.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/community/mission_and_values.html
+++ b/0.6.1/community/mission_and_values.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/community/resources.html
+++ b/0.6.1/community/resources.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/community/team.html
+++ b/0.6.1/community/team.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/community/working_groups.html
+++ b/0.6.1/community/working_groups.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/developers/architecture/app_model.html
+++ b/0.6.1/developers/architecture/app_model.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.1/developers/architecture/dir_organization.html
+++ b/0.6.1/developers/architecture/dir_organization.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.1/developers/architecture/index.html
+++ b/0.6.1/developers/architecture/index.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.1/developers/architecture/magicgui_type_reg.html
+++ b/0.6.1/developers/architecture/magicgui_type_reg.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.1/developers/architecture/napari_models.html
+++ b/0.6.1/developers/architecture/napari_models.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.1/developers/architecture/ui_sections/application_menus_ui.html
+++ b/0.6.1/developers/architecture/ui_sections/application_menus_ui.html
@@ -106,6 +106,7 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.1/developers/architecture/ui_sections/application_status_bar_ui.html
+++ b/0.6.1/developers/architecture/ui_sections/application_status_bar_ui.html
@@ -106,6 +106,7 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.1/developers/architecture/ui_sections/console_ui.html
+++ b/0.6.1/developers/architecture/ui_sections/console_ui.html
@@ -106,6 +106,7 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.1/developers/architecture/ui_sections/dialogs_ui.html
+++ b/0.6.1/developers/architecture/ui_sections/dialogs_ui.html
@@ -106,6 +106,7 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.1/developers/architecture/ui_sections/index.html
+++ b/0.6.1/developers/architecture/ui_sections/index.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.1/developers/architecture/ui_sections/layers_controls_ui.html
+++ b/0.6.1/developers/architecture/ui_sections/layers_controls_ui.html
@@ -106,6 +106,7 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.1/developers/architecture/ui_sections/layers_list_ui.html
+++ b/0.6.1/developers/architecture/ui_sections/layers_list_ui.html
@@ -106,6 +106,7 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.1/developers/architecture/ui_sections/viewer_ui.html
+++ b/0.6.1/developers/architecture/ui_sections/viewer_ui.html
@@ -106,6 +106,7 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.1/developers/contributing/dev_install.html
+++ b/0.6.1/developers/contributing/dev_install.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.1/developers/contributing/documentation/docs_deployment.html
+++ b/0.6.1/developers/contributing/documentation/docs_deployment.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.1/developers/contributing/documentation/docs_template.html
+++ b/0.6.1/developers/contributing/documentation/docs_template.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.1/developers/contributing/documentation/index.html
+++ b/0.6.1/developers/contributing/documentation/index.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.1/developers/contributing/index.html
+++ b/0.6.1/developers/contributing/index.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.1/developers/contributing/performance/benchmarks.html
+++ b/0.6.1/developers/contributing/performance/benchmarks.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.1/developers/contributing/performance/index.html
+++ b/0.6.1/developers/contributing/performance/index.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.1/developers/contributing/performance/profiling.html
+++ b/0.6.1/developers/contributing/performance/profiling.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.1/developers/contributing/testing.html
+++ b/0.6.1/developers/contributing/testing.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.1/developers/contributing/translations.html
+++ b/0.6.1/developers/contributing/translations.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.1/developers/coredev/core_dev_guide.html
+++ b/0.6.1/developers/coredev/core_dev_guide.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.1/developers/coredev/maintenance.html
+++ b/0.6.1/developers/coredev/maintenance.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.1/developers/coredev/packaging.html
+++ b/0.6.1/developers/coredev/packaging.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.1/developers/coredev/release.html
+++ b/0.6.1/developers/coredev/release.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.1/developers/index.html
+++ b/0.6.1/developers/index.html
@@ -72,6 +72,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/index.html
+++ b/0.6.1/index.html
@@ -72,6 +72,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="genindex.html" />
     <link rel="search" title="Search" href="search.html" />

--- a/0.6.1/naps/0-nap-process.html
+++ b/0.6.1/naps/0-nap-process.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/naps/1-institutional-funding-partners.html
+++ b/0.6.1/naps/1-institutional-funding-partners.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/naps/2-conda-based-packaging.html
+++ b/0.6.1/naps/2-conda-based-packaging.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/naps/3-spaces.html
+++ b/0.6.1/naps/3-spaces.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/naps/4-async-slicing.html
+++ b/0.6.1/naps/4-async-slicing.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/naps/5-new-logo.html
+++ b/0.6.1/naps/5-new-logo.html
@@ -72,6 +72,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/naps/6-contributable-menus.html
+++ b/0.6.1/naps/6-contributable-menus.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/naps/7-key-binding-dispatch.html
+++ b/0.6.1/naps/7-key-binding-dispatch.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/naps/8-telemetry.html
+++ b/0.6.1/naps/8-telemetry.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/naps/9-multiple-canvases.html
+++ b/0.6.1/naps/9-multiple-canvases.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/naps/index.html
+++ b/0.6.1/naps/index.html
@@ -72,6 +72,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/naps/template.html
+++ b/0.6.1/naps/template.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/release/index.html
+++ b/0.6.1/release/index.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/release/release_0_1_0.html
+++ b/0.6.1/release/release_0_1_0.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/release/release_0_1_3.html
+++ b/0.6.1/release/release_0_1_3.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/release/release_0_1_5.html
+++ b/0.6.1/release/release_0_1_5.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/release/release_0_2_0.html
+++ b/0.6.1/release/release_0_2_0.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/release/release_0_2_1.html
+++ b/0.6.1/release/release_0_2_1.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/release/release_0_2_10.html
+++ b/0.6.1/release/release_0_2_10.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/release/release_0_2_11.html
+++ b/0.6.1/release/release_0_2_11.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/release/release_0_2_12.html
+++ b/0.6.1/release/release_0_2_12.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/release/release_0_2_3.html
+++ b/0.6.1/release/release_0_2_3.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/release/release_0_2_4.html
+++ b/0.6.1/release/release_0_2_4.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/release/release_0_2_5.html
+++ b/0.6.1/release/release_0_2_5.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/release/release_0_2_6.html
+++ b/0.6.1/release/release_0_2_6.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/release/release_0_2_7.html
+++ b/0.6.1/release/release_0_2_7.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/release/release_0_2_8.html
+++ b/0.6.1/release/release_0_2_8.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/release/release_0_2_9.html
+++ b/0.6.1/release/release_0_2_9.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/release/release_0_3_0.html
+++ b/0.6.1/release/release_0_3_0.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/release/release_0_3_1.html
+++ b/0.6.1/release/release_0_3_1.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/release/release_0_3_2.html
+++ b/0.6.1/release/release_0_3_2.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/release/release_0_3_3.html
+++ b/0.6.1/release/release_0_3_3.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/release/release_0_3_4.html
+++ b/0.6.1/release/release_0_3_4.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/release/release_0_3_5.html
+++ b/0.6.1/release/release_0_3_5.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/release/release_0_3_6.html
+++ b/0.6.1/release/release_0_3_6.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/release/release_0_3_7.html
+++ b/0.6.1/release/release_0_3_7.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/release/release_0_3_8.html
+++ b/0.6.1/release/release_0_3_8.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/release/release_0_4_0.html
+++ b/0.6.1/release/release_0_4_0.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/release/release_0_4_1.html
+++ b/0.6.1/release/release_0_4_1.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/release/release_0_4_10.html
+++ b/0.6.1/release/release_0_4_10.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/release/release_0_4_11.html
+++ b/0.6.1/release/release_0_4_11.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/release/release_0_4_12.html
+++ b/0.6.1/release/release_0_4_12.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/release/release_0_4_13.html
+++ b/0.6.1/release/release_0_4_13.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/release/release_0_4_14.html
+++ b/0.6.1/release/release_0_4_14.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/release/release_0_4_15.html
+++ b/0.6.1/release/release_0_4_15.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/release/release_0_4_16.html
+++ b/0.6.1/release/release_0_4_16.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/release/release_0_4_17.html
+++ b/0.6.1/release/release_0_4_17.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/release/release_0_4_18.html
+++ b/0.6.1/release/release_0_4_18.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/release/release_0_4_19.html
+++ b/0.6.1/release/release_0_4_19.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/release/release_0_4_2.html
+++ b/0.6.1/release/release_0_4_2.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/release/release_0_4_3.html
+++ b/0.6.1/release/release_0_4_3.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/release/release_0_4_4.html
+++ b/0.6.1/release/release_0_4_4.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/release/release_0_4_5.html
+++ b/0.6.1/release/release_0_4_5.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/release/release_0_4_6.html
+++ b/0.6.1/release/release_0_4_6.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/release/release_0_4_7.html
+++ b/0.6.1/release/release_0_4_7.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/release/release_0_4_8.html
+++ b/0.6.1/release/release_0_4_8.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/release/release_0_4_9.html
+++ b/0.6.1/release/release_0_4_9.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/release/release_0_5_0.html
+++ b/0.6.1/release/release_0_5_0.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/release/release_0_5_1.html
+++ b/0.6.1/release/release_0_5_1.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/release/release_0_5_2.html
+++ b/0.6.1/release/release_0_5_2.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/release/release_0_5_3.html
+++ b/0.6.1/release/release_0_5_3.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/release/release_0_5_4.html
+++ b/0.6.1/release/release_0_5_4.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/release/release_0_5_5.html
+++ b/0.6.1/release/release_0_5_5.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/release/release_0_5_6.html
+++ b/0.6.1/release/release_0_5_6.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/release/release_0_6_0.html
+++ b/0.6.1/release/release_0_6_0.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/release/release_0_6_1.html
+++ b/0.6.1/release/release_0_6_1.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/release/release_0_6_2.html
+++ b/0.6.1/release/release_0_6_2.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/roadmaps/0_3.html
+++ b/0.6.1/roadmaps/0_3.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/roadmaps/0_3_retrospective.html
+++ b/0.6.1/roadmaps/0_3_retrospective.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/roadmaps/0_4.html
+++ b/0.6.1/roadmaps/0_4.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/roadmaps/active_roadmap.html
+++ b/0.6.1/roadmaps/active_roadmap.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.1/roadmaps/index.html
+++ b/0.6.1/roadmaps/index.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.1';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.1";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/community/code_of_conduct.html
+++ b/0.6.2/community/code_of_conduct.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/community/code_of_conduct_reporting.html
+++ b/0.6.2/community/code_of_conduct_reporting.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/community/governance.html
+++ b/0.6.2/community/governance.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/community/index.html
+++ b/0.6.2/community/index.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/community/licensing.html
+++ b/0.6.2/community/licensing.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/community/meeting_schedule.html
+++ b/0.6.2/community/meeting_schedule.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/community/mission_and_values.html
+++ b/0.6.2/community/mission_and_values.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/community/resources.html
+++ b/0.6.2/community/resources.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/community/team.html
+++ b/0.6.2/community/team.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/community/working_groups.html
+++ b/0.6.2/community/working_groups.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/developers/architecture/app_model.html
+++ b/0.6.2/developers/architecture/app_model.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.2/developers/architecture/dir_organization.html
+++ b/0.6.2/developers/architecture/dir_organization.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.2/developers/architecture/index.html
+++ b/0.6.2/developers/architecture/index.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.2/developers/architecture/magicgui_type_reg.html
+++ b/0.6.2/developers/architecture/magicgui_type_reg.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.2/developers/architecture/napari_models.html
+++ b/0.6.2/developers/architecture/napari_models.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.2/developers/architecture/ui_sections/application_menus_ui.html
+++ b/0.6.2/developers/architecture/ui_sections/application_menus_ui.html
@@ -106,6 +106,7 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.2/developers/architecture/ui_sections/application_status_bar_ui.html
+++ b/0.6.2/developers/architecture/ui_sections/application_status_bar_ui.html
@@ -106,6 +106,7 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.2/developers/architecture/ui_sections/console_ui.html
+++ b/0.6.2/developers/architecture/ui_sections/console_ui.html
@@ -106,6 +106,7 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.2/developers/architecture/ui_sections/dialogs_ui.html
+++ b/0.6.2/developers/architecture/ui_sections/dialogs_ui.html
@@ -106,6 +106,7 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.2/developers/architecture/ui_sections/index.html
+++ b/0.6.2/developers/architecture/ui_sections/index.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.2/developers/architecture/ui_sections/layers_controls_ui.html
+++ b/0.6.2/developers/architecture/ui_sections/layers_controls_ui.html
@@ -106,6 +106,7 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.2/developers/architecture/ui_sections/layers_list_ui.html
+++ b/0.6.2/developers/architecture/ui_sections/layers_list_ui.html
@@ -106,6 +106,7 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.2/developers/architecture/ui_sections/viewer_ui.html
+++ b/0.6.2/developers/architecture/ui_sections/viewer_ui.html
@@ -106,6 +106,7 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.2/developers/contributing/dev_install.html
+++ b/0.6.2/developers/contributing/dev_install.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.2/developers/contributing/documentation/docs_deployment.html
+++ b/0.6.2/developers/contributing/documentation/docs_deployment.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.2/developers/contributing/documentation/docs_template.html
+++ b/0.6.2/developers/contributing/documentation/docs_template.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.2/developers/contributing/documentation/index.html
+++ b/0.6.2/developers/contributing/documentation/index.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.2/developers/contributing/index.html
+++ b/0.6.2/developers/contributing/index.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.2/developers/contributing/performance/benchmarks.html
+++ b/0.6.2/developers/contributing/performance/benchmarks.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.2/developers/contributing/performance/index.html
+++ b/0.6.2/developers/contributing/performance/index.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.2/developers/contributing/performance/profiling.html
+++ b/0.6.2/developers/contributing/performance/profiling.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.2/developers/contributing/testing.html
+++ b/0.6.2/developers/contributing/testing.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.2/developers/contributing/translations.html
+++ b/0.6.2/developers/contributing/translations.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.2/developers/coredev/core_dev_guide.html
+++ b/0.6.2/developers/coredev/core_dev_guide.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.2/developers/coredev/maintenance.html
+++ b/0.6.2/developers/coredev/maintenance.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.2/developers/coredev/packaging.html
+++ b/0.6.2/developers/coredev/packaging.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.2/developers/coredev/release.html
+++ b/0.6.2/developers/coredev/release.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.2/developers/index.html
+++ b/0.6.2/developers/index.html
@@ -72,6 +72,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/index.html
+++ b/0.6.2/index.html
@@ -72,6 +72,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="genindex.html" />
     <link rel="search" title="Search" href="search.html" />

--- a/0.6.2/naps/0-nap-process.html
+++ b/0.6.2/naps/0-nap-process.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/naps/1-institutional-funding-partners.html
+++ b/0.6.2/naps/1-institutional-funding-partners.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/naps/2-conda-based-packaging.html
+++ b/0.6.2/naps/2-conda-based-packaging.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/naps/3-spaces.html
+++ b/0.6.2/naps/3-spaces.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/naps/4-async-slicing.html
+++ b/0.6.2/naps/4-async-slicing.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/naps/5-new-logo.html
+++ b/0.6.2/naps/5-new-logo.html
@@ -72,6 +72,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/naps/6-contributable-menus.html
+++ b/0.6.2/naps/6-contributable-menus.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/naps/7-key-binding-dispatch.html
+++ b/0.6.2/naps/7-key-binding-dispatch.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/naps/8-telemetry.html
+++ b/0.6.2/naps/8-telemetry.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/naps/9-multiple-canvases.html
+++ b/0.6.2/naps/9-multiple-canvases.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/naps/index.html
+++ b/0.6.2/naps/index.html
@@ -72,6 +72,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/naps/template.html
+++ b/0.6.2/naps/template.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/release/index.html
+++ b/0.6.2/release/index.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/release/release_0_1_0.html
+++ b/0.6.2/release/release_0_1_0.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/release/release_0_1_3.html
+++ b/0.6.2/release/release_0_1_3.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/release/release_0_1_5.html
+++ b/0.6.2/release/release_0_1_5.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/release/release_0_2_0.html
+++ b/0.6.2/release/release_0_2_0.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/release/release_0_2_1.html
+++ b/0.6.2/release/release_0_2_1.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/release/release_0_2_10.html
+++ b/0.6.2/release/release_0_2_10.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/release/release_0_2_11.html
+++ b/0.6.2/release/release_0_2_11.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/release/release_0_2_12.html
+++ b/0.6.2/release/release_0_2_12.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/release/release_0_2_3.html
+++ b/0.6.2/release/release_0_2_3.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/release/release_0_2_4.html
+++ b/0.6.2/release/release_0_2_4.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/release/release_0_2_5.html
+++ b/0.6.2/release/release_0_2_5.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/release/release_0_2_6.html
+++ b/0.6.2/release/release_0_2_6.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/release/release_0_2_7.html
+++ b/0.6.2/release/release_0_2_7.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/release/release_0_2_8.html
+++ b/0.6.2/release/release_0_2_8.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/release/release_0_2_9.html
+++ b/0.6.2/release/release_0_2_9.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/release/release_0_3_0.html
+++ b/0.6.2/release/release_0_3_0.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/release/release_0_3_1.html
+++ b/0.6.2/release/release_0_3_1.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/release/release_0_3_2.html
+++ b/0.6.2/release/release_0_3_2.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/release/release_0_3_3.html
+++ b/0.6.2/release/release_0_3_3.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/release/release_0_3_4.html
+++ b/0.6.2/release/release_0_3_4.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/release/release_0_3_5.html
+++ b/0.6.2/release/release_0_3_5.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/release/release_0_3_6.html
+++ b/0.6.2/release/release_0_3_6.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/release/release_0_3_7.html
+++ b/0.6.2/release/release_0_3_7.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/release/release_0_3_8.html
+++ b/0.6.2/release/release_0_3_8.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/release/release_0_4_0.html
+++ b/0.6.2/release/release_0_4_0.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/release/release_0_4_1.html
+++ b/0.6.2/release/release_0_4_1.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/release/release_0_4_10.html
+++ b/0.6.2/release/release_0_4_10.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/release/release_0_4_11.html
+++ b/0.6.2/release/release_0_4_11.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/release/release_0_4_12.html
+++ b/0.6.2/release/release_0_4_12.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/release/release_0_4_13.html
+++ b/0.6.2/release/release_0_4_13.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/release/release_0_4_14.html
+++ b/0.6.2/release/release_0_4_14.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/release/release_0_4_15.html
+++ b/0.6.2/release/release_0_4_15.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/release/release_0_4_16.html
+++ b/0.6.2/release/release_0_4_16.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/release/release_0_4_17.html
+++ b/0.6.2/release/release_0_4_17.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/release/release_0_4_18.html
+++ b/0.6.2/release/release_0_4_18.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/release/release_0_4_19.html
+++ b/0.6.2/release/release_0_4_19.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/release/release_0_4_2.html
+++ b/0.6.2/release/release_0_4_2.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/release/release_0_4_3.html
+++ b/0.6.2/release/release_0_4_3.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/release/release_0_4_4.html
+++ b/0.6.2/release/release_0_4_4.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/release/release_0_4_5.html
+++ b/0.6.2/release/release_0_4_5.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/release/release_0_4_6.html
+++ b/0.6.2/release/release_0_4_6.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/release/release_0_4_7.html
+++ b/0.6.2/release/release_0_4_7.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/release/release_0_4_8.html
+++ b/0.6.2/release/release_0_4_8.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/release/release_0_4_9.html
+++ b/0.6.2/release/release_0_4_9.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/release/release_0_5_0.html
+++ b/0.6.2/release/release_0_5_0.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/release/release_0_5_1.html
+++ b/0.6.2/release/release_0_5_1.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/release/release_0_5_2.html
+++ b/0.6.2/release/release_0_5_2.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/release/release_0_5_3.html
+++ b/0.6.2/release/release_0_5_3.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/release/release_0_5_4.html
+++ b/0.6.2/release/release_0_5_4.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/release/release_0_5_5.html
+++ b/0.6.2/release/release_0_5_5.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/release/release_0_5_6.html
+++ b/0.6.2/release/release_0_5_6.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/release/release_0_6_0.html
+++ b/0.6.2/release/release_0_6_0.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/release/release_0_6_1.html
+++ b/0.6.2/release/release_0_6_1.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/release/release_0_6_2.html
+++ b/0.6.2/release/release_0_6_2.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/release/release_0_6_3.html
+++ b/0.6.2/release/release_0_6_3.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/roadmaps/0_3.html
+++ b/0.6.2/roadmaps/0_3.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/roadmaps/0_3_retrospective.html
+++ b/0.6.2/roadmaps/0_3_retrospective.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/roadmaps/0_4.html
+++ b/0.6.2/roadmaps/0_4.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/roadmaps/active_roadmap.html
+++ b/0.6.2/roadmaps/active_roadmap.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.2/roadmaps/index.html
+++ b/0.6.2/roadmaps/index.html
@@ -70,6 +70,7 @@
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';;
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.2';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.2";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/_modules/index.html
+++ b/0.6.3/_modules/index.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/_modules/napari/_qt/qt_event_loop.html
+++ b/0.6.3/_modules/napari/_qt/qt_event_loop.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.3/_modules/napari/_qt/qt_main_window.html
+++ b/0.6.3/_modules/napari/_qt/qt_main_window.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.3/_modules/napari/_qt/qt_resources.html
+++ b/0.6.3/_modules/napari/_qt/qt_resources.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.3/_modules/napari/_qt/qt_viewer.html
+++ b/0.6.3/_modules/napari/_qt/qt_viewer.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.3/_modules/napari/_qt/qthreading.html
+++ b/0.6.3/_modules/napari/_qt/qthreading.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.3/_modules/napari/_qt/widgets/qt_tooltip.html
+++ b/0.6.3/_modules/napari/_qt/widgets/qt_tooltip.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.6.3/_modules/napari/_qt/widgets/qt_viewer_buttons.html
+++ b/0.6.3/_modules/napari/_qt/widgets/qt_viewer_buttons.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.6.3/_modules/napari/components/camera.html
+++ b/0.6.3/_modules/napari/components/camera.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.3/_modules/napari/components/dims.html
+++ b/0.6.3/_modules/napari/components/dims.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.3/_modules/napari/components/layerlist.html
+++ b/0.6.3/_modules/napari/components/layerlist.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.3/_modules/napari/components/viewer_model.html
+++ b/0.6.3/_modules/napari/components/viewer_model.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.3/_modules/napari/layers/base/base.html
+++ b/0.6.3/_modules/napari/layers/base/base.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.6.3/_modules/napari/layers/image/image.html
+++ b/0.6.3/_modules/napari/layers/image/image.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.6.3/_modules/napari/layers/labels/labels.html
+++ b/0.6.3/_modules/napari/layers/labels/labels.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.6.3/_modules/napari/layers/points/points.html
+++ b/0.6.3/_modules/napari/layers/points/points.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.6.3/_modules/napari/layers/shapes/shapes.html
+++ b/0.6.3/_modules/napari/layers/shapes/shapes.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.6.3/_modules/napari/layers/surface/surface.html
+++ b/0.6.3/_modules/napari/layers/surface/surface.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.6.3/_modules/napari/layers/tracks/tracks.html
+++ b/0.6.3/_modules/napari/layers/tracks/tracks.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.6.3/_modules/napari/layers/vectors/vectors.html
+++ b/0.6.3/_modules/napari/layers/vectors/vectors.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.6.3/_modules/napari/plugins/hook_specifications.html
+++ b/0.6.3/_modules/napari/plugins/hook_specifications.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.3/_modules/napari/plugins/io.html
+++ b/0.6.3/_modules/napari/plugins/io.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.3/_modules/napari/types.html
+++ b/0.6.3/_modules/napari/types.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/_modules/napari/utils/_dask_utils.html
+++ b/0.6.3/_modules/napari/utils/_dask_utils.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.3/_modules/napari/utils/_testsupport.html
+++ b/0.6.3/_modules/napari/utils/_testsupport.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.3/_modules/napari/utils/colormaps/colormap.html
+++ b/0.6.3/_modules/napari/utils/colormaps/colormap.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.6.3/_modules/napari/utils/events/containers/_evented_dict.html
+++ b/0.6.3/_modules/napari/utils/events/containers/_evented_dict.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../../search.html" />

--- a/0.6.3/_modules/napari/utils/events/containers/_evented_list.html
+++ b/0.6.3/_modules/napari/utils/events/containers/_evented_list.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../../search.html" />

--- a/0.6.3/_modules/napari/utils/events/containers/_nested_list.html
+++ b/0.6.3/_modules/napari/utils/events/containers/_nested_list.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../../search.html" />

--- a/0.6.3/_modules/napari/utils/events/containers/_selectable_list.html
+++ b/0.6.3/_modules/napari/utils/events/containers/_selectable_list.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../../search.html" />

--- a/0.6.3/_modules/napari/utils/events/containers/_selection.html
+++ b/0.6.3/_modules/napari/utils/events/containers/_selection.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../../search.html" />

--- a/0.6.3/_modules/napari/utils/events/containers/_set.html
+++ b/0.6.3/_modules/napari/utils/events/containers/_set.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../../search.html" />

--- a/0.6.3/_modules/napari/utils/events/containers/_typed.html
+++ b/0.6.3/_modules/napari/utils/events/containers/_typed.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../../search.html" />

--- a/0.6.3/_modules/napari/utils/events/event.html
+++ b/0.6.3/_modules/napari/utils/events/event.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.6.3/_modules/napari/utils/events/event_utils.html
+++ b/0.6.3/_modules/napari/utils/events/event_utils.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.6.3/_modules/napari/utils/events/evented_model.html
+++ b/0.6.3/_modules/napari/utils/events/evented_model.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.6.3/_modules/napari/utils/events/types.html
+++ b/0.6.3/_modules/napari/utils/events/types.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.6.3/_modules/napari/utils/info.html
+++ b/0.6.3/_modules/napari/utils/info.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.3/_modules/napari/utils/notebook_display.html
+++ b/0.6.3/_modules/napari/utils/notebook_display.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.3/_modules/napari/utils/notifications.html
+++ b/0.6.3/_modules/napari/utils/notifications.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.3/_modules/napari/utils/perf/_event.html
+++ b/0.6.3/_modules/napari/utils/perf/_event.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.6.3/_modules/napari/utils/perf/_timers.html
+++ b/0.6.3/_modules/napari/utils/perf/_timers.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.6.3/_modules/napari/utils/progress.html
+++ b/0.6.3/_modules/napari/utils/progress.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.3/_modules/napari/utils/transforms/transform_utils.html
+++ b/0.6.3/_modules/napari/utils/transforms/transform_utils.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.6.3/_modules/napari/utils/transforms/transforms.html
+++ b/0.6.3/_modules/napari/utils/transforms/transforms.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.6.3/_modules/napari/view_layers.html
+++ b/0.6.3/_modules/napari/view_layers.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/_modules/napari/viewer.html
+++ b/0.6.3/_modules/napari/viewer.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/_modules/superqt/utils/_qthreading.html
+++ b/0.6.3/_modules/superqt/utils/_qthreading.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.3/_tags/analysis.html
+++ b/0.6.3/_tags/analysis.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/_tags/experimental.html
+++ b/0.6.3/_tags/experimental.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/_tags/features-table.html
+++ b/0.6.3/_tags/features-table.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/_tags/gui.html
+++ b/0.6.3/_tags/gui.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/_tags/historical.html
+++ b/0.6.3/_tags/historical.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/_tags/interactivity.html
+++ b/0.6.3/_tags/interactivity.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/_tags/layers.html
+++ b/0.6.3/_tags/layers.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/_tags/tagsindex.html
+++ b/0.6.3/_tags/tagsindex.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/_tags/visualization-advanced.html
+++ b/0.6.3/_tags/visualization-advanced.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/_tags/visualization-basic.html
+++ b/0.6.3/_tags/visualization-basic.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/_tags/visualization-nd.html
+++ b/0.6.3/_tags/visualization-nd.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/_tags/xarray.html
+++ b/0.6.3/_tags/xarray.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/deprecated.html
+++ b/0.6.3/api/deprecated.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/event_loop.html
+++ b/0.6.3/api/event_loop.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/index.html
+++ b/0.6.3/api/index.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/misc.html
+++ b/0.6.3/api/misc.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/modules.html
+++ b/0.6.3/api/modules.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.Viewer.html
+++ b/0.6.3/api/napari.Viewer.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.components.Camera.html
+++ b/0.6.3/api/napari.components.Camera.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.components.Dims.html
+++ b/0.6.3/api/napari.components.Dims.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.components.LayerList.html
+++ b/0.6.3/api/napari.components.LayerList.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.components.ViewerModel.html
+++ b/0.6.3/api/napari.components.ViewerModel.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.components.html
+++ b/0.6.3/api/napari.components.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.html
+++ b/0.6.3/api/napari.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.layers.Image.html
+++ b/0.6.3/api/napari.layers.Image.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.layers.Labels.html
+++ b/0.6.3/api/napari.layers.Labels.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.layers.Layer.html
+++ b/0.6.3/api/napari.layers.Layer.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.layers.Points.html
+++ b/0.6.3/api/napari.layers.Points.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.layers.Shapes.html
+++ b/0.6.3/api/napari.layers.Shapes.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.layers.Surface.html
+++ b/0.6.3/api/napari.layers.Surface.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.layers.Tracks.html
+++ b/0.6.3/api/napari.layers.Tracks.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.layers.Vectors.html
+++ b/0.6.3/api/napari.layers.Vectors.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.layers.html
+++ b/0.6.3/api/napari.layers.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.plugins.html
+++ b/0.6.3/api/napari.plugins.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.qt.QtToolTipLabel.html
+++ b/0.6.3/api/napari.qt.QtToolTipLabel.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.qt.QtViewer.html
+++ b/0.6.3/api/napari.qt.QtViewer.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.qt.QtViewerButtons.html
+++ b/0.6.3/api/napari.qt.QtViewerButtons.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.qt.Window.html
+++ b/0.6.3/api/napari.qt.Window.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.qt.html
+++ b/0.6.3/api/napari.qt.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.qt.threading.FunctionWorker.html
+++ b/0.6.3/api/napari.qt.threading.FunctionWorker.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.qt.threading.GeneratorWorker.html
+++ b/0.6.3/api/napari.qt.threading.GeneratorWorker.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.qt.threading.GeneratorWorkerSignals.html
+++ b/0.6.3/api/napari.qt.threading.GeneratorWorkerSignals.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.qt.threading.WorkerBase.html
+++ b/0.6.3/api/napari.qt.threading.WorkerBase.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.qt.threading.WorkerBaseSignals.html
+++ b/0.6.3/api/napari.qt.threading.WorkerBaseSignals.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.qt.threading.html
+++ b/0.6.3/api/napari.qt.threading.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.types.ArrayBase.html
+++ b/0.6.3/api/napari.types.ArrayBase.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.types.FullLayerData.html
+++ b/0.6.3/api/napari.types.FullLayerData.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.types.ReaderFunction.html
+++ b/0.6.3/api/napari.types.ReaderFunction.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.types.SampleDict.html
+++ b/0.6.3/api/napari.types.SampleDict.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.types.WidgetCallable.html
+++ b/0.6.3/api/napari.types.WidgetCallable.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.types.WriterFunction.html
+++ b/0.6.3/api/napari.types.WriterFunction.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.types.html
+++ b/0.6.3/api/napari.types.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.utils.Colormap.html
+++ b/0.6.3/api/napari.utils.Colormap.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.utils.CyclicLabelColormap.html
+++ b/0.6.3/api/napari.utils.CyclicLabelColormap.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.utils.DirectLabelColormap.html
+++ b/0.6.3/api/napari.utils.DirectLabelColormap.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.utils.NotebookScreenshot.html
+++ b/0.6.3/api/napari.utils.NotebookScreenshot.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.utils.cancelable_progress.html
+++ b/0.6.3/api/napari.utils.cancelable_progress.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.utils.events.EmitterGroup.html
+++ b/0.6.3/api/napari.utils.events.EmitterGroup.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.utils.events.Event.html
+++ b/0.6.3/api/napari.utils.events.Event.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.utils.events.EventEmitter.html
+++ b/0.6.3/api/napari.utils.events.EventEmitter.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.utils.events.EventedDict.html
+++ b/0.6.3/api/napari.utils.events.EventedDict.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.utils.events.EventedList.html
+++ b/0.6.3/api/napari.utils.events.EventedList.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.utils.events.EventedModel.html
+++ b/0.6.3/api/napari.utils.events.EventedModel.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.utils.events.EventedSet.html
+++ b/0.6.3/api/napari.utils.events.EventedSet.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.utils.events.NestableEventedList.html
+++ b/0.6.3/api/napari.utils.events.NestableEventedList.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.utils.events.SelectableEventedList.html
+++ b/0.6.3/api/napari.utils.events.SelectableEventedList.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.utils.events.Selection.html
+++ b/0.6.3/api/napari.utils.events.Selection.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.utils.events.SupportsEvents.html
+++ b/0.6.3/api/napari.utils.events.SupportsEvents.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.utils.events.TypedMutableSequence.html
+++ b/0.6.3/api/napari.utils.events.TypedMutableSequence.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.utils.events.html
+++ b/0.6.3/api/napari.utils.events.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.utils.html
+++ b/0.6.3/api/napari.utils.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.utils.nbscreenshot.html
+++ b/0.6.3/api/napari.utils.nbscreenshot.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.utils.notifications.ErrorNotification.html
+++ b/0.6.3/api/napari.utils.notifications.ErrorNotification.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.utils.notifications.Notification.html
+++ b/0.6.3/api/napari.utils.notifications.Notification.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
@@ -615,10 +616,10 @@ and the callable is a callback to perform when the action is triggered.
 <p class="rubric">Methods</p>
 <div class="pst-scrollable-table-container"><table class="autosummary longtable table autosummary">
 <tbody>
-<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">from_exception</span></code>(exc, **kwargs)</p></td>
+<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">from_exception</span></code>(exc, **kwargs)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">from_warning</span></code>(warning, **kwargs)</p></td>
+<tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">from_warning</span></code>(warning, **kwargs)</p></td>
 <td><p></p></td>
 </tr>
 </tbody>

--- a/0.6.3/api/napari.utils.notifications.NotificationManager.html
+++ b/0.6.3/api/napari.utils.notifications.NotificationManager.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.utils.notifications.NotificationSeverity.html
+++ b/0.6.3/api/napari.utils.notifications.NotificationSeverity.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.utils.notifications.WarningNotification.html
+++ b/0.6.3/api/napari.utils.notifications.WarningNotification.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.utils.notifications.html
+++ b/0.6.3/api/napari.utils.notifications.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.utils.perf.PerfEvent.html
+++ b/0.6.3/api/napari.utils.perf.PerfEvent.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.utils.perf.html
+++ b/0.6.3/api/napari.utils.perf.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.utils.progress.html
+++ b/0.6.3/api/napari.utils.progress.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.utils.transforms.Affine.html
+++ b/0.6.3/api/napari.utils.transforms.Affine.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
@@ -656,7 +657,7 @@ other parameters.</p></li>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.transforms.Affine.expand_dims" title="napari.utils.transforms.Affine.expand_dims"><code class="xref py py-obj docutils literal notranslate"><span class="pre">expand_dims</span></code></a>(axes)</p></td>
 <td><p>Return a transform with added axes for non-visible dimensions.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.transforms.Affine.replace_slice" title="napari.utils.transforms.Affine.replace_slice"><code class="xref py py-obj docutils literal notranslate"><span class="pre">replace_slice</span></code></a>(axes, transform)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.transforms.Affine.replace_slice" title="napari.utils.transforms.Affine.replace_slice"><code class="xref py py-obj docutils literal notranslate"><span class="pre">replace_slice</span></code></a>(axes, transform)</p></td>
 <td><p>Returns a transform where the transform at the indicated n dimensions is replaced with another n-dimensional transform</p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.transforms.Affine.set_slice" title="napari.utils.transforms.Affine.set_slice"><code class="xref py py-obj docutils literal notranslate"><span class="pre">set_slice</span></code></a>(axes)</p></td>

--- a/0.6.3/api/napari.utils.transforms.CompositeAffine.html
+++ b/0.6.3/api/napari.utils.transforms.CompositeAffine.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.utils.transforms.ScaleTranslate.html
+++ b/0.6.3/api/napari.utils.transforms.ScaleTranslate.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.utils.transforms.Transform.html
+++ b/0.6.3/api/napari.utils.transforms.Transform.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.utils.transforms.TransformChain.html
+++ b/0.6.3/api/napari.utils.transforms.TransformChain.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.utils.transforms.html
+++ b/0.6.3/api/napari.utils.transforms.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.view_layers.html
+++ b/0.6.3/api/napari.view_layers.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.window.Window.html
+++ b/0.6.3/api/napari.window.Window.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/napari.window.html
+++ b/0.6.3/api/napari.window.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/api/viewer.html
+++ b/0.6.3/api/viewer.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/community/code_of_conduct.html
+++ b/0.6.3/community/code_of_conduct.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'community/code_of_conduct';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/community/code_of_conduct_reporting.html
+++ b/0.6.3/community/code_of_conduct_reporting.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'community/code_of_conduct_reporting';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/community/governance.html
+++ b/0.6.3/community/governance.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'community/governance';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/community/index.html
+++ b/0.6.3/community/index.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'community/index';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/community/licensing.html
+++ b/0.6.3/community/licensing.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'community/licensing';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/community/meeting_schedule.html
+++ b/0.6.3/community/meeting_schedule.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'community/meeting_schedule';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/community/mission_and_values.html
+++ b/0.6.3/community/mission_and_values.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'community/mission_and_values';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/community/resources.html
+++ b/0.6.3/community/resources.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'community/resources';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/community/team.html
+++ b/0.6.3/community/team.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'community/team';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/community/working_groups.html
+++ b/0.6.3/community/working_groups.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'community/working_groups';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/developers/architecture/app_model.html
+++ b/0.6.3/developers/architecture/app_model.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/architecture/app_model';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/developers/architecture/dir_organization.html
+++ b/0.6.3/developers/architecture/dir_organization.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/architecture/dir_organization';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/developers/architecture/index.html
+++ b/0.6.3/developers/architecture/index.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/architecture/index';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/developers/architecture/magicgui_type_reg.html
+++ b/0.6.3/developers/architecture/magicgui_type_reg.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/architecture/magicgui_type_reg';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/developers/architecture/napari_models.html
+++ b/0.6.3/developers/architecture/napari_models.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/architecture/napari_models';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/developers/architecture/ui_sections/application_menus_ui.html
+++ b/0.6.3/developers/architecture/ui_sections/application_menus_ui.html
@@ -103,10 +103,10 @@ window.addEventListener("load", load);
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/architecture/ui_sections/application_menus_ui';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.3/developers/architecture/ui_sections/application_status_bar_ui.html
+++ b/0.6.3/developers/architecture/ui_sections/application_status_bar_ui.html
@@ -103,10 +103,10 @@ window.addEventListener("load", load);
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/architecture/ui_sections/application_status_bar_ui';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.3/developers/architecture/ui_sections/console_ui.html
+++ b/0.6.3/developers/architecture/ui_sections/console_ui.html
@@ -103,10 +103,10 @@ window.addEventListener("load", load);
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/architecture/ui_sections/console_ui';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.3/developers/architecture/ui_sections/dialogs_ui.html
+++ b/0.6.3/developers/architecture/ui_sections/dialogs_ui.html
@@ -103,10 +103,10 @@ window.addEventListener("load", load);
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/architecture/ui_sections/dialogs_ui';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.3/developers/architecture/ui_sections/index.html
+++ b/0.6.3/developers/architecture/ui_sections/index.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/architecture/ui_sections/index';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.3/developers/architecture/ui_sections/layers_controls_ui.html
+++ b/0.6.3/developers/architecture/ui_sections/layers_controls_ui.html
@@ -103,10 +103,10 @@ window.addEventListener("load", load);
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/architecture/ui_sections/layers_controls_ui';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.3/developers/architecture/ui_sections/layers_list_ui.html
+++ b/0.6.3/developers/architecture/ui_sections/layers_list_ui.html
@@ -103,10 +103,10 @@ window.addEventListener("load", load);
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/architecture/ui_sections/layers_list_ui';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.3/developers/architecture/ui_sections/viewer_ui.html
+++ b/0.6.3/developers/architecture/ui_sections/viewer_ui.html
@@ -103,10 +103,10 @@ window.addEventListener("load", load);
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/architecture/ui_sections/viewer_ui';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.3/developers/contributing/dev_install.html
+++ b/0.6.3/developers/contributing/dev_install.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/contributing/dev_install';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/developers/contributing/documentation/docs_deployment.html
+++ b/0.6.3/developers/contributing/documentation/docs_deployment.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/contributing/documentation/docs_deployment';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.3/developers/contributing/documentation/docs_template.html
+++ b/0.6.3/developers/contributing/documentation/docs_template.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/contributing/documentation/docs_template';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.3/developers/contributing/documentation/index.html
+++ b/0.6.3/developers/contributing/documentation/index.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/contributing/documentation/index';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.3/developers/contributing/index.html
+++ b/0.6.3/developers/contributing/index.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/contributing/index';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/developers/contributing/performance/benchmarks.html
+++ b/0.6.3/developers/contributing/performance/benchmarks.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/contributing/performance/benchmarks';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.3/developers/contributing/performance/index.html
+++ b/0.6.3/developers/contributing/performance/index.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/contributing/performance/index';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.3/developers/contributing/performance/profiling.html
+++ b/0.6.3/developers/contributing/performance/profiling.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/contributing/performance/profiling';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.3/developers/contributing/testing.html
+++ b/0.6.3/developers/contributing/testing.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/contributing/testing';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/developers/contributing/translations.html
+++ b/0.6.3/developers/contributing/translations.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/contributing/translations';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/developers/coredev/core_dev_guide.html
+++ b/0.6.3/developers/coredev/core_dev_guide.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/coredev/core_dev_guide';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/developers/coredev/maintenance.html
+++ b/0.6.3/developers/coredev/maintenance.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/coredev/maintenance';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/developers/coredev/packaging.html
+++ b/0.6.3/developers/coredev/packaging.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/coredev/packaging';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/developers/coredev/release.html
+++ b/0.6.3/developers/coredev/release.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/coredev/release';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/developers/index.html
+++ b/0.6.3/developers/index.html
@@ -69,10 +69,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'developers/index';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/further-resources/glossary.html
+++ b/0.6.3/further-resources/glossary.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/further-resources/napari-workshops.html
+++ b/0.6.3/further-resources/napari-workshops.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/further-resources/sample_data.html
+++ b/0.6.3/further-resources/sample_data.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery.html
+++ b/0.6.3/gallery.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="genindex.html" />
     <link rel="search" title="Search" href="search.html" />

--- a/0.6.3/gallery/3D_paths.html
+++ b/0.6.3/gallery/3D_paths.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/3Dimage_plane_rendering.html
+++ b/0.6.3/gallery/3Dimage_plane_rendering.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/action_manager.html
+++ b/0.6.3/gallery/action_manager.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/add-points-3d.html
+++ b/0.6.3/gallery/add-points-3d.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/add_3D_image.html
+++ b/0.6.3/gallery/add_3D_image.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/add_grayscale_image.html
+++ b/0.6.3/gallery/add_grayscale_image.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/add_image.html
+++ b/0.6.3/gallery/add_image.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/add_image_transformed.html
+++ b/0.6.3/gallery/add_image_transformed.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/add_labels.html
+++ b/0.6.3/gallery/add_labels.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/add_labels_with_features.html
+++ b/0.6.3/gallery/add_labels_with_features.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/add_multiscale_image.html
+++ b/0.6.3/gallery/add_multiscale_image.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/add_points.html
+++ b/0.6.3/gallery/add_points.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/add_points_on_nD_shapes.html
+++ b/0.6.3/gallery/add_points_on_nD_shapes.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/add_points_with_features.html
+++ b/0.6.3/gallery/add_points_with_features.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/add_points_with_multicolor_text.html
+++ b/0.6.3/gallery/add_points_with_multicolor_text.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/add_points_with_text.html
+++ b/0.6.3/gallery/add_points_with_text.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/add_shapes.html
+++ b/0.6.3/gallery/add_shapes.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/add_shapes_with_features.html
+++ b/0.6.3/gallery/add_shapes_with_features.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/add_shapes_with_text.html
+++ b/0.6.3/gallery/add_shapes_with_text.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/add_surface_2D.html
+++ b/0.6.3/gallery/add_surface_2D.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/add_vectors.html
+++ b/0.6.3/gallery/add_vectors.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/add_vectors_color_by_angle.html
+++ b/0.6.3/gallery/add_vectors_color_by_angle.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/add_vectors_image.html
+++ b/0.6.3/gallery/add_vectors_image.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/affine_coffee_cup.html
+++ b/0.6.3/gallery/affine_coffee_cup.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/affine_transforms.html
+++ b/0.6.3/gallery/affine_transforms.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/annotate-2d.html
+++ b/0.6.3/gallery/annotate-2d.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/annotate_segmentation_with_text.html
+++ b/0.6.3/gallery/annotate_segmentation_with_text.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/bbox_annotator.html
+++ b/0.6.3/gallery/bbox_annotator.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/concentric-spheres.html
+++ b/0.6.3/gallery/concentric-spheres.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/cursor_position.html
+++ b/0.6.3/gallery/cursor_position.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/cursor_ray.html
+++ b/0.6.3/gallery/cursor_ray.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/custom_key_bindings.html
+++ b/0.6.3/gallery/custom_key_bindings.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/custom_mouse_functions.html
+++ b/0.6.3/gallery/custom_mouse_functions.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/dask_nD_image.html
+++ b/0.6.3/gallery/dask_nD_image.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/drag_and_drop_python_code.html
+++ b/0.6.3/gallery/drag_and_drop_python_code.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/dynamic-projections-dask.html
+++ b/0.6.3/gallery/dynamic-projections-dask.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/export_figure.html
+++ b/0.6.3/gallery/export_figure.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/export_rois.html
+++ b/0.6.3/gallery/export_rois.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/features_table_widget.html
+++ b/0.6.3/gallery/features_table_widget.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/fourier_transform_playground.html
+++ b/0.6.3/gallery/fourier_transform_playground.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/get_current_viewer.html
+++ b/0.6.3/gallery/get_current_viewer.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/glasbey-colormap.html
+++ b/0.6.3/gallery/glasbey-colormap.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/grid_mode.html
+++ b/0.6.3/gallery/grid_mode.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/image-points-3d.html
+++ b/0.6.3/gallery/image-points-3d.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/image_border.html
+++ b/0.6.3/gallery/image_border.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/image_custom_kernel.html
+++ b/0.6.3/gallery/image_custom_kernel.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/image_depth.html
+++ b/0.6.3/gallery/image_depth.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/imshow.html
+++ b/0.6.3/gallery/imshow.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/inherit_viewer_style.html
+++ b/0.6.3/gallery/inherit_viewer_style.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/interaction_box_image.html
+++ b/0.6.3/gallery/interaction_box_image.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/interactive_move_rectangle_3d.html
+++ b/0.6.3/gallery/interactive_move_rectangle_3d.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/interactive_scripting.html
+++ b/0.6.3/gallery/interactive_scripting.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/labels-2d.html
+++ b/0.6.3/gallery/labels-2d.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/labels3d.html
+++ b/0.6.3/gallery/labels3d.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/layer_bounding_box.html
+++ b/0.6.3/gallery/layer_bounding_box.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/layer_text_scaling.html
+++ b/0.6.3/gallery/layer_text_scaling.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/layers.html
+++ b/0.6.3/gallery/layers.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/linked_layers.html
+++ b/0.6.3/gallery/linked_layers.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/magic_image_arithmetic.html
+++ b/0.6.3/gallery/magic_image_arithmetic.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/magic_parameter_sweep.html
+++ b/0.6.3/gallery/magic_parameter_sweep.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/magic_viewer.html
+++ b/0.6.3/gallery/magic_viewer.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/minimum_blending.html
+++ b/0.6.3/gallery/minimum_blending.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/mixed-dimensions-labels.html
+++ b/0.6.3/gallery/mixed-dimensions-labels.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/mouse_drag_callback.html
+++ b/0.6.3/gallery/mouse_drag_callback.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/multiple_viewer_widget.html
+++ b/0.6.3/gallery/multiple_viewer_widget.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/nD_image.html
+++ b/0.6.3/gallery/nD_image.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/nD_labels.html
+++ b/0.6.3/gallery/nD_labels.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/nD_multiscale_image.html
+++ b/0.6.3/gallery/nD_multiscale_image.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/nD_multiscale_image_non_uniform.html
+++ b/0.6.3/gallery/nD_multiscale_image_non_uniform.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/nD_points.html
+++ b/0.6.3/gallery/nD_points.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/nD_points_with_features.html
+++ b/0.6.3/gallery/nD_points_with_features.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/nD_shapes.html
+++ b/0.6.3/gallery/nD_shapes.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/nD_shapes_with_text.html
+++ b/0.6.3/gallery/nD_shapes_with_text.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/nD_surface.html
+++ b/0.6.3/gallery/nD_surface.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/nD_vectors.html
+++ b/0.6.3/gallery/nD_vectors.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/nD_vectors_image.html
+++ b/0.6.3/gallery/nD_vectors_image.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/new_theme.html
+++ b/0.6.3/gallery/new_theme.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/paint-nd.html
+++ b/0.6.3/gallery/paint-nd.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/pass_colormaps.html
+++ b/0.6.3/gallery/pass_colormaps.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/point_cloud.html
+++ b/0.6.3/gallery/point_cloud.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/points-over-time.html
+++ b/0.6.3/gallery/points-over-time.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/reader_plugin.html
+++ b/0.6.3/gallery/reader_plugin.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/scale_bar.html
+++ b/0.6.3/gallery/scale_bar.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/screenshot_and_export_figure.html
+++ b/0.6.3/gallery/screenshot_and_export_figure.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/set_colormaps.html
+++ b/0.6.3/gallery/set_colormaps.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/set_theme.html
+++ b/0.6.3/gallery/set_theme.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/sg_execution_times.html
+++ b/0.6.3/gallery/sg_execution_times.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/shapes_to_labels.html
+++ b/0.6.3/gallery/shapes_to_labels.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/show_points_based_on_feature.html
+++ b/0.6.3/gallery/show_points_based_on_feature.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/spherical_points.html
+++ b/0.6.3/gallery/spherical_points.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/surface_multi_texture.html
+++ b/0.6.3/gallery/surface_multi_texture.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/surface_normals_wireframe.html
+++ b/0.6.3/gallery/surface_normals_wireframe.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/surface_texture_and_colors.html
+++ b/0.6.3/gallery/surface_texture_and_colors.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/surface_timeseries.html
+++ b/0.6.3/gallery/surface_timeseries.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/swap_dims.html
+++ b/0.6.3/gallery/swap_dims.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/to_screenshot.html
+++ b/0.6.3/gallery/to_screenshot.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/tracks_2d.html
+++ b/0.6.3/gallery/tracks_2d.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/tracks_3d.html
+++ b/0.6.3/gallery/tracks_3d.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/tracks_3d_with_graph.html
+++ b/0.6.3/gallery/tracks_3d_with_graph.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/update_console.html
+++ b/0.6.3/gallery/update_console.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/viewer_fps_label.html
+++ b/0.6.3/gallery/viewer_fps_label.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/vortex.html
+++ b/0.6.3/gallery/vortex.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/without_gui_qt.html
+++ b/0.6.3/gallery/without_gui_qt.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/gallery/xarray-latlon-timeseries.html
+++ b/0.6.3/gallery/xarray-latlon-timeseries.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/genindex.html
+++ b/0.6.3/genindex.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="#" />
     <link rel="search" title="Search" href="search.html" />

--- a/0.6.3/guides/3D_interactivity.html
+++ b/0.6.3/guides/3D_interactivity.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/guides/_layer_events.html
+++ b/0.6.3/guides/_layer_events.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/guides/_layerlist_events.html
+++ b/0.6.3/guides/_layerlist_events.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/guides/_viewer_events.html
+++ b/0.6.3/guides/_viewer_events.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/guides/contexts_expressions.html
+++ b/0.6.3/guides/contexts_expressions.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/guides/event_loop.html
+++ b/0.6.3/guides/event_loop.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/guides/events_reference.html
+++ b/0.6.3/guides/events_reference.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/guides/handedness.html
+++ b/0.6.3/guides/handedness.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/guides/index.html
+++ b/0.6.3/guides/index.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/guides/layers.html
+++ b/0.6.3/guides/layers.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/guides/performance.html
+++ b/0.6.3/guides/performance.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/guides/preferences.html
+++ b/0.6.3/guides/preferences.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/guides/rendering.html
+++ b/0.6.3/guides/rendering.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/guides/threading.html
+++ b/0.6.3/guides/threading.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/guides/triangulation.html
+++ b/0.6.3/guides/triangulation.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/howtos/docker.html
+++ b/0.6.3/howtos/docker.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/howtos/extending/connecting_events.html
+++ b/0.6.3/howtos/extending/connecting_events.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/howtos/extending/index.html
+++ b/0.6.3/howtos/extending/index.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/howtos/extending/magicgui.html
+++ b/0.6.3/howtos/extending/magicgui.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/howtos/headless.html
+++ b/0.6.3/howtos/headless.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/howtos/index.html
+++ b/0.6.3/howtos/index.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/howtos/layers/image.html
+++ b/0.6.3/howtos/layers/image.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/howtos/layers/index.html
+++ b/0.6.3/howtos/layers/index.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/howtos/layers/labels.html
+++ b/0.6.3/howtos/layers/labels.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/howtos/layers/points.html
+++ b/0.6.3/howtos/layers/points.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/howtos/layers/shapes.html
+++ b/0.6.3/howtos/layers/shapes.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/howtos/layers/surface.html
+++ b/0.6.3/howtos/layers/surface.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/howtos/layers/tracks.html
+++ b/0.6.3/howtos/layers/tracks.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/howtos/layers/vectors.html
+++ b/0.6.3/howtos/layers/vectors.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/howtos/napari_imageJ.html
+++ b/0.6.3/howtos/napari_imageJ.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/howtos/perfmon.html
+++ b/0.6.3/howtos/perfmon.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/howtos/themes.html
+++ b/0.6.3/howtos/themes.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/index.html
+++ b/0.6.3/index.html
@@ -69,10 +69,11 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'index';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="genindex.html" />
     <link rel="search" title="Search" href="search.html" />

--- a/0.6.3/naps/0-nap-process.html
+++ b/0.6.3/naps/0-nap-process.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/0-nap-process';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/naps/1-institutional-funding-partners.html
+++ b/0.6.3/naps/1-institutional-funding-partners.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/1-institutional-funding-partners';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/naps/2-conda-based-packaging.html
+++ b/0.6.3/naps/2-conda-based-packaging.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/2-conda-based-packaging';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/naps/3-spaces.html
+++ b/0.6.3/naps/3-spaces.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/3-spaces';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/naps/4-async-slicing.html
+++ b/0.6.3/naps/4-async-slicing.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/4-async-slicing';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/naps/5-new-logo.html
+++ b/0.6.3/naps/5-new-logo.html
@@ -69,10 +69,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/5-new-logo';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/naps/6-contributable-menus.html
+++ b/0.6.3/naps/6-contributable-menus.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/6-contributable-menus';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/naps/7-key-binding-dispatch.html
+++ b/0.6.3/naps/7-key-binding-dispatch.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/7-key-binding-dispatch';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/naps/8-telemetry.html
+++ b/0.6.3/naps/8-telemetry.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/8-telemetry';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/naps/9-multiple-canvases.html
+++ b/0.6.3/naps/9-multiple-canvases.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/9-multiple-canvases';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/naps/index.html
+++ b/0.6.3/naps/index.html
@@ -69,10 +69,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/index';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/naps/template.html
+++ b/0.6.3/naps/template.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'naps/template';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/plugins/advanced_topics/adapted_plugin_guide.html
+++ b/0.6.3/plugins/advanced_topics/adapted_plugin_guide.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/plugins/advanced_topics/index.html
+++ b/0.6.3/plugins/advanced_topics/index.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/plugins/advanced_topics/npe1.html
+++ b/0.6.3/plugins/advanced_topics/npe1.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/plugins/advanced_topics/npe2_migration_guide.html
+++ b/0.6.3/plugins/advanced_topics/npe2_migration_guide.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/plugins/advanced_topics/widget_communication.html
+++ b/0.6.3/plugins/advanced_topics/widget_communication.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/plugins/building_a_plugin/best_practices.html
+++ b/0.6.3/plugins/building_a_plugin/best_practices.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/plugins/building_a_plugin/debug_plugins.html
+++ b/0.6.3/plugins/building_a_plugin/debug_plugins.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/plugins/building_a_plugin/first_plugin.html
+++ b/0.6.3/plugins/building_a_plugin/first_plugin.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/plugins/building_a_plugin/guides.html
+++ b/0.6.3/plugins/building_a_plugin/guides.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/plugins/building_a_plugin/index.html
+++ b/0.6.3/plugins/building_a_plugin/index.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/plugins/index.html
+++ b/0.6.3/plugins/index.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/plugins/start_using_plugins/finding_and_installing_plugins.html
+++ b/0.6.3/plugins/start_using_plugins/finding_and_installing_plugins.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/plugins/technical_references/contributions.html
+++ b/0.6.3/plugins/technical_references/contributions.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/plugins/technical_references/index.html
+++ b/0.6.3/plugins/technical_references/index.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/plugins/technical_references/manifest.html
+++ b/0.6.3/plugins/technical_references/manifest.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/plugins/testing_and_publishing/deploy.html
+++ b/0.6.3/plugins/testing_and_publishing/deploy.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/plugins/testing_and_publishing/index.html
+++ b/0.6.3/plugins/testing_and_publishing/index.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/plugins/testing_and_publishing/test.html
+++ b/0.6.3/plugins/testing_and_publishing/test.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/plugins/testing_workshop_docs/1-pythons-assert-keyword.html
+++ b/0.6.3/plugins/testing_workshop_docs/1-pythons-assert-keyword.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/plugins/testing_workshop_docs/2-pytest-testing-frameworks.html
+++ b/0.6.3/plugins/testing_workshop_docs/2-pytest-testing-frameworks.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/plugins/testing_workshop_docs/3-readers-and-fixtures.html
+++ b/0.6.3/plugins/testing_workshop_docs/3-readers-and-fixtures.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/plugins/testing_workshop_docs/4-test-coverage.html
+++ b/0.6.3/plugins/testing_workshop_docs/4-test-coverage.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/plugins/testing_workshop_docs/index.html
+++ b/0.6.3/plugins/testing_workshop_docs/index.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/plugins/testing_workshop_docs/testing-resources.html
+++ b/0.6.3/plugins/testing_workshop_docs/testing-resources.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/plugins/virtual_environment_docs/1-virtual-environments.html
+++ b/0.6.3/plugins/virtual_environment_docs/1-virtual-environments.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/plugins/virtual_environment_docs/2-deploying-your-plugin.html
+++ b/0.6.3/plugins/virtual_environment_docs/2-deploying-your-plugin.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/plugins/virtual_environment_docs/3-version-management.html
+++ b/0.6.3/plugins/virtual_environment_docs/3-version-management.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/plugins/virtual_environment_docs/4-developer-tools.html
+++ b/0.6.3/plugins/virtual_environment_docs/4-developer-tools.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/plugins/virtual_environment_docs/5-survey.html
+++ b/0.6.3/plugins/virtual_environment_docs/5-survey.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/plugins/virtual_environment_docs/index.html
+++ b/0.6.3/plugins/virtual_environment_docs/index.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/py-modindex.html
+++ b/0.6.3/py-modindex.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="genindex.html" />
     <link rel="search" title="Search" href="search.html" />

--- a/0.6.3/release/index.html
+++ b/0.6.3/release/index.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/index';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/release/release_0_1_0.html
+++ b/0.6.3/release/release_0_1_0.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_1_0';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/release/release_0_1_3.html
+++ b/0.6.3/release/release_0_1_3.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_1_3';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/release/release_0_1_5.html
+++ b/0.6.3/release/release_0_1_5.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_1_5';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/release/release_0_2_0.html
+++ b/0.6.3/release/release_0_2_0.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_0';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/release/release_0_2_1.html
+++ b/0.6.3/release/release_0_2_1.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_1';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/release/release_0_2_10.html
+++ b/0.6.3/release/release_0_2_10.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_10';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/release/release_0_2_11.html
+++ b/0.6.3/release/release_0_2_11.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_11';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/release/release_0_2_12.html
+++ b/0.6.3/release/release_0_2_12.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_12';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/release/release_0_2_3.html
+++ b/0.6.3/release/release_0_2_3.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_3';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/release/release_0_2_4.html
+++ b/0.6.3/release/release_0_2_4.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_4';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/release/release_0_2_5.html
+++ b/0.6.3/release/release_0_2_5.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_5';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/release/release_0_2_6.html
+++ b/0.6.3/release/release_0_2_6.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_6';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/release/release_0_2_7.html
+++ b/0.6.3/release/release_0_2_7.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_7';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/release/release_0_2_8.html
+++ b/0.6.3/release/release_0_2_8.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_8';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/release/release_0_2_9.html
+++ b/0.6.3/release/release_0_2_9.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_2_9';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/release/release_0_3_0.html
+++ b/0.6.3/release/release_0_3_0.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_3_0';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/release/release_0_3_1.html
+++ b/0.6.3/release/release_0_3_1.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_3_1';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/release/release_0_3_2.html
+++ b/0.6.3/release/release_0_3_2.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_3_2';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/release/release_0_3_3.html
+++ b/0.6.3/release/release_0_3_3.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_3_3';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/release/release_0_3_4.html
+++ b/0.6.3/release/release_0_3_4.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_3_4';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/release/release_0_3_5.html
+++ b/0.6.3/release/release_0_3_5.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_3_5';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/release/release_0_3_6.html
+++ b/0.6.3/release/release_0_3_6.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_3_6';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/release/release_0_3_7.html
+++ b/0.6.3/release/release_0_3_7.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_3_7';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/release/release_0_3_8.html
+++ b/0.6.3/release/release_0_3_8.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_3_8';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/release/release_0_4_0.html
+++ b/0.6.3/release/release_0_4_0.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_0';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/release/release_0_4_1.html
+++ b/0.6.3/release/release_0_4_1.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_1';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/release/release_0_4_10.html
+++ b/0.6.3/release/release_0_4_10.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_10';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/release/release_0_4_11.html
+++ b/0.6.3/release/release_0_4_11.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_11';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/release/release_0_4_12.html
+++ b/0.6.3/release/release_0_4_12.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_12';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/release/release_0_4_13.html
+++ b/0.6.3/release/release_0_4_13.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_13';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/release/release_0_4_14.html
+++ b/0.6.3/release/release_0_4_14.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_14';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/release/release_0_4_15.html
+++ b/0.6.3/release/release_0_4_15.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_15';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/release/release_0_4_16.html
+++ b/0.6.3/release/release_0_4_16.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_16';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/release/release_0_4_17.html
+++ b/0.6.3/release/release_0_4_17.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_17';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/release/release_0_4_18.html
+++ b/0.6.3/release/release_0_4_18.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_18';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/release/release_0_4_19.html
+++ b/0.6.3/release/release_0_4_19.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_19';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/release/release_0_4_2.html
+++ b/0.6.3/release/release_0_4_2.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_2';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/release/release_0_4_3.html
+++ b/0.6.3/release/release_0_4_3.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_3';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/release/release_0_4_4.html
+++ b/0.6.3/release/release_0_4_4.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_4';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/release/release_0_4_5.html
+++ b/0.6.3/release/release_0_4_5.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_5';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/release/release_0_4_6.html
+++ b/0.6.3/release/release_0_4_6.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_6';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/release/release_0_4_7.html
+++ b/0.6.3/release/release_0_4_7.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_7';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/release/release_0_4_8.html
+++ b/0.6.3/release/release_0_4_8.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_8';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/release/release_0_4_9.html
+++ b/0.6.3/release/release_0_4_9.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_4_9';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/release/release_0_5_0.html
+++ b/0.6.3/release/release_0_5_0.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_5_0';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/release/release_0_5_1.html
+++ b/0.6.3/release/release_0_5_1.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_5_1';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/release/release_0_5_2.html
+++ b/0.6.3/release/release_0_5_2.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_5_2';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/release/release_0_5_3.html
+++ b/0.6.3/release/release_0_5_3.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_5_3';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/release/release_0_5_4.html
+++ b/0.6.3/release/release_0_5_4.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_5_4';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/release/release_0_5_5.html
+++ b/0.6.3/release/release_0_5_5.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_5_5';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/release/release_0_5_6.html
+++ b/0.6.3/release/release_0_5_6.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_5_6';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/release/release_0_6_0.html
+++ b/0.6.3/release/release_0_6_0.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_6_0';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/release/release_0_6_1.html
+++ b/0.6.3/release/release_0_6_1.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_6_1';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/release/release_0_6_2.html
+++ b/0.6.3/release/release_0_6_2.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_6_2';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/release/release_0_6_3.html
+++ b/0.6.3/release/release_0_6_3.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_6_3';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/release/release_0_6_4.html
+++ b/0.6.3/release/release_0_6_4.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'release/release_0_6_4';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/roadmaps/0_3.html
+++ b/0.6.3/roadmaps/0_3.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'roadmaps/0_3';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/roadmaps/0_3_retrospective.html
+++ b/0.6.3/roadmaps/0_3_retrospective.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'roadmaps/0_3_retrospective';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/roadmaps/0_4.html
+++ b/0.6.3/roadmaps/0_4.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'roadmaps/0_4';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/roadmaps/active_roadmap.html
+++ b/0.6.3/roadmaps/active_roadmap.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'roadmaps/active_roadmap';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/roadmaps/index.html
+++ b/0.6.3/roadmaps/index.html
@@ -67,10 +67,10 @@
     <script>DOCUMENTATION_OPTIONS.pagename = 'roadmaps/index';</script>
     <script>
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
-        DOCUMENTATION_OPTIONS.theme_switcher_json_url = '_static/version_switcher.json';
+        DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/search.html
+++ b/0.6.3/search.html
@@ -93,7 +93,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
   <script src="_static/searchtools.js"></script>
   <script src="_static/language_data.js"></script>

--- a/0.6.3/sg_execution_times.html
+++ b/0.6.3/sg_execution_times.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="genindex.html" />
     <link rel="search" title="Search" href="search.html" />

--- a/0.6.3/troubleshooting.html
+++ b/0.6.3/troubleshooting.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="genindex.html" />
     <link rel="search" title="Search" href="search.html" />

--- a/0.6.3/tutorials/annotation/annotate_points.html
+++ b/0.6.3/tutorials/annotation/annotate_points.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/tutorials/annotation/index.html
+++ b/0.6.3/tutorials/annotation/index.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/tutorials/fundamentals/features.html
+++ b/0.6.3/tutorials/fundamentals/features.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/tutorials/fundamentals/getting_started.html
+++ b/0.6.3/tutorials/fundamentals/getting_started.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/tutorials/fundamentals/installation.html
+++ b/0.6.3/tutorials/fundamentals/installation.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/tutorials/fundamentals/installation_bundle_conda.html
+++ b/0.6.3/tutorials/fundamentals/installation_bundle_conda.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/tutorials/fundamentals/quick_start.html
+++ b/0.6.3/tutorials/fundamentals/quick_start.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/tutorials/fundamentals/viewer.html
+++ b/0.6.3/tutorials/fundamentals/viewer.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/tutorials/index.html
+++ b/0.6.3/tutorials/index.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/tutorials/processing/dask.html
+++ b/0.6.3/tutorials/processing/dask.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/tutorials/processing/index.html
+++ b/0.6.3/tutorials/processing/index.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/tutorials/segmentation/annotate_segmentation.html
+++ b/0.6.3/tutorials/segmentation/annotate_segmentation.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/tutorials/segmentation/index.html
+++ b/0.6.3/tutorials/segmentation/index.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/tutorials/start_index.html
+++ b/0.6.3/tutorials/start_index.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.3/tutorials/tracking/cell_tracking.html
+++ b/0.6.3/tutorials/tracking/cell_tracking.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/tutorials/tracking/index.html
+++ b/0.6.3/tutorials/tracking/index.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.3/usage.html
+++ b/0.6.3/usage.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.3';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.3";
         </script>
     <link rel="index" title="Index" href="genindex.html" />
     <link rel="search" title="Search" href="search.html" />

--- a/0.6.4/_modules/index.html
+++ b/0.6.4/_modules/index.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/_modules/napari/_qt/qt_event_loop.html
+++ b/0.6.4/_modules/napari/_qt/qt_event_loop.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.4/_modules/napari/_qt/qt_main_window.html
+++ b/0.6.4/_modules/napari/_qt/qt_main_window.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.4/_modules/napari/_qt/qt_resources.html
+++ b/0.6.4/_modules/napari/_qt/qt_resources.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.4/_modules/napari/_qt/qt_viewer.html
+++ b/0.6.4/_modules/napari/_qt/qt_viewer.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.4/_modules/napari/_qt/qthreading.html
+++ b/0.6.4/_modules/napari/_qt/qthreading.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.4/_modules/napari/_qt/widgets/qt_tooltip.html
+++ b/0.6.4/_modules/napari/_qt/widgets/qt_tooltip.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.6.4/_modules/napari/_qt/widgets/qt_viewer_buttons.html
+++ b/0.6.4/_modules/napari/_qt/widgets/qt_viewer_buttons.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.6.4/_modules/napari/components/camera.html
+++ b/0.6.4/_modules/napari/components/camera.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.4/_modules/napari/components/dims.html
+++ b/0.6.4/_modules/napari/components/dims.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.4/_modules/napari/components/layerlist.html
+++ b/0.6.4/_modules/napari/components/layerlist.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.4/_modules/napari/components/viewer_model.html
+++ b/0.6.4/_modules/napari/components/viewer_model.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.4/_modules/napari/layers/base/base.html
+++ b/0.6.4/_modules/napari/layers/base/base.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.6.4/_modules/napari/layers/image/image.html
+++ b/0.6.4/_modules/napari/layers/image/image.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.6.4/_modules/napari/layers/labels/labels.html
+++ b/0.6.4/_modules/napari/layers/labels/labels.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.6.4/_modules/napari/layers/points/points.html
+++ b/0.6.4/_modules/napari/layers/points/points.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.6.4/_modules/napari/layers/shapes/shapes.html
+++ b/0.6.4/_modules/napari/layers/shapes/shapes.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.6.4/_modules/napari/layers/surface/surface.html
+++ b/0.6.4/_modules/napari/layers/surface/surface.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.6.4/_modules/napari/layers/tracks/tracks.html
+++ b/0.6.4/_modules/napari/layers/tracks/tracks.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.6.4/_modules/napari/layers/vectors/vectors.html
+++ b/0.6.4/_modules/napari/layers/vectors/vectors.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.6.4/_modules/napari/plugins/hook_specifications.html
+++ b/0.6.4/_modules/napari/plugins/hook_specifications.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.4/_modules/napari/plugins/io.html
+++ b/0.6.4/_modules/napari/plugins/io.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.4/_modules/napari/types.html
+++ b/0.6.4/_modules/napari/types.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/_modules/napari/utils/_dask_utils.html
+++ b/0.6.4/_modules/napari/utils/_dask_utils.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.4/_modules/napari/utils/_testsupport.html
+++ b/0.6.4/_modules/napari/utils/_testsupport.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.4/_modules/napari/utils/colormaps/colormap.html
+++ b/0.6.4/_modules/napari/utils/colormaps/colormap.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.6.4/_modules/napari/utils/events/containers/_evented_dict.html
+++ b/0.6.4/_modules/napari/utils/events/containers/_evented_dict.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../../search.html" />

--- a/0.6.4/_modules/napari/utils/events/containers/_evented_list.html
+++ b/0.6.4/_modules/napari/utils/events/containers/_evented_list.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../../search.html" />

--- a/0.6.4/_modules/napari/utils/events/containers/_nested_list.html
+++ b/0.6.4/_modules/napari/utils/events/containers/_nested_list.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../../search.html" />

--- a/0.6.4/_modules/napari/utils/events/containers/_selectable_list.html
+++ b/0.6.4/_modules/napari/utils/events/containers/_selectable_list.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../../search.html" />

--- a/0.6.4/_modules/napari/utils/events/containers/_selection.html
+++ b/0.6.4/_modules/napari/utils/events/containers/_selection.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../../search.html" />

--- a/0.6.4/_modules/napari/utils/events/containers/_set.html
+++ b/0.6.4/_modules/napari/utils/events/containers/_set.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../../search.html" />

--- a/0.6.4/_modules/napari/utils/events/containers/_typed.html
+++ b/0.6.4/_modules/napari/utils/events/containers/_typed.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../../search.html" />

--- a/0.6.4/_modules/napari/utils/events/event.html
+++ b/0.6.4/_modules/napari/utils/events/event.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.6.4/_modules/napari/utils/events/event_utils.html
+++ b/0.6.4/_modules/napari/utils/events/event_utils.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.6.4/_modules/napari/utils/events/evented_model.html
+++ b/0.6.4/_modules/napari/utils/events/evented_model.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.6.4/_modules/napari/utils/events/types.html
+++ b/0.6.4/_modules/napari/utils/events/types.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.6.4/_modules/napari/utils/info.html
+++ b/0.6.4/_modules/napari/utils/info.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.4/_modules/napari/utils/notebook_display.html
+++ b/0.6.4/_modules/napari/utils/notebook_display.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.4/_modules/napari/utils/notifications.html
+++ b/0.6.4/_modules/napari/utils/notifications.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.4/_modules/napari/utils/perf/_event.html
+++ b/0.6.4/_modules/napari/utils/perf/_event.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.6.4/_modules/napari/utils/perf/_timers.html
+++ b/0.6.4/_modules/napari/utils/perf/_timers.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.6.4/_modules/napari/utils/progress.html
+++ b/0.6.4/_modules/napari/utils/progress.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.4/_modules/napari/utils/transforms/transform_utils.html
+++ b/0.6.4/_modules/napari/utils/transforms/transform_utils.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.6.4/_modules/napari/utils/transforms/transforms.html
+++ b/0.6.4/_modules/napari/utils/transforms/transforms.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.6.4/_modules/napari/view_layers.html
+++ b/0.6.4/_modules/napari/view_layers.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/_modules/napari/viewer.html
+++ b/0.6.4/_modules/napari/viewer.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/_modules/superqt/utils/_qthreading.html
+++ b/0.6.4/_modules/superqt/utils/_qthreading.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.4/_tags/analysis.html
+++ b/0.6.4/_tags/analysis.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/_tags/experimental.html
+++ b/0.6.4/_tags/experimental.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/_tags/features-table.html
+++ b/0.6.4/_tags/features-table.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/_tags/gui.html
+++ b/0.6.4/_tags/gui.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/_tags/historical.html
+++ b/0.6.4/_tags/historical.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/_tags/interactivity.html
+++ b/0.6.4/_tags/interactivity.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/_tags/layers.html
+++ b/0.6.4/_tags/layers.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/_tags/tagsindex.html
+++ b/0.6.4/_tags/tagsindex.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/_tags/visualization-advanced.html
+++ b/0.6.4/_tags/visualization-advanced.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/_tags/visualization-basic.html
+++ b/0.6.4/_tags/visualization-basic.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/_tags/visualization-nd.html
+++ b/0.6.4/_tags/visualization-nd.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/_tags/xarray.html
+++ b/0.6.4/_tags/xarray.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/deprecated.html
+++ b/0.6.4/api/deprecated.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/event_loop.html
+++ b/0.6.4/api/event_loop.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/index.html
+++ b/0.6.4/api/index.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/misc.html
+++ b/0.6.4/api/misc.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/modules.html
+++ b/0.6.4/api/modules.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.Viewer.html
+++ b/0.6.4/api/napari.Viewer.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.components.Camera.html
+++ b/0.6.4/api/napari.components.Camera.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.components.Dims.html
+++ b/0.6.4/api/napari.components.Dims.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.components.LayerList.html
+++ b/0.6.4/api/napari.components.LayerList.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.components.ViewerModel.html
+++ b/0.6.4/api/napari.components.ViewerModel.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.components.html
+++ b/0.6.4/api/napari.components.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.html
+++ b/0.6.4/api/napari.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.layers.Image.html
+++ b/0.6.4/api/napari.layers.Image.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.layers.Labels.html
+++ b/0.6.4/api/napari.layers.Labels.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.layers.Layer.html
+++ b/0.6.4/api/napari.layers.Layer.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.layers.Points.html
+++ b/0.6.4/api/napari.layers.Points.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.layers.Shapes.html
+++ b/0.6.4/api/napari.layers.Shapes.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.layers.Surface.html
+++ b/0.6.4/api/napari.layers.Surface.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.layers.Tracks.html
+++ b/0.6.4/api/napari.layers.Tracks.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.layers.Vectors.html
+++ b/0.6.4/api/napari.layers.Vectors.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.layers.html
+++ b/0.6.4/api/napari.layers.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.plugins.html
+++ b/0.6.4/api/napari.plugins.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.qt.QtToolTipLabel.html
+++ b/0.6.4/api/napari.qt.QtToolTipLabel.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.qt.QtViewer.html
+++ b/0.6.4/api/napari.qt.QtViewer.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.qt.QtViewerButtons.html
+++ b/0.6.4/api/napari.qt.QtViewerButtons.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.qt.Window.html
+++ b/0.6.4/api/napari.qt.Window.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.qt.html
+++ b/0.6.4/api/napari.qt.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.qt.threading.FunctionWorker.html
+++ b/0.6.4/api/napari.qt.threading.FunctionWorker.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.qt.threading.GeneratorWorker.html
+++ b/0.6.4/api/napari.qt.threading.GeneratorWorker.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.qt.threading.GeneratorWorkerSignals.html
+++ b/0.6.4/api/napari.qt.threading.GeneratorWorkerSignals.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.qt.threading.WorkerBase.html
+++ b/0.6.4/api/napari.qt.threading.WorkerBase.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.qt.threading.WorkerBaseSignals.html
+++ b/0.6.4/api/napari.qt.threading.WorkerBaseSignals.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.qt.threading.html
+++ b/0.6.4/api/napari.qt.threading.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.types.ArrayBase.html
+++ b/0.6.4/api/napari.types.ArrayBase.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.types.FullLayerData.html
+++ b/0.6.4/api/napari.types.FullLayerData.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.types.ReaderFunction.html
+++ b/0.6.4/api/napari.types.ReaderFunction.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.types.SampleDict.html
+++ b/0.6.4/api/napari.types.SampleDict.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.types.WidgetCallable.html
+++ b/0.6.4/api/napari.types.WidgetCallable.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.types.WriterFunction.html
+++ b/0.6.4/api/napari.types.WriterFunction.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.types.html
+++ b/0.6.4/api/napari.types.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.utils.Colormap.html
+++ b/0.6.4/api/napari.utils.Colormap.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.utils.CyclicLabelColormap.html
+++ b/0.6.4/api/napari.utils.CyclicLabelColormap.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.utils.DirectLabelColormap.html
+++ b/0.6.4/api/napari.utils.DirectLabelColormap.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.utils.NotebookScreenshot.html
+++ b/0.6.4/api/napari.utils.NotebookScreenshot.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.utils.cancelable_progress.html
+++ b/0.6.4/api/napari.utils.cancelable_progress.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.utils.events.EmitterGroup.html
+++ b/0.6.4/api/napari.utils.events.EmitterGroup.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.utils.events.Event.html
+++ b/0.6.4/api/napari.utils.events.Event.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.utils.events.EventEmitter.html
+++ b/0.6.4/api/napari.utils.events.EventEmitter.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.utils.events.EventedDict.html
+++ b/0.6.4/api/napari.utils.events.EventedDict.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.utils.events.EventedList.html
+++ b/0.6.4/api/napari.utils.events.EventedList.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.utils.events.EventedModel.html
+++ b/0.6.4/api/napari.utils.events.EventedModel.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.utils.events.EventedSet.html
+++ b/0.6.4/api/napari.utils.events.EventedSet.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.utils.events.NestableEventedList.html
+++ b/0.6.4/api/napari.utils.events.NestableEventedList.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.utils.events.SelectableEventedList.html
+++ b/0.6.4/api/napari.utils.events.SelectableEventedList.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.utils.events.Selection.html
+++ b/0.6.4/api/napari.utils.events.Selection.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.utils.events.SupportsEvents.html
+++ b/0.6.4/api/napari.utils.events.SupportsEvents.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.utils.events.TypedMutableSequence.html
+++ b/0.6.4/api/napari.utils.events.TypedMutableSequence.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.utils.events.html
+++ b/0.6.4/api/napari.utils.events.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.utils.html
+++ b/0.6.4/api/napari.utils.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.utils.nbscreenshot.html
+++ b/0.6.4/api/napari.utils.nbscreenshot.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.utils.notifications.ErrorNotification.html
+++ b/0.6.4/api/napari.utils.notifications.ErrorNotification.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.utils.notifications.Notification.html
+++ b/0.6.4/api/napari.utils.notifications.Notification.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.utils.notifications.NotificationManager.html
+++ b/0.6.4/api/napari.utils.notifications.NotificationManager.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.utils.notifications.NotificationSeverity.html
+++ b/0.6.4/api/napari.utils.notifications.NotificationSeverity.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.utils.notifications.WarningNotification.html
+++ b/0.6.4/api/napari.utils.notifications.WarningNotification.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.utils.notifications.html
+++ b/0.6.4/api/napari.utils.notifications.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.utils.perf.PerfEvent.html
+++ b/0.6.4/api/napari.utils.perf.PerfEvent.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.utils.perf.html
+++ b/0.6.4/api/napari.utils.perf.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.utils.progress.html
+++ b/0.6.4/api/napari.utils.progress.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.utils.transforms.Affine.html
+++ b/0.6.4/api/napari.utils.transforms.Affine.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.utils.transforms.CompositeAffine.html
+++ b/0.6.4/api/napari.utils.transforms.CompositeAffine.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.utils.transforms.ScaleTranslate.html
+++ b/0.6.4/api/napari.utils.transforms.ScaleTranslate.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.utils.transforms.Transform.html
+++ b/0.6.4/api/napari.utils.transforms.Transform.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.utils.transforms.TransformChain.html
+++ b/0.6.4/api/napari.utils.transforms.TransformChain.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.utils.transforms.html
+++ b/0.6.4/api/napari.utils.transforms.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.view_layers.html
+++ b/0.6.4/api/napari.view_layers.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.window.Window.html
+++ b/0.6.4/api/napari.window.Window.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/napari.window.html
+++ b/0.6.4/api/napari.window.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/api/viewer.html
+++ b/0.6.4/api/viewer.html
@@ -67,7 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/community/code_of_conduct.html
+++ b/0.6.4/community/code_of_conduct.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/community/code_of_conduct_reporting.html
+++ b/0.6.4/community/code_of_conduct_reporting.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/community/governance.html
+++ b/0.6.4/community/governance.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/community/index.html
+++ b/0.6.4/community/index.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/community/licensing.html
+++ b/0.6.4/community/licensing.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/community/meeting_schedule.html
+++ b/0.6.4/community/meeting_schedule.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/community/mission_and_values.html
+++ b/0.6.4/community/mission_and_values.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/community/resources.html
+++ b/0.6.4/community/resources.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/community/team.html
+++ b/0.6.4/community/team.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/community/working_groups.html
+++ b/0.6.4/community/working_groups.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/developers/architecture/app_model.html
+++ b/0.6.4/developers/architecture/app_model.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/developers/architecture/dir_organization.html
+++ b/0.6.4/developers/architecture/dir_organization.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/developers/architecture/index.html
+++ b/0.6.4/developers/architecture/index.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/developers/architecture/magicgui_type_reg.html
+++ b/0.6.4/developers/architecture/magicgui_type_reg.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/developers/architecture/napari_models.html
+++ b/0.6.4/developers/architecture/napari_models.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/developers/architecture/ui_sections/application_menus_ui.html
+++ b/0.6.4/developers/architecture/ui_sections/application_menus_ui.html
@@ -105,8 +105,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.4/developers/architecture/ui_sections/application_status_bar_ui.html
+++ b/0.6.4/developers/architecture/ui_sections/application_status_bar_ui.html
@@ -105,8 +105,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.4/developers/architecture/ui_sections/console_ui.html
+++ b/0.6.4/developers/architecture/ui_sections/console_ui.html
@@ -105,8 +105,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.4/developers/architecture/ui_sections/dialogs_ui.html
+++ b/0.6.4/developers/architecture/ui_sections/dialogs_ui.html
@@ -105,8 +105,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.4/developers/architecture/ui_sections/index.html
+++ b/0.6.4/developers/architecture/ui_sections/index.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.4/developers/architecture/ui_sections/layers_controls_ui.html
+++ b/0.6.4/developers/architecture/ui_sections/layers_controls_ui.html
@@ -105,8 +105,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.4/developers/architecture/ui_sections/layers_list_ui.html
+++ b/0.6.4/developers/architecture/ui_sections/layers_list_ui.html
@@ -105,8 +105,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.4/developers/architecture/ui_sections/viewer_ui.html
+++ b/0.6.4/developers/architecture/ui_sections/viewer_ui.html
@@ -105,8 +105,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.4/developers/contributing/dev_install.html
+++ b/0.6.4/developers/contributing/dev_install.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/developers/contributing/documentation/docs_deployment.html
+++ b/0.6.4/developers/contributing/documentation/docs_deployment.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.4/developers/contributing/documentation/docs_template.html
+++ b/0.6.4/developers/contributing/documentation/docs_template.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.4/developers/contributing/documentation/index.html
+++ b/0.6.4/developers/contributing/documentation/index.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.4/developers/contributing/index.html
+++ b/0.6.4/developers/contributing/index.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/developers/contributing/performance/benchmarks.html
+++ b/0.6.4/developers/contributing/performance/benchmarks.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.4/developers/contributing/performance/index.html
+++ b/0.6.4/developers/contributing/performance/index.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.4/developers/contributing/performance/profiling.html
+++ b/0.6.4/developers/contributing/performance/profiling.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.4/developers/contributing/testing.html
+++ b/0.6.4/developers/contributing/testing.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/developers/contributing/translations.html
+++ b/0.6.4/developers/contributing/translations.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/developers/coredev/core_dev_guide.html
+++ b/0.6.4/developers/coredev/core_dev_guide.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/developers/coredev/maintenance.html
+++ b/0.6.4/developers/coredev/maintenance.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/developers/coredev/packaging.html
+++ b/0.6.4/developers/coredev/packaging.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/developers/coredev/release.html
+++ b/0.6.4/developers/coredev/release.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/developers/index.html
+++ b/0.6.4/developers/index.html
@@ -71,8 +71,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/further-resources/glossary.html
+++ b/0.6.4/further-resources/glossary.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/further-resources/napari-workshops.html
+++ b/0.6.4/further-resources/napari-workshops.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/further-resources/sample_data.html
+++ b/0.6.4/further-resources/sample_data.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery.html
+++ b/0.6.4/gallery.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="genindex.html" />
     <link rel="search" title="Search" href="search.html" />

--- a/0.6.4/gallery/3D_paths.html
+++ b/0.6.4/gallery/3D_paths.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/3Dimage_plane_rendering.html
+++ b/0.6.4/gallery/3Dimage_plane_rendering.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/action_manager.html
+++ b/0.6.4/gallery/action_manager.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/add-points-3d.html
+++ b/0.6.4/gallery/add-points-3d.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/add_3D_image.html
+++ b/0.6.4/gallery/add_3D_image.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/add_grayscale_image.html
+++ b/0.6.4/gallery/add_grayscale_image.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/add_image.html
+++ b/0.6.4/gallery/add_image.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/add_image_transformed.html
+++ b/0.6.4/gallery/add_image_transformed.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/add_labels.html
+++ b/0.6.4/gallery/add_labels.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/add_labels_with_features.html
+++ b/0.6.4/gallery/add_labels_with_features.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/add_multiscale_image.html
+++ b/0.6.4/gallery/add_multiscale_image.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/add_points.html
+++ b/0.6.4/gallery/add_points.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/add_points_on_nD_shapes.html
+++ b/0.6.4/gallery/add_points_on_nD_shapes.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/add_points_with_features.html
+++ b/0.6.4/gallery/add_points_with_features.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/add_points_with_multicolor_text.html
+++ b/0.6.4/gallery/add_points_with_multicolor_text.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/add_points_with_text.html
+++ b/0.6.4/gallery/add_points_with_text.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/add_shapes.html
+++ b/0.6.4/gallery/add_shapes.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/add_shapes_with_features.html
+++ b/0.6.4/gallery/add_shapes_with_features.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/add_shapes_with_text.html
+++ b/0.6.4/gallery/add_shapes_with_text.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/add_surface_2D.html
+++ b/0.6.4/gallery/add_surface_2D.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/add_vectors.html
+++ b/0.6.4/gallery/add_vectors.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/add_vectors_color_by_angle.html
+++ b/0.6.4/gallery/add_vectors_color_by_angle.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/add_vectors_image.html
+++ b/0.6.4/gallery/add_vectors_image.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/affine_coffee_cup.html
+++ b/0.6.4/gallery/affine_coffee_cup.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/affine_transforms.html
+++ b/0.6.4/gallery/affine_transforms.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/annotate-2d.html
+++ b/0.6.4/gallery/annotate-2d.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/annotate_segmentation_with_text.html
+++ b/0.6.4/gallery/annotate_segmentation_with_text.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/bbox_annotator.html
+++ b/0.6.4/gallery/bbox_annotator.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/concentric-spheres.html
+++ b/0.6.4/gallery/concentric-spheres.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/cursor_position.html
+++ b/0.6.4/gallery/cursor_position.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/cursor_ray.html
+++ b/0.6.4/gallery/cursor_ray.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/custom_key_bindings.html
+++ b/0.6.4/gallery/custom_key_bindings.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/custom_mouse_functions.html
+++ b/0.6.4/gallery/custom_mouse_functions.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/dask_nD_image.html
+++ b/0.6.4/gallery/dask_nD_image.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/drag_and_drop_python_code.html
+++ b/0.6.4/gallery/drag_and_drop_python_code.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/dynamic-projections-dask.html
+++ b/0.6.4/gallery/dynamic-projections-dask.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/export_figure.html
+++ b/0.6.4/gallery/export_figure.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/export_rois.html
+++ b/0.6.4/gallery/export_rois.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/features_table_widget.html
+++ b/0.6.4/gallery/features_table_widget.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/fourier_transform_playground.html
+++ b/0.6.4/gallery/fourier_transform_playground.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/get_current_viewer.html
+++ b/0.6.4/gallery/get_current_viewer.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/glasbey-colormap.html
+++ b/0.6.4/gallery/glasbey-colormap.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/grid_mode.html
+++ b/0.6.4/gallery/grid_mode.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/image-points-3d.html
+++ b/0.6.4/gallery/image-points-3d.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/image_border.html
+++ b/0.6.4/gallery/image_border.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/image_custom_kernel.html
+++ b/0.6.4/gallery/image_custom_kernel.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/image_depth.html
+++ b/0.6.4/gallery/image_depth.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/imshow.html
+++ b/0.6.4/gallery/imshow.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/inherit_viewer_style.html
+++ b/0.6.4/gallery/inherit_viewer_style.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/interaction_box_image.html
+++ b/0.6.4/gallery/interaction_box_image.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/interactive_move_rectangle_3d.html
+++ b/0.6.4/gallery/interactive_move_rectangle_3d.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/interactive_scripting.html
+++ b/0.6.4/gallery/interactive_scripting.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/labels-2d.html
+++ b/0.6.4/gallery/labels-2d.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/labels3d.html
+++ b/0.6.4/gallery/labels3d.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/layer_bounding_box.html
+++ b/0.6.4/gallery/layer_bounding_box.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/layer_text_scaling.html
+++ b/0.6.4/gallery/layer_text_scaling.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/layers.html
+++ b/0.6.4/gallery/layers.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/linked_layers.html
+++ b/0.6.4/gallery/linked_layers.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/magic_image_arithmetic.html
+++ b/0.6.4/gallery/magic_image_arithmetic.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/magic_parameter_sweep.html
+++ b/0.6.4/gallery/magic_parameter_sweep.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/magic_viewer.html
+++ b/0.6.4/gallery/magic_viewer.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/minimum_blending.html
+++ b/0.6.4/gallery/minimum_blending.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/mixed-dimensions-labels.html
+++ b/0.6.4/gallery/mixed-dimensions-labels.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/mouse_drag_callback.html
+++ b/0.6.4/gallery/mouse_drag_callback.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/multiple_viewer_widget.html
+++ b/0.6.4/gallery/multiple_viewer_widget.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/nD_image.html
+++ b/0.6.4/gallery/nD_image.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/nD_labels.html
+++ b/0.6.4/gallery/nD_labels.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/nD_multiscale_image.html
+++ b/0.6.4/gallery/nD_multiscale_image.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/nD_multiscale_image_non_uniform.html
+++ b/0.6.4/gallery/nD_multiscale_image_non_uniform.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/nD_points.html
+++ b/0.6.4/gallery/nD_points.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/nD_points_with_features.html
+++ b/0.6.4/gallery/nD_points_with_features.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/nD_shapes.html
+++ b/0.6.4/gallery/nD_shapes.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/nD_shapes_with_text.html
+++ b/0.6.4/gallery/nD_shapes_with_text.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/nD_surface.html
+++ b/0.6.4/gallery/nD_surface.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/nD_vectors.html
+++ b/0.6.4/gallery/nD_vectors.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/nD_vectors_image.html
+++ b/0.6.4/gallery/nD_vectors_image.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/new_theme.html
+++ b/0.6.4/gallery/new_theme.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/paint-nd.html
+++ b/0.6.4/gallery/paint-nd.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/pass_colormaps.html
+++ b/0.6.4/gallery/pass_colormaps.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/point_cloud.html
+++ b/0.6.4/gallery/point_cloud.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/points-over-time.html
+++ b/0.6.4/gallery/points-over-time.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/reader_plugin.html
+++ b/0.6.4/gallery/reader_plugin.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/scale_bar.html
+++ b/0.6.4/gallery/scale_bar.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/screenshot_and_export_figure.html
+++ b/0.6.4/gallery/screenshot_and_export_figure.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/set_colormaps.html
+++ b/0.6.4/gallery/set_colormaps.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/set_theme.html
+++ b/0.6.4/gallery/set_theme.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/sg_execution_times.html
+++ b/0.6.4/gallery/sg_execution_times.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/shapes_to_labels.html
+++ b/0.6.4/gallery/shapes_to_labels.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/show_points_based_on_feature.html
+++ b/0.6.4/gallery/show_points_based_on_feature.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/spherical_points.html
+++ b/0.6.4/gallery/spherical_points.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/surface_multi_texture.html
+++ b/0.6.4/gallery/surface_multi_texture.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/surface_normals_wireframe.html
+++ b/0.6.4/gallery/surface_normals_wireframe.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/surface_texture_and_colors.html
+++ b/0.6.4/gallery/surface_texture_and_colors.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/surface_timeseries.html
+++ b/0.6.4/gallery/surface_timeseries.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/swap_dims.html
+++ b/0.6.4/gallery/swap_dims.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/to_screenshot.html
+++ b/0.6.4/gallery/to_screenshot.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/tracks_2d.html
+++ b/0.6.4/gallery/tracks_2d.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/tracks_3d.html
+++ b/0.6.4/gallery/tracks_3d.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/tracks_3d_with_graph.html
+++ b/0.6.4/gallery/tracks_3d_with_graph.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/update_console.html
+++ b/0.6.4/gallery/update_console.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/viewer_fps_label.html
+++ b/0.6.4/gallery/viewer_fps_label.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/vortex.html
+++ b/0.6.4/gallery/vortex.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/without_gui_qt.html
+++ b/0.6.4/gallery/without_gui_qt.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/gallery/xarray-latlon-timeseries.html
+++ b/0.6.4/gallery/xarray-latlon-timeseries.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/genindex.html
+++ b/0.6.4/genindex.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="#" />
     <link rel="search" title="Search" href="search.html" />

--- a/0.6.4/guides/3D_interactivity.html
+++ b/0.6.4/guides/3D_interactivity.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/guides/_layer_events.html
+++ b/0.6.4/guides/_layer_events.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/guides/_layerlist_events.html
+++ b/0.6.4/guides/_layerlist_events.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/guides/_viewer_events.html
+++ b/0.6.4/guides/_viewer_events.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/guides/contexts_expressions.html
+++ b/0.6.4/guides/contexts_expressions.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/guides/event_loop.html
+++ b/0.6.4/guides/event_loop.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/guides/events_reference.html
+++ b/0.6.4/guides/events_reference.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/guides/handedness.html
+++ b/0.6.4/guides/handedness.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/guides/index.html
+++ b/0.6.4/guides/index.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/guides/layers.html
+++ b/0.6.4/guides/layers.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/guides/performance.html
+++ b/0.6.4/guides/performance.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/guides/preferences.html
+++ b/0.6.4/guides/preferences.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/guides/rendering.html
+++ b/0.6.4/guides/rendering.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/guides/threading.html
+++ b/0.6.4/guides/threading.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/guides/triangulation.html
+++ b/0.6.4/guides/triangulation.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/howtos/docker.html
+++ b/0.6.4/howtos/docker.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/howtos/extending/connecting_events.html
+++ b/0.6.4/howtos/extending/connecting_events.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/howtos/extending/index.html
+++ b/0.6.4/howtos/extending/index.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/howtos/extending/magicgui.html
+++ b/0.6.4/howtos/extending/magicgui.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/howtos/headless.html
+++ b/0.6.4/howtos/headless.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/howtos/index.html
+++ b/0.6.4/howtos/index.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/howtos/layers/image.html
+++ b/0.6.4/howtos/layers/image.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/howtos/layers/index.html
+++ b/0.6.4/howtos/layers/index.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/howtos/layers/labels.html
+++ b/0.6.4/howtos/layers/labels.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/howtos/layers/points.html
+++ b/0.6.4/howtos/layers/points.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/howtos/layers/shapes.html
+++ b/0.6.4/howtos/layers/shapes.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/howtos/layers/surface.html
+++ b/0.6.4/howtos/layers/surface.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/howtos/layers/tracks.html
+++ b/0.6.4/howtos/layers/tracks.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/howtos/layers/vectors.html
+++ b/0.6.4/howtos/layers/vectors.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/howtos/napari_imageJ.html
+++ b/0.6.4/howtos/napari_imageJ.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/howtos/perfmon.html
+++ b/0.6.4/howtos/perfmon.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/howtos/themes.html
+++ b/0.6.4/howtos/themes.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/index.html
+++ b/0.6.4/index.html
@@ -71,8 +71,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="genindex.html" />
     <link rel="search" title="Search" href="search.html" />

--- a/0.6.4/naps/0-nap-process.html
+++ b/0.6.4/naps/0-nap-process.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/naps/1-institutional-funding-partners.html
+++ b/0.6.4/naps/1-institutional-funding-partners.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/naps/2-conda-based-packaging.html
+++ b/0.6.4/naps/2-conda-based-packaging.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/naps/3-spaces.html
+++ b/0.6.4/naps/3-spaces.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/naps/4-async-slicing.html
+++ b/0.6.4/naps/4-async-slicing.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/naps/5-new-logo.html
+++ b/0.6.4/naps/5-new-logo.html
@@ -71,8 +71,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/naps/6-contributable-menus.html
+++ b/0.6.4/naps/6-contributable-menus.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/naps/7-key-binding-dispatch.html
+++ b/0.6.4/naps/7-key-binding-dispatch.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/naps/8-telemetry.html
+++ b/0.6.4/naps/8-telemetry.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/naps/9-multiple-canvases.html
+++ b/0.6.4/naps/9-multiple-canvases.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/naps/index.html
+++ b/0.6.4/naps/index.html
@@ -71,8 +71,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/naps/template.html
+++ b/0.6.4/naps/template.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/plugins/advanced_topics/adapted_plugin_guide.html
+++ b/0.6.4/plugins/advanced_topics/adapted_plugin_guide.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/plugins/advanced_topics/index.html
+++ b/0.6.4/plugins/advanced_topics/index.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/plugins/advanced_topics/npe1.html
+++ b/0.6.4/plugins/advanced_topics/npe1.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/plugins/advanced_topics/npe2_migration_guide.html
+++ b/0.6.4/plugins/advanced_topics/npe2_migration_guide.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/plugins/advanced_topics/widget_communication.html
+++ b/0.6.4/plugins/advanced_topics/widget_communication.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/plugins/building_a_plugin/best_practices.html
+++ b/0.6.4/plugins/building_a_plugin/best_practices.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/plugins/building_a_plugin/debug_plugins.html
+++ b/0.6.4/plugins/building_a_plugin/debug_plugins.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/plugins/building_a_plugin/first_plugin.html
+++ b/0.6.4/plugins/building_a_plugin/first_plugin.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/plugins/building_a_plugin/guides.html
+++ b/0.6.4/plugins/building_a_plugin/guides.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/plugins/building_a_plugin/index.html
+++ b/0.6.4/plugins/building_a_plugin/index.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/plugins/index.html
+++ b/0.6.4/plugins/index.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/plugins/start_using_plugins/finding_and_installing_plugins.html
+++ b/0.6.4/plugins/start_using_plugins/finding_and_installing_plugins.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/plugins/technical_references/contributions.html
+++ b/0.6.4/plugins/technical_references/contributions.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/plugins/technical_references/index.html
+++ b/0.6.4/plugins/technical_references/index.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/plugins/technical_references/manifest.html
+++ b/0.6.4/plugins/technical_references/manifest.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/plugins/testing_and_publishing/deploy.html
+++ b/0.6.4/plugins/testing_and_publishing/deploy.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/plugins/testing_and_publishing/index.html
+++ b/0.6.4/plugins/testing_and_publishing/index.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/plugins/testing_and_publishing/test.html
+++ b/0.6.4/plugins/testing_and_publishing/test.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/plugins/testing_workshop_docs/1-pythons-assert-keyword.html
+++ b/0.6.4/plugins/testing_workshop_docs/1-pythons-assert-keyword.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/plugins/testing_workshop_docs/2-pytest-testing-frameworks.html
+++ b/0.6.4/plugins/testing_workshop_docs/2-pytest-testing-frameworks.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/plugins/testing_workshop_docs/3-readers-and-fixtures.html
+++ b/0.6.4/plugins/testing_workshop_docs/3-readers-and-fixtures.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/plugins/testing_workshop_docs/4-test-coverage.html
+++ b/0.6.4/plugins/testing_workshop_docs/4-test-coverage.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/plugins/testing_workshop_docs/index.html
+++ b/0.6.4/plugins/testing_workshop_docs/index.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/plugins/testing_workshop_docs/testing-resources.html
+++ b/0.6.4/plugins/testing_workshop_docs/testing-resources.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/plugins/virtual_environment_docs/1-virtual-environments.html
+++ b/0.6.4/plugins/virtual_environment_docs/1-virtual-environments.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/plugins/virtual_environment_docs/2-deploying-your-plugin.html
+++ b/0.6.4/plugins/virtual_environment_docs/2-deploying-your-plugin.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/plugins/virtual_environment_docs/3-version-management.html
+++ b/0.6.4/plugins/virtual_environment_docs/3-version-management.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/plugins/virtual_environment_docs/4-developer-tools.html
+++ b/0.6.4/plugins/virtual_environment_docs/4-developer-tools.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/plugins/virtual_environment_docs/5-survey.html
+++ b/0.6.4/plugins/virtual_environment_docs/5-survey.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/plugins/virtual_environment_docs/index.html
+++ b/0.6.4/plugins/virtual_environment_docs/index.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/py-modindex.html
+++ b/0.6.4/py-modindex.html
@@ -94,7 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="genindex.html" />
     <link rel="search" title="Search" href="search.html" />

--- a/0.6.4/release/index.html
+++ b/0.6.4/release/index.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/release/release_0_1_0.html
+++ b/0.6.4/release/release_0_1_0.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/release/release_0_1_3.html
+++ b/0.6.4/release/release_0_1_3.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/release/release_0_1_5.html
+++ b/0.6.4/release/release_0_1_5.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/release/release_0_2_0.html
+++ b/0.6.4/release/release_0_2_0.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/release/release_0_2_1.html
+++ b/0.6.4/release/release_0_2_1.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/release/release_0_2_10.html
+++ b/0.6.4/release/release_0_2_10.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/release/release_0_2_11.html
+++ b/0.6.4/release/release_0_2_11.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/release/release_0_2_12.html
+++ b/0.6.4/release/release_0_2_12.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/release/release_0_2_3.html
+++ b/0.6.4/release/release_0_2_3.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/release/release_0_2_4.html
+++ b/0.6.4/release/release_0_2_4.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/release/release_0_2_5.html
+++ b/0.6.4/release/release_0_2_5.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/release/release_0_2_6.html
+++ b/0.6.4/release/release_0_2_6.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/release/release_0_2_7.html
+++ b/0.6.4/release/release_0_2_7.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/release/release_0_2_8.html
+++ b/0.6.4/release/release_0_2_8.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/release/release_0_2_9.html
+++ b/0.6.4/release/release_0_2_9.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/release/release_0_3_0.html
+++ b/0.6.4/release/release_0_3_0.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/release/release_0_3_1.html
+++ b/0.6.4/release/release_0_3_1.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/release/release_0_3_2.html
+++ b/0.6.4/release/release_0_3_2.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/release/release_0_3_3.html
+++ b/0.6.4/release/release_0_3_3.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/release/release_0_3_4.html
+++ b/0.6.4/release/release_0_3_4.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/release/release_0_3_5.html
+++ b/0.6.4/release/release_0_3_5.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/release/release_0_3_6.html
+++ b/0.6.4/release/release_0_3_6.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/release/release_0_3_7.html
+++ b/0.6.4/release/release_0_3_7.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/release/release_0_3_8.html
+++ b/0.6.4/release/release_0_3_8.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/release/release_0_4_0.html
+++ b/0.6.4/release/release_0_4_0.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/release/release_0_4_1.html
+++ b/0.6.4/release/release_0_4_1.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/release/release_0_4_10.html
+++ b/0.6.4/release/release_0_4_10.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/release/release_0_4_11.html
+++ b/0.6.4/release/release_0_4_11.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/release/release_0_4_12.html
+++ b/0.6.4/release/release_0_4_12.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/release/release_0_4_13.html
+++ b/0.6.4/release/release_0_4_13.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/release/release_0_4_14.html
+++ b/0.6.4/release/release_0_4_14.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/release/release_0_4_15.html
+++ b/0.6.4/release/release_0_4_15.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/release/release_0_4_16.html
+++ b/0.6.4/release/release_0_4_16.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/release/release_0_4_17.html
+++ b/0.6.4/release/release_0_4_17.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/release/release_0_4_18.html
+++ b/0.6.4/release/release_0_4_18.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/release/release_0_4_19.html
+++ b/0.6.4/release/release_0_4_19.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/release/release_0_4_2.html
+++ b/0.6.4/release/release_0_4_2.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/release/release_0_4_3.html
+++ b/0.6.4/release/release_0_4_3.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/release/release_0_4_4.html
+++ b/0.6.4/release/release_0_4_4.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/release/release_0_4_5.html
+++ b/0.6.4/release/release_0_4_5.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/release/release_0_4_6.html
+++ b/0.6.4/release/release_0_4_6.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/release/release_0_4_7.html
+++ b/0.6.4/release/release_0_4_7.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/release/release_0_4_8.html
+++ b/0.6.4/release/release_0_4_8.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/release/release_0_4_9.html
+++ b/0.6.4/release/release_0_4_9.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/release/release_0_5_0.html
+++ b/0.6.4/release/release_0_5_0.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/release/release_0_5_1.html
+++ b/0.6.4/release/release_0_5_1.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/release/release_0_5_2.html
+++ b/0.6.4/release/release_0_5_2.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/release/release_0_5_3.html
+++ b/0.6.4/release/release_0_5_3.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/release/release_0_5_4.html
+++ b/0.6.4/release/release_0_5_4.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/release/release_0_5_5.html
+++ b/0.6.4/release/release_0_5_5.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/release/release_0_5_6.html
+++ b/0.6.4/release/release_0_5_6.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/release/release_0_6_0.html
+++ b/0.6.4/release/release_0_6_0.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/release/release_0_6_1.html
+++ b/0.6.4/release/release_0_6_1.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/release/release_0_6_2.html
+++ b/0.6.4/release/release_0_6_2.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/release/release_0_6_3.html
+++ b/0.6.4/release/release_0_6_3.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/release/release_0_6_4.html
+++ b/0.6.4/release/release_0_6_4.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/release/release_0_6_5.html
+++ b/0.6.4/release/release_0_6_5.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/roadmaps/0_3.html
+++ b/0.6.4/roadmaps/0_3.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/roadmaps/0_3_retrospective.html
+++ b/0.6.4/roadmaps/0_3_retrospective.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/roadmaps/0_4.html
+++ b/0.6.4/roadmaps/0_4.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/roadmaps/active_roadmap.html
+++ b/0.6.4/roadmaps/active_roadmap.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/roadmaps/index.html
+++ b/0.6.4/roadmaps/index.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/search.html
+++ b/0.6.4/search.html
@@ -93,7 +93,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
   <script src="_static/searchtools.js"></script>
   <script src="_static/language_data.js"></script>

--- a/0.6.4/sg_execution_times.html
+++ b/0.6.4/sg_execution_times.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="genindex.html" />
     <link rel="search" title="Search" href="search.html" />

--- a/0.6.4/troubleshooting.html
+++ b/0.6.4/troubleshooting.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="genindex.html" />
     <link rel="search" title="Search" href="search.html" />

--- a/0.6.4/tutorials/annotation/annotate_points.html
+++ b/0.6.4/tutorials/annotation/annotate_points.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/tutorials/annotation/index.html
+++ b/0.6.4/tutorials/annotation/index.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/tutorials/fundamentals/features.html
+++ b/0.6.4/tutorials/fundamentals/features.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/tutorials/fundamentals/getting_started.html
+++ b/0.6.4/tutorials/fundamentals/getting_started.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/tutorials/fundamentals/installation.html
+++ b/0.6.4/tutorials/fundamentals/installation.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/tutorials/fundamentals/installation_bundle_conda.html
+++ b/0.6.4/tutorials/fundamentals/installation_bundle_conda.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/tutorials/fundamentals/quick_start.html
+++ b/0.6.4/tutorials/fundamentals/quick_start.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/tutorials/fundamentals/viewer.html
+++ b/0.6.4/tutorials/fundamentals/viewer.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/tutorials/index.html
+++ b/0.6.4/tutorials/index.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/tutorials/processing/dask.html
+++ b/0.6.4/tutorials/processing/dask.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/tutorials/processing/index.html
+++ b/0.6.4/tutorials/processing/index.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/tutorials/segmentation/annotate_segmentation.html
+++ b/0.6.4/tutorials/segmentation/annotate_segmentation.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/tutorials/segmentation/index.html
+++ b/0.6.4/tutorials/segmentation/index.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/tutorials/start_index.html
+++ b/0.6.4/tutorials/start_index.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.4/tutorials/tracking/cell_tracking.html
+++ b/0.6.4/tutorials/tracking/cell_tracking.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/tutorials/tracking/index.html
+++ b/0.6.4/tutorials/tracking/index.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.4/usage.html
+++ b/0.6.4/usage.html
@@ -69,7 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.4';
-DOCUMENTATION_OPTIONS.show_version_warning_banner = false;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.4";
         </script>
     <link rel="index" title="Index" href="genindex.html" />
     <link rel="search" title="Search" href="search.html" />

--- a/0.6.5/_modules/index.html
+++ b/0.6.5/_modules/index.html
@@ -94,8 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/_modules/napari/_qt/qt_event_loop.html
+++ b/0.6.5/_modules/napari/_qt/qt_event_loop.html
@@ -94,8 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.5/_modules/napari/_qt/qt_main_window.html
+++ b/0.6.5/_modules/napari/_qt/qt_main_window.html
@@ -94,8 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.5/_modules/napari/_qt/qt_resources.html
+++ b/0.6.5/_modules/napari/_qt/qt_resources.html
@@ -94,8 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.5/_modules/napari/_qt/qt_viewer.html
+++ b/0.6.5/_modules/napari/_qt/qt_viewer.html
@@ -94,8 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.5/_modules/napari/_qt/qthreading.html
+++ b/0.6.5/_modules/napari/_qt/qthreading.html
@@ -94,8 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.5/_modules/napari/_qt/widgets/qt_tooltip.html
+++ b/0.6.5/_modules/napari/_qt/widgets/qt_tooltip.html
@@ -94,8 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.6.5/_modules/napari/_qt/widgets/qt_viewer_buttons.html
+++ b/0.6.5/_modules/napari/_qt/widgets/qt_viewer_buttons.html
@@ -94,8 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.6.5/_modules/napari/components/camera.html
+++ b/0.6.5/_modules/napari/components/camera.html
@@ -94,8 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.5/_modules/napari/components/dims.html
+++ b/0.6.5/_modules/napari/components/dims.html
@@ -94,8 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.5/_modules/napari/components/layerlist.html
+++ b/0.6.5/_modules/napari/components/layerlist.html
@@ -94,8 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.5/_modules/napari/components/viewer_model.html
+++ b/0.6.5/_modules/napari/components/viewer_model.html
@@ -94,8 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.5/_modules/napari/layers/base/base.html
+++ b/0.6.5/_modules/napari/layers/base/base.html
@@ -94,8 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.6.5/_modules/napari/layers/image/image.html
+++ b/0.6.5/_modules/napari/layers/image/image.html
@@ -94,8 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.6.5/_modules/napari/layers/labels/labels.html
+++ b/0.6.5/_modules/napari/layers/labels/labels.html
@@ -94,8 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.6.5/_modules/napari/layers/points/points.html
+++ b/0.6.5/_modules/napari/layers/points/points.html
@@ -94,8 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.6.5/_modules/napari/layers/shapes/shapes.html
+++ b/0.6.5/_modules/napari/layers/shapes/shapes.html
@@ -94,8 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.6.5/_modules/napari/layers/surface/surface.html
+++ b/0.6.5/_modules/napari/layers/surface/surface.html
@@ -94,8 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.6.5/_modules/napari/layers/tracks/tracks.html
+++ b/0.6.5/_modules/napari/layers/tracks/tracks.html
@@ -94,8 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.6.5/_modules/napari/layers/vectors/vectors.html
+++ b/0.6.5/_modules/napari/layers/vectors/vectors.html
@@ -94,8 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.6.5/_modules/napari/plugins/hook_specifications.html
+++ b/0.6.5/_modules/napari/plugins/hook_specifications.html
@@ -94,8 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.5/_modules/napari/plugins/io.html
+++ b/0.6.5/_modules/napari/plugins/io.html
@@ -94,8 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.5/_modules/napari/types.html
+++ b/0.6.5/_modules/napari/types.html
@@ -94,8 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/_modules/napari/utils/_dask_utils.html
+++ b/0.6.5/_modules/napari/utils/_dask_utils.html
@@ -94,8 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.5/_modules/napari/utils/_testsupport.html
+++ b/0.6.5/_modules/napari/utils/_testsupport.html
@@ -94,8 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.5/_modules/napari/utils/colormaps/colormap.html
+++ b/0.6.5/_modules/napari/utils/colormaps/colormap.html
@@ -94,8 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.6.5/_modules/napari/utils/events/containers/_evented_dict.html
+++ b/0.6.5/_modules/napari/utils/events/containers/_evented_dict.html
@@ -94,8 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../../search.html" />

--- a/0.6.5/_modules/napari/utils/events/containers/_evented_list.html
+++ b/0.6.5/_modules/napari/utils/events/containers/_evented_list.html
@@ -94,8 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../../search.html" />

--- a/0.6.5/_modules/napari/utils/events/containers/_nested_list.html
+++ b/0.6.5/_modules/napari/utils/events/containers/_nested_list.html
@@ -94,8 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../../search.html" />

--- a/0.6.5/_modules/napari/utils/events/containers/_selectable_list.html
+++ b/0.6.5/_modules/napari/utils/events/containers/_selectable_list.html
@@ -94,8 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../../search.html" />

--- a/0.6.5/_modules/napari/utils/events/containers/_selection.html
+++ b/0.6.5/_modules/napari/utils/events/containers/_selection.html
@@ -94,8 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../../search.html" />

--- a/0.6.5/_modules/napari/utils/events/containers/_set.html
+++ b/0.6.5/_modules/napari/utils/events/containers/_set.html
@@ -94,8 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../../search.html" />

--- a/0.6.5/_modules/napari/utils/events/containers/_typed.html
+++ b/0.6.5/_modules/napari/utils/events/containers/_typed.html
@@ -94,8 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../../search.html" />

--- a/0.6.5/_modules/napari/utils/events/event.html
+++ b/0.6.5/_modules/napari/utils/events/event.html
@@ -94,8 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.6.5/_modules/napari/utils/events/event_utils.html
+++ b/0.6.5/_modules/napari/utils/events/event_utils.html
@@ -94,8 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.6.5/_modules/napari/utils/events/evented_model.html
+++ b/0.6.5/_modules/napari/utils/events/evented_model.html
@@ -94,8 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.6.5/_modules/napari/utils/events/types.html
+++ b/0.6.5/_modules/napari/utils/events/types.html
@@ -94,8 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.6.5/_modules/napari/utils/info.html
+++ b/0.6.5/_modules/napari/utils/info.html
@@ -94,8 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.5/_modules/napari/utils/notebook_display.html
+++ b/0.6.5/_modules/napari/utils/notebook_display.html
@@ -94,8 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.5/_modules/napari/utils/notifications.html
+++ b/0.6.5/_modules/napari/utils/notifications.html
@@ -94,8 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.5/_modules/napari/utils/perf/_event.html
+++ b/0.6.5/_modules/napari/utils/perf/_event.html
@@ -94,8 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.6.5/_modules/napari/utils/perf/_timers.html
+++ b/0.6.5/_modules/napari/utils/perf/_timers.html
@@ -94,8 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.6.5/_modules/napari/utils/progress.html
+++ b/0.6.5/_modules/napari/utils/progress.html
@@ -94,8 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.5/_modules/napari/utils/transforms/transform_utils.html
+++ b/0.6.5/_modules/napari/utils/transforms/transform_utils.html
@@ -94,8 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.6.5/_modules/napari/utils/transforms/transforms.html
+++ b/0.6.5/_modules/napari/utils/transforms/transforms.html
@@ -94,8 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../../../genindex.html" />
     <link rel="search" title="Search" href="../../../../search.html" />

--- a/0.6.5/_modules/napari/view_layers.html
+++ b/0.6.5/_modules/napari/view_layers.html
@@ -94,8 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/_modules/napari/viewer.html
+++ b/0.6.5/_modules/napari/viewer.html
@@ -94,8 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/_modules/superqt/utils/_qthreading.html
+++ b/0.6.5/_modules/superqt/utils/_qthreading.html
@@ -94,8 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.5/_tags/analysis.html
+++ b/0.6.5/_tags/analysis.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/_tags/experimental.html
+++ b/0.6.5/_tags/experimental.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/_tags/features-table.html
+++ b/0.6.5/_tags/features-table.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/_tags/gui.html
+++ b/0.6.5/_tags/gui.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/_tags/historical.html
+++ b/0.6.5/_tags/historical.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/_tags/interactivity.html
+++ b/0.6.5/_tags/interactivity.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/_tags/layers.html
+++ b/0.6.5/_tags/layers.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/_tags/tagsindex.html
+++ b/0.6.5/_tags/tagsindex.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/_tags/visualization-advanced.html
+++ b/0.6.5/_tags/visualization-advanced.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/_tags/visualization-basic.html
+++ b/0.6.5/_tags/visualization-basic.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/_tags/visualization-nd.html
+++ b/0.6.5/_tags/visualization-nd.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/_tags/xarray.html
+++ b/0.6.5/_tags/xarray.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/api/deprecated.html
+++ b/0.6.5/api/deprecated.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/api/event_loop.html
+++ b/0.6.5/api/event_loop.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
@@ -603,7 +603,7 @@ Currently, napari’s user interface uses the Qt library.
 See the <a class="reference internal" href="../guides/event_loop.html#intro-to-event-loop"><span class="std std-ref">event loop guide</span></a> for an explanation of the event loop’s purpose and operation.</p>
 <div class="pst-scrollable-table-container"><table class="autosummary longtable table autosummary">
 <tbody>
-<tr class="row-odd"><td><p><a class="reference internal" href="napari.html#napari.run" title="napari.run"><code class="xref py py-obj docutils literal notranslate"><span class="pre">napari.run</span></code></a>(*[, force, gui_exceptions, ...])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="napari.html#napari.run" title="napari.run"><code class="xref py py-obj docutils literal notranslate"><span class="pre">napari.run</span></code></a>(*[, force, gui_exceptions, ...])</p></td>
 <td><p>Start the Qt Event Loop</p></td>
 </tr>
 </tbody>

--- a/0.6.5/api/index.html
+++ b/0.6.5/api/index.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/api/misc.html
+++ b/0.6.5/api/misc.html
@@ -67,8 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
@@ -598,7 +598,7 @@
 <h1>Misc<a class="headerlink" href="#misc" title="Link to this heading">#</a></h1>
 <div class="pst-scrollable-table-container"><table class="autosummary longtable table autosummary">
 <tbody>
-<tr class="row-odd"><td><p><a class="reference internal" href="napari.html#napari.save_layers" title="napari.save_layers"><code class="xref py py-obj docutils literal notranslate"><span class="pre">napari.save_layers</span></code></a>(path, layers, *[, ...])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="napari.html#napari.save_layers" title="napari.save_layers"><code class="xref py py-obj docutils literal notranslate"><span class="pre">napari.save_layers</span></code></a>(path, layers, *[, ...])</p></td>
 <td><p>Write list of layers or individual layer to a path using writer plugins.</p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="napari.html#napari.sys_info" title="napari.sys_info"><code class="xref py py-obj docutils literal notranslate"><span class="pre">napari.sys_info</span></code></a>([as_html])</p></td>

--- a/0.6.5/api/modules.html
+++ b/0.6.5/api/modules.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/api/napari.Viewer.html
+++ b/0.6.5/api/napari.Viewer.html
@@ -67,8 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
@@ -627,31 +627,31 @@ ndisplay is 2 or 3. By default None</p></li>
 <p class="rubric">Methods</p>
 <div class="pst-scrollable-table-container"><table class="autosummary longtable table autosummary">
 <tbody>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.Viewer.add_image" title="napari.Viewer.add_image"><code class="xref py py-obj docutils literal notranslate"><span class="pre">add_image</span></code></a>([data, channel_axis, affine, ...])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.Viewer.add_image" title="napari.Viewer.add_image"><code class="xref py py-obj docutils literal notranslate"><span class="pre">add_image</span></code></a>([data, channel_axis, affine, ...])</p></td>
 <td><p>Add one or more Image layers to the layer list.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.Viewer.add_labels" title="napari.Viewer.add_labels"><code class="xref py py-obj docutils literal notranslate"><span class="pre">add_labels</span></code></a>(data, *[, affine, axis_labels, ...])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.Viewer.add_labels" title="napari.Viewer.add_labels"><code class="xref py py-obj docutils literal notranslate"><span class="pre">add_labels</span></code></a>(data, *[, affine, axis_labels, ...])</p></td>
 <td><p>Add a Labels layer to the layer list.</p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.Viewer.add_layer" title="napari.Viewer.add_layer"><code class="xref py py-obj docutils literal notranslate"><span class="pre">add_layer</span></code></a>(layer)</p></td>
 <td><p>Add a layer to the viewer.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.Viewer.add_points" title="napari.Viewer.add_points"><code class="xref py py-obj docutils literal notranslate"><span class="pre">add_points</span></code></a>([data, ndim, affine, ...])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.Viewer.add_points" title="napari.Viewer.add_points"><code class="xref py py-obj docutils literal notranslate"><span class="pre">add_points</span></code></a>([data, ndim, affine, ...])</p></td>
 <td><p>Add a Points layer to the layer list.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.Viewer.add_shapes" title="napari.Viewer.add_shapes"><code class="xref py py-obj docutils literal notranslate"><span class="pre">add_shapes</span></code></a>([data, ndim, affine, ...])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.Viewer.add_shapes" title="napari.Viewer.add_shapes"><code class="xref py py-obj docutils literal notranslate"><span class="pre">add_shapes</span></code></a>([data, ndim, affine, ...])</p></td>
 <td><p>Add a Shapes layer to the layer list.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.Viewer.add_surface" title="napari.Viewer.add_surface"><code class="xref py py-obj docutils literal notranslate"><span class="pre">add_surface</span></code></a>(data, *[, affine, axis_labels, ...])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.Viewer.add_surface" title="napari.Viewer.add_surface"><code class="xref py py-obj docutils literal notranslate"><span class="pre">add_surface</span></code></a>(data, *[, affine, axis_labels, ...])</p></td>
 <td><p>Add a Surface layer to the layer list.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.Viewer.add_tracks" title="napari.Viewer.add_tracks"><code class="xref py py-obj docutils literal notranslate"><span class="pre">add_tracks</span></code></a>(data, *[, affine, axis_labels, ...])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.Viewer.add_tracks" title="napari.Viewer.add_tracks"><code class="xref py py-obj docutils literal notranslate"><span class="pre">add_tracks</span></code></a>(data, *[, affine, axis_labels, ...])</p></td>
 <td><p>Add a Tracks layer to the layer list.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.Viewer.add_vectors" title="napari.Viewer.add_vectors"><code class="xref py py-obj docutils literal notranslate"><span class="pre">add_vectors</span></code></a>([data, affine, axis_labels, ...])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.Viewer.add_vectors" title="napari.Viewer.add_vectors"><code class="xref py py-obj docutils literal notranslate"><span class="pre">add_vectors</span></code></a>([data, affine, axis_labels, ...])</p></td>
 <td><p>Add a Vectors layer to the layer list.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.Viewer.bind_key" title="napari.Viewer.bind_key"><code class="xref py py-obj docutils literal notranslate"><span class="pre">bind_key</span></code></a>(key_bind[, func, overwrite])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.Viewer.bind_key" title="napari.Viewer.bind_key"><code class="xref py py-obj docutils literal notranslate"><span class="pre">bind_key</span></code></a>(key_bind[, func, overwrite])</p></td>
 <td><p>Bind a key combination to a keymap.</p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.Viewer.close" title="napari.Viewer.close"><code class="xref py py-obj docutils literal notranslate"><span class="pre">close</span></code></a>()</p></td>
@@ -663,7 +663,7 @@ ndisplay is 2 or 3. By default None</p></li>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.Viewer.construct" title="napari.Viewer.construct"><code class="xref py py-obj docutils literal notranslate"><span class="pre">construct</span></code></a>([_fields_set])</p></td>
 <td><p>Creates a new model setting __dict__ and __fields_set__ from trusted or pre-validated data.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.Viewer.copy" title="napari.Viewer.copy"><code class="xref py py-obj docutils literal notranslate"><span class="pre">copy</span></code></a>(*[, include, exclude, update, deep])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.Viewer.copy" title="napari.Viewer.copy"><code class="xref py py-obj docutils literal notranslate"><span class="pre">copy</span></code></a>(*[, include, exclude, update, deep])</p></td>
 <td><p>Duplicate a model, optionally choose which fields to include, exclude and change.</p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.Viewer.dict" title="napari.Viewer.dict"><code class="xref py py-obj docutils literal notranslate"><span class="pre">dict</span></code></a>(**kwargs)</p></td>
@@ -672,13 +672,13 @@ ndisplay is 2 or 3. By default None</p></li>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.Viewer.enums_as_values" title="napari.Viewer.enums_as_values"><code class="xref py py-obj docutils literal notranslate"><span class="pre">enums_as_values</span></code></a>([as_values])</p></td>
 <td><p>Temporarily override how enums are retrieved.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.Viewer.export_figure" title="napari.Viewer.export_figure"><code class="xref py py-obj docutils literal notranslate"><span class="pre">export_figure</span></code></a>([path, scale_factor, flash])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.Viewer.export_figure" title="napari.Viewer.export_figure"><code class="xref py py-obj docutils literal notranslate"><span class="pre">export_figure</span></code></a>([path, scale_factor, flash])</p></td>
 <td><p>Export an image of the full extent of the displayed layer data.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.Viewer.export_rois" title="napari.Viewer.export_rois"><code class="xref py py-obj docutils literal notranslate"><span class="pre">export_rois</span></code></a>(rois[, paths, scale])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.Viewer.export_rois" title="napari.Viewer.export_rois"><code class="xref py py-obj docutils literal notranslate"><span class="pre">export_rois</span></code></a>(rois[, paths, scale])</p></td>
 <td><p>Export the given rectangular rois to specified file paths.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.Viewer.fit_to_view" title="napari.Viewer.fit_to_view"><code class="xref py py-obj docutils literal notranslate"><span class="pre">fit_to_view</span></code></a>(*[, margin])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.Viewer.fit_to_view" title="napari.Viewer.fit_to_view"><code class="xref py py-obj docutils literal notranslate"><span class="pre">fit_to_view</span></code></a>(*[, margin])</p></td>
 <td><p>Fit the current data view to the canvas.</p></td>
 </tr>
 <tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">from_orm</span></code>(obj)</p></td>
@@ -687,40 +687,40 @@ ndisplay is 2 or 3. By default None</p></li>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.Viewer.json" title="napari.Viewer.json"><code class="xref py py-obj docutils literal notranslate"><span class="pre">json</span></code></a>(**kwargs)</p></td>
 <td><p>Serialize to json.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.Viewer.open" title="napari.Viewer.open"><code class="xref py py-obj docutils literal notranslate"><span class="pre">open</span></code></a>(path, *[, stack, plugin, layer_type])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.Viewer.open" title="napari.Viewer.open"><code class="xref py py-obj docutils literal notranslate"><span class="pre">open</span></code></a>(path, *[, stack, plugin, layer_type])</p></td>
 <td><p>Open a path or list of paths with plugins, and add layers to viewer.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.Viewer.open_sample" title="napari.Viewer.open_sample"><code class="xref py py-obj docutils literal notranslate"><span class="pre">open_sample</span></code></a>(plugin, sample[, reader_plugin])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.Viewer.open_sample" title="napari.Viewer.open_sample"><code class="xref py py-obj docutils literal notranslate"><span class="pre">open_sample</span></code></a>(plugin, sample[, reader_plugin])</p></td>
 <td><p>Open <cite>sample</cite> from <cite>plugin</cite> and add it to the viewer.</p></td>
 </tr>
-<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">parse_file</span></code>(path, *[, content_type, ...])</p></td>
+<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">parse_file</span></code>(path, *[, content_type, ...])</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">parse_obj</span></code>(obj)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">parse_raw</span></code>(b, *[, content_type, encoding, ...])</p></td>
+<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">parse_raw</span></code>(b, *[, content_type, encoding, ...])</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.Viewer.reset" title="napari.Viewer.reset"><code class="xref py py-obj docutils literal notranslate"><span class="pre">reset</span></code></a>()</p></td>
 <td><p>Reset the state of the model to default values.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.Viewer.reset_view" title="napari.Viewer.reset_view"><code class="xref py py-obj docutils literal notranslate"><span class="pre">reset_view</span></code></a>(*[, margin, reset_camera_angle])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.Viewer.reset_view" title="napari.Viewer.reset_view"><code class="xref py py-obj docutils literal notranslate"><span class="pre">reset_view</span></code></a>(*[, margin, reset_camera_angle])</p></td>
 <td><p>Reset the camera and fit the current layers to the canvas.</p></td>
 </tr>
-<tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">schema</span></code>([by_alias, ref_template])</p></td>
+<tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">schema</span></code>([by_alias, ref_template])</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">schema_json</span></code>(*[, by_alias, ref_template])</p></td>
+<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">schema_json</span></code>(*[, by_alias, ref_template])</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.Viewer.screenshot" title="napari.Viewer.screenshot"><code class="xref py py-obj docutils literal notranslate"><span class="pre">screenshot</span></code></a>([path, size, scale, canvas_only, ...])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.Viewer.screenshot" title="napari.Viewer.screenshot"><code class="xref py py-obj docutils literal notranslate"><span class="pre">screenshot</span></code></a>([path, size, scale, canvas_only, ...])</p></td>
 <td><p>Take currently displayed screen and convert to an image array.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.Viewer.show" title="napari.Viewer.show"><code class="xref py py-obj docutils literal notranslate"><span class="pre">show</span></code></a>(*[, block])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.Viewer.show" title="napari.Viewer.show"><code class="xref py py-obj docutils literal notranslate"><span class="pre">show</span></code></a>(*[, block])</p></td>
 <td><p>Resize, show, and raise the viewer window.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.Viewer.update" title="napari.Viewer.update"><code class="xref py py-obj docutils literal notranslate"><span class="pre">update</span></code></a>(values[, recurse])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.Viewer.update" title="napari.Viewer.update"><code class="xref py py-obj docutils literal notranslate"><span class="pre">update</span></code></a>(values[, recurse])</p></td>
 <td><p>Update a model in place.</p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.Viewer.update_console" title="napari.Viewer.update_console"><code class="xref py py-obj docutils literal notranslate"><span class="pre">update_console</span></code></a>(variables)</p></td>

--- a/0.6.5/api/napari.components.Camera.html
+++ b/0.6.5/api/napari.components.Camera.html
@@ -67,8 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
@@ -684,19 +684,19 @@ sets of Euler angles may lead to the same view.</p>
 <p class="rubric">Methods</p>
 <div class="pst-scrollable-table-container"><table class="autosummary longtable table autosummary">
 <tbody>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.components.Camera.calculate_nd_up_direction" title="napari.components.Camera.calculate_nd_up_direction"><code class="xref py py-obj docutils literal notranslate"><span class="pre">calculate_nd_up_direction</span></code></a>(ndim, dims_displayed)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.components.Camera.calculate_nd_up_direction" title="napari.components.Camera.calculate_nd_up_direction"><code class="xref py py-obj docutils literal notranslate"><span class="pre">calculate_nd_up_direction</span></code></a>(ndim, dims_displayed)</p></td>
 <td><p>Calculate the nD up direction vector of the camera.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.components.Camera.calculate_nd_view_direction" title="napari.components.Camera.calculate_nd_view_direction"><code class="xref py py-obj docutils literal notranslate"><span class="pre">calculate_nd_view_direction</span></code></a>(ndim, dims_displayed)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.components.Camera.calculate_nd_view_direction" title="napari.components.Camera.calculate_nd_view_direction"><code class="xref py py-obj docutils literal notranslate"><span class="pre">calculate_nd_view_direction</span></code></a>(ndim, dims_displayed)</p></td>
 <td><p>Calculate the nD view direction vector of the camera.</p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.components.Camera.construct" title="napari.components.Camera.construct"><code class="xref py py-obj docutils literal notranslate"><span class="pre">construct</span></code></a>([_fields_set])</p></td>
 <td><p>Creates a new model setting __dict__ and __fields_set__ from trusted or pre-validated data.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.components.Camera.copy" title="napari.components.Camera.copy"><code class="xref py py-obj docutils literal notranslate"><span class="pre">copy</span></code></a>(*[, include, exclude, update, deep])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.components.Camera.copy" title="napari.components.Camera.copy"><code class="xref py py-obj docutils literal notranslate"><span class="pre">copy</span></code></a>(*[, include, exclude, update, deep])</p></td>
 <td><p>Duplicate a model, optionally choose which fields to include, exclude and change.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.components.Camera.dict" title="napari.components.Camera.dict"><code class="xref py py-obj docutils literal notranslate"><span class="pre">dict</span></code></a>(*[, include, exclude, by_alias, ...])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.components.Camera.dict" title="napari.components.Camera.dict"><code class="xref py py-obj docutils literal notranslate"><span class="pre">dict</span></code></a>(*[, include, exclude, by_alias, ...])</p></td>
 <td><p>Generate a dictionary representation of the model, optionally specifying which fields to include or exclude.</p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.components.Camera.enums_as_values" title="napari.components.Camera.enums_as_values"><code class="xref py py-obj docutils literal notranslate"><span class="pre">enums_as_values</span></code></a>([as_values])</p></td>
@@ -705,31 +705,31 @@ sets of Euler angles may lead to the same view.</p>
 <tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">from_orm</span></code>(obj)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.components.Camera.json" title="napari.components.Camera.json"><code class="xref py py-obj docutils literal notranslate"><span class="pre">json</span></code></a>(*[, include, exclude, by_alias, ...])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.components.Camera.json" title="napari.components.Camera.json"><code class="xref py py-obj docutils literal notranslate"><span class="pre">json</span></code></a>(*[, include, exclude, by_alias, ...])</p></td>
 <td><p>Generate a JSON representation of the model, <cite>include</cite> and <cite>exclude</cite> arguments as per <cite>dict()</cite>.</p></td>
 </tr>
-<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">parse_file</span></code>(path, *[, content_type, ...])</p></td>
+<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">parse_file</span></code>(path, *[, content_type, ...])</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">parse_obj</span></code>(obj)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">parse_raw</span></code>(b, *[, content_type, encoding, ...])</p></td>
+<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">parse_raw</span></code>(b, *[, content_type, encoding, ...])</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.components.Camera.reset" title="napari.components.Camera.reset"><code class="xref py py-obj docutils literal notranslate"><span class="pre">reset</span></code></a>()</p></td>
 <td><p>Reset the state of the model to default values.</p></td>
 </tr>
-<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">schema</span></code>([by_alias, ref_template])</p></td>
+<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">schema</span></code>([by_alias, ref_template])</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">schema_json</span></code>(*[, by_alias, ref_template])</p></td>
+<tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">schema_json</span></code>(*[, by_alias, ref_template])</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.components.Camera.set_view_direction" title="napari.components.Camera.set_view_direction"><code class="xref py py-obj docutils literal notranslate"><span class="pre">set_view_direction</span></code></a>(view_direction[, ...])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.components.Camera.set_view_direction" title="napari.components.Camera.set_view_direction"><code class="xref py py-obj docutils literal notranslate"><span class="pre">set_view_direction</span></code></a>(view_direction[, ...])</p></td>
 <td><p>Set camera angles from direction vectors.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.components.Camera.update" title="napari.components.Camera.update"><code class="xref py py-obj docutils literal notranslate"><span class="pre">update</span></code></a>(values[, recurse])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.components.Camera.update" title="napari.components.Camera.update"><code class="xref py py-obj docutils literal notranslate"><span class="pre">update</span></code></a>(values[, recurse])</p></td>
 <td><p>Update a model in place.</p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.components.Camera.update_forward_refs" title="napari.components.Camera.update_forward_refs"><code class="xref py py-obj docutils literal notranslate"><span class="pre">update_forward_refs</span></code></a>(**localns)</p></td>

--- a/0.6.5/api/napari.components.Dims.html
+++ b/0.6.5/api/napari.components.Dims.html
@@ -67,8 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
@@ -815,10 +815,10 @@ the <code class="docutils literal notranslate"><span class="pre">range</span></c
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.components.Dims.construct" title="napari.components.Dims.construct"><code class="xref py py-obj docutils literal notranslate"><span class="pre">construct</span></code></a>([_fields_set])</p></td>
 <td><p>Creates a new model setting __dict__ and __fields_set__ from trusted or pre-validated data.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.components.Dims.copy" title="napari.components.Dims.copy"><code class="xref py py-obj docutils literal notranslate"><span class="pre">copy</span></code></a>(*[, include, exclude, update, deep])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.components.Dims.copy" title="napari.components.Dims.copy"><code class="xref py py-obj docutils literal notranslate"><span class="pre">copy</span></code></a>(*[, include, exclude, update, deep])</p></td>
 <td><p>Duplicate a model, optionally choose which fields to include, exclude and change.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.components.Dims.dict" title="napari.components.Dims.dict"><code class="xref py py-obj docutils literal notranslate"><span class="pre">dict</span></code></a>(*[, include, exclude, by_alias, ...])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.components.Dims.dict" title="napari.components.Dims.dict"><code class="xref py py-obj docutils literal notranslate"><span class="pre">dict</span></code></a>(*[, include, exclude, by_alias, ...])</p></td>
 <td><p>Generate a dictionary representation of the model, optionally specifying which fields to include or exclude.</p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.components.Dims.enums_as_values" title="napari.components.Dims.enums_as_values"><code class="xref py py-obj docutils literal notranslate"><span class="pre">enums_as_values</span></code></a>([as_values])</p></td>
@@ -827,16 +827,16 @@ the <code class="docutils literal notranslate"><span class="pre">range</span></c
 <tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">from_orm</span></code>(obj)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.components.Dims.json" title="napari.components.Dims.json"><code class="xref py py-obj docutils literal notranslate"><span class="pre">json</span></code></a>(*[, include, exclude, by_alias, ...])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.components.Dims.json" title="napari.components.Dims.json"><code class="xref py py-obj docutils literal notranslate"><span class="pre">json</span></code></a>(*[, include, exclude, by_alias, ...])</p></td>
 <td><p>Generate a JSON representation of the model, <cite>include</cite> and <cite>exclude</cite> arguments as per <cite>dict()</cite>.</p></td>
 </tr>
-<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">parse_file</span></code>(path, *[, content_type, ...])</p></td>
+<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">parse_file</span></code>(path, *[, content_type, ...])</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">parse_obj</span></code>(obj)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">parse_raw</span></code>(b, *[, content_type, encoding, ...])</p></td>
+<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">parse_raw</span></code>(b, *[, content_type, encoding, ...])</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.components.Dims.reset" title="napari.components.Dims.reset"><code class="xref py py-obj docutils literal notranslate"><span class="pre">reset</span></code></a>()</p></td>
@@ -845,28 +845,28 @@ the <code class="docutils literal notranslate"><span class="pre">range</span></c
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.components.Dims.roll" title="napari.components.Dims.roll"><code class="xref py py-obj docutils literal notranslate"><span class="pre">roll</span></code></a>()</p></td>
 <td><p>Roll order of dimensions for display.</p></td>
 </tr>
-<tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">schema</span></code>([by_alias, ref_template])</p></td>
+<tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">schema</span></code>([by_alias, ref_template])</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">schema_json</span></code>(*[, by_alias, ref_template])</p></td>
+<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">schema_json</span></code>(*[, by_alias, ref_template])</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.components.Dims.set_axis_label" title="napari.components.Dims.set_axis_label"><code class="xref py py-obj docutils literal notranslate"><span class="pre">set_axis_label</span></code></a>(axis, label)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.components.Dims.set_axis_label" title="napari.components.Dims.set_axis_label"><code class="xref py py-obj docutils literal notranslate"><span class="pre">set_axis_label</span></code></a>(axis, label)</p></td>
 <td><p>Sets new axis labels for the given axes.</p></td>
 </tr>
-<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">set_current_step</span></code>(axis, value)</p></td>
+<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">set_current_step</span></code>(axis, value)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.components.Dims.set_point" title="napari.components.Dims.set_point"><code class="xref py py-obj docutils literal notranslate"><span class="pre">set_point</span></code></a>(axis, value)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.components.Dims.set_point" title="napari.components.Dims.set_point"><code class="xref py py-obj docutils literal notranslate"><span class="pre">set_point</span></code></a>(axis, value)</p></td>
 <td><p>Sets point to slice dimension in world coordinates.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.components.Dims.set_range" title="napari.components.Dims.set_range"><code class="xref py py-obj docutils literal notranslate"><span class="pre">set_range</span></code></a>(axis, _range)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.components.Dims.set_range" title="napari.components.Dims.set_range"><code class="xref py py-obj docutils literal notranslate"><span class="pre">set_range</span></code></a>(axis, _range)</p></td>
 <td><p>Sets ranges (min, max, step) for the given dimensions.</p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.components.Dims.transpose" title="napari.components.Dims.transpose"><code class="xref py py-obj docutils literal notranslate"><span class="pre">transpose</span></code></a>()</p></td>
 <td><p>Transpose displayed dimensions.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.components.Dims.update" title="napari.components.Dims.update"><code class="xref py py-obj docutils literal notranslate"><span class="pre">update</span></code></a>(values[, recurse])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.components.Dims.update" title="napari.components.Dims.update"><code class="xref py py-obj docutils literal notranslate"><span class="pre">update</span></code></a>(values[, recurse])</p></td>
 <td><p>Update a model in place.</p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.components.Dims.update_forward_refs" title="napari.components.Dims.update_forward_refs"><code class="xref py py-obj docutils literal notranslate"><span class="pre">update_forward_refs</span></code></a>(**localns)</p></td>

--- a/0.6.5/api/napari.components.LayerList.html
+++ b/0.6.5/api/napari.components.LayerList.html
@@ -67,8 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
@@ -695,22 +695,22 @@ position <code class="docutils literal notranslate"><span class="pre">idx</span>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.components.LayerList.get_extent" title="napari.components.LayerList.get_extent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_extent</span></code></a>(layers)</p></td>
 <td><p>Return extent for a given layer list.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.components.LayerList.index" title="napari.components.LayerList.index"><code class="xref py py-obj docutils literal notranslate"><span class="pre">index</span></code></a>(value[, start, stop])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.components.LayerList.index" title="napari.components.LayerList.index"><code class="xref py py-obj docutils literal notranslate"><span class="pre">index</span></code></a>(value[, start, stop])</p></td>
 <td><p>Return first index of value.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.components.LayerList.insert" title="napari.components.LayerList.insert"><code class="xref py py-obj docutils literal notranslate"><span class="pre">insert</span></code></a>(index, value)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.components.LayerList.insert" title="napari.components.LayerList.insert"><code class="xref py py-obj docutils literal notranslate"><span class="pre">insert</span></code></a>(index, value)</p></td>
 <td><p>Insert <code class="docutils literal notranslate"><span class="pre">value</span></code> before index.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.components.LayerList.link_layers" title="napari.components.LayerList.link_layers"><code class="xref py py-obj docutils literal notranslate"><span class="pre">link_layers</span></code></a>([layers, attributes])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.components.LayerList.link_layers" title="napari.components.LayerList.link_layers"><code class="xref py py-obj docutils literal notranslate"><span class="pre">link_layers</span></code></a>([layers, attributes])</p></td>
 <td><p>Links the selected layers.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.components.LayerList.move" title="napari.components.LayerList.move"><code class="xref py py-obj docutils literal notranslate"><span class="pre">move</span></code></a>(src_index[, dest_index])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.components.LayerList.move" title="napari.components.LayerList.move"><code class="xref py py-obj docutils literal notranslate"><span class="pre">move</span></code></a>(src_index[, dest_index])</p></td>
 <td><p>Insert object at <code class="docutils literal notranslate"><span class="pre">src_index</span></code> before <code class="docutils literal notranslate"><span class="pre">dest_index</span></code>.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.components.LayerList.move_multiple" title="napari.components.LayerList.move_multiple"><code class="xref py py-obj docutils literal notranslate"><span class="pre">move_multiple</span></code></a>(sources[, dest_index])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.components.LayerList.move_multiple" title="napari.components.LayerList.move_multiple"><code class="xref py py-obj docutils literal notranslate"><span class="pre">move_multiple</span></code></a>(sources[, dest_index])</p></td>
 <td><p>Move a batch of <cite>sources</cite> indices, to a single destination.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.components.LayerList.move_selected" title="napari.components.LayerList.move_selected"><code class="xref py py-obj docutils literal notranslate"><span class="pre">move_selected</span></code></a>(index, insert)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.components.LayerList.move_selected" title="napari.components.LayerList.move_selected"><code class="xref py py-obj docutils literal notranslate"><span class="pre">move_selected</span></code></a>(index, insert)</p></td>
 <td><p>Reorder list by moving the item at index and inserting it at the insert index.</p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.components.LayerList.pop" title="napari.components.LayerList.pop"><code class="xref py py-obj docutils literal notranslate"><span class="pre">pop</span></code></a>([index])</p></td>
@@ -725,13 +725,13 @@ position <code class="docutils literal notranslate"><span class="pre">idx</span>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.components.LayerList.reverse" title="napari.components.LayerList.reverse"><code class="xref py py-obj docutils literal notranslate"><span class="pre">reverse</span></code></a>()</p></td>
 <td><p>Reverse list <em>IN PLACE</em>.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.components.LayerList.save" title="napari.components.LayerList.save"><code class="xref py py-obj docutils literal notranslate"><span class="pre">save</span></code></a>(path, *[, selected, plugin, _writer])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.components.LayerList.save" title="napari.components.LayerList.save"><code class="xref py py-obj docutils literal notranslate"><span class="pre">save</span></code></a>(path, *[, selected, plugin, _writer])</p></td>
 <td><p>Save all or only selected layers to a path using writer plugins.</p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.components.LayerList.select_all" title="napari.components.LayerList.select_all"><code class="xref py py-obj docutils literal notranslate"><span class="pre">select_all</span></code></a>()</p></td>
 <td><p>Select all items in the list.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.components.LayerList.select_next" title="napari.components.LayerList.select_next"><code class="xref py py-obj docutils literal notranslate"><span class="pre">select_next</span></code></a>([step, shift])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.components.LayerList.select_next" title="napari.components.LayerList.select_next"><code class="xref py py-obj docutils literal notranslate"><span class="pre">select_next</span></code></a>([step, shift])</p></td>
 <td><p>Selects next item from list.</p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.components.LayerList.select_previous" title="napari.components.LayerList.select_previous"><code class="xref py py-obj docutils literal notranslate"><span class="pre">select_previous</span></code></a>([shift])</p></td>
@@ -740,7 +740,7 @@ position <code class="docutils literal notranslate"><span class="pre">idx</span>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.components.LayerList.toggle_selected_visibility" title="napari.components.LayerList.toggle_selected_visibility"><code class="xref py py-obj docutils literal notranslate"><span class="pre">toggle_selected_visibility</span></code></a>()</p></td>
 <td><p>Toggle visibility of selected layers</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.components.LayerList.unlink_layers" title="napari.components.LayerList.unlink_layers"><code class="xref py py-obj docutils literal notranslate"><span class="pre">unlink_layers</span></code></a>([layers, attributes])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.components.LayerList.unlink_layers" title="napari.components.LayerList.unlink_layers"><code class="xref py py-obj docutils literal notranslate"><span class="pre">unlink_layers</span></code></a>([layers, attributes])</p></td>
 <td><p>Unlinks previously linked layers.</p></td>
 </tr>
 </tbody>

--- a/0.6.5/api/napari.components.ViewerModel.html
+++ b/0.6.5/api/napari.components.ViewerModel.html
@@ -67,8 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
@@ -793,37 +793,37 @@ objects.</p>
 <p class="rubric">Methods</p>
 <div class="pst-scrollable-table-container"><table class="autosummary longtable table autosummary">
 <tbody>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.components.ViewerModel.add_image" title="napari.components.ViewerModel.add_image"><code class="xref py py-obj docutils literal notranslate"><span class="pre">add_image</span></code></a>([data, channel_axis, affine, ...])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.components.ViewerModel.add_image" title="napari.components.ViewerModel.add_image"><code class="xref py py-obj docutils literal notranslate"><span class="pre">add_image</span></code></a>([data, channel_axis, affine, ...])</p></td>
 <td><p>Add one or more Image layers to the layer list.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.components.ViewerModel.add_labels" title="napari.components.ViewerModel.add_labels"><code class="xref py py-obj docutils literal notranslate"><span class="pre">add_labels</span></code></a>(data, *[, affine, axis_labels, ...])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.components.ViewerModel.add_labels" title="napari.components.ViewerModel.add_labels"><code class="xref py py-obj docutils literal notranslate"><span class="pre">add_labels</span></code></a>(data, *[, affine, axis_labels, ...])</p></td>
 <td><p>Add a Labels layer to the layer list.</p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.components.ViewerModel.add_layer" title="napari.components.ViewerModel.add_layer"><code class="xref py py-obj docutils literal notranslate"><span class="pre">add_layer</span></code></a>(layer)</p></td>
 <td><p>Add a layer to the viewer.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.components.ViewerModel.add_points" title="napari.components.ViewerModel.add_points"><code class="xref py py-obj docutils literal notranslate"><span class="pre">add_points</span></code></a>([data, ndim, affine, ...])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.components.ViewerModel.add_points" title="napari.components.ViewerModel.add_points"><code class="xref py py-obj docutils literal notranslate"><span class="pre">add_points</span></code></a>([data, ndim, affine, ...])</p></td>
 <td><p>Add a Points layer to the layer list.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.components.ViewerModel.add_shapes" title="napari.components.ViewerModel.add_shapes"><code class="xref py py-obj docutils literal notranslate"><span class="pre">add_shapes</span></code></a>([data, ndim, affine, ...])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.components.ViewerModel.add_shapes" title="napari.components.ViewerModel.add_shapes"><code class="xref py py-obj docutils literal notranslate"><span class="pre">add_shapes</span></code></a>([data, ndim, affine, ...])</p></td>
 <td><p>Add a Shapes layer to the layer list.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.components.ViewerModel.add_surface" title="napari.components.ViewerModel.add_surface"><code class="xref py py-obj docutils literal notranslate"><span class="pre">add_surface</span></code></a>(data, *[, affine, axis_labels, ...])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.components.ViewerModel.add_surface" title="napari.components.ViewerModel.add_surface"><code class="xref py py-obj docutils literal notranslate"><span class="pre">add_surface</span></code></a>(data, *[, affine, axis_labels, ...])</p></td>
 <td><p>Add a Surface layer to the layer list.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.components.ViewerModel.add_tracks" title="napari.components.ViewerModel.add_tracks"><code class="xref py py-obj docutils literal notranslate"><span class="pre">add_tracks</span></code></a>(data, *[, affine, axis_labels, ...])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.components.ViewerModel.add_tracks" title="napari.components.ViewerModel.add_tracks"><code class="xref py py-obj docutils literal notranslate"><span class="pre">add_tracks</span></code></a>(data, *[, affine, axis_labels, ...])</p></td>
 <td><p>Add a Tracks layer to the layer list.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.components.ViewerModel.add_vectors" title="napari.components.ViewerModel.add_vectors"><code class="xref py py-obj docutils literal notranslate"><span class="pre">add_vectors</span></code></a>([data, affine, axis_labels, ...])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.components.ViewerModel.add_vectors" title="napari.components.ViewerModel.add_vectors"><code class="xref py py-obj docutils literal notranslate"><span class="pre">add_vectors</span></code></a>([data, affine, axis_labels, ...])</p></td>
 <td><p>Add a Vectors layer to the layer list.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.components.ViewerModel.bind_key" title="napari.components.ViewerModel.bind_key"><code class="xref py py-obj docutils literal notranslate"><span class="pre">bind_key</span></code></a>(key_bind[, func, overwrite])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.components.ViewerModel.bind_key" title="napari.components.ViewerModel.bind_key"><code class="xref py py-obj docutils literal notranslate"><span class="pre">bind_key</span></code></a>(key_bind[, func, overwrite])</p></td>
 <td><p>Bind a key combination to a keymap.</p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.components.ViewerModel.construct" title="napari.components.ViewerModel.construct"><code class="xref py py-obj docutils literal notranslate"><span class="pre">construct</span></code></a>([_fields_set])</p></td>
 <td><p>Creates a new model setting __dict__ and __fields_set__ from trusted or pre-validated data.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.components.ViewerModel.copy" title="napari.components.ViewerModel.copy"><code class="xref py py-obj docutils literal notranslate"><span class="pre">copy</span></code></a>(*[, include, exclude, update, deep])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.components.ViewerModel.copy" title="napari.components.ViewerModel.copy"><code class="xref py py-obj docutils literal notranslate"><span class="pre">copy</span></code></a>(*[, include, exclude, update, deep])</p></td>
 <td><p>Duplicate a model, optionally choose which fields to include, exclude and change.</p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.components.ViewerModel.dict" title="napari.components.ViewerModel.dict"><code class="xref py py-obj docutils literal notranslate"><span class="pre">dict</span></code></a>(**kwargs)</p></td>
@@ -832,7 +832,7 @@ objects.</p>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.components.ViewerModel.enums_as_values" title="napari.components.ViewerModel.enums_as_values"><code class="xref py py-obj docutils literal notranslate"><span class="pre">enums_as_values</span></code></a>([as_values])</p></td>
 <td><p>Temporarily override how enums are retrieved.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.components.ViewerModel.fit_to_view" title="napari.components.ViewerModel.fit_to_view"><code class="xref py py-obj docutils literal notranslate"><span class="pre">fit_to_view</span></code></a>(*[, margin])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.components.ViewerModel.fit_to_view" title="napari.components.ViewerModel.fit_to_view"><code class="xref py py-obj docutils literal notranslate"><span class="pre">fit_to_view</span></code></a>(*[, margin])</p></td>
 <td><p>Fit the current data view to the canvas.</p></td>
 </tr>
 <tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">from_orm</span></code>(obj)</p></td>
@@ -841,34 +841,34 @@ objects.</p>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.components.ViewerModel.json" title="napari.components.ViewerModel.json"><code class="xref py py-obj docutils literal notranslate"><span class="pre">json</span></code></a>(**kwargs)</p></td>
 <td><p>Serialize to json.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.components.ViewerModel.open" title="napari.components.ViewerModel.open"><code class="xref py py-obj docutils literal notranslate"><span class="pre">open</span></code></a>(path, *[, stack, plugin, layer_type])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.components.ViewerModel.open" title="napari.components.ViewerModel.open"><code class="xref py py-obj docutils literal notranslate"><span class="pre">open</span></code></a>(path, *[, stack, plugin, layer_type])</p></td>
 <td><p>Open a path or list of paths with plugins, and add layers to viewer.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.components.ViewerModel.open_sample" title="napari.components.ViewerModel.open_sample"><code class="xref py py-obj docutils literal notranslate"><span class="pre">open_sample</span></code></a>(plugin, sample[, reader_plugin])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.components.ViewerModel.open_sample" title="napari.components.ViewerModel.open_sample"><code class="xref py py-obj docutils literal notranslate"><span class="pre">open_sample</span></code></a>(plugin, sample[, reader_plugin])</p></td>
 <td><p>Open <cite>sample</cite> from <cite>plugin</cite> and add it to the viewer.</p></td>
 </tr>
-<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">parse_file</span></code>(path, *[, content_type, ...])</p></td>
+<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">parse_file</span></code>(path, *[, content_type, ...])</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">parse_obj</span></code>(obj)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">parse_raw</span></code>(b, *[, content_type, encoding, ...])</p></td>
+<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">parse_raw</span></code>(b, *[, content_type, encoding, ...])</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.components.ViewerModel.reset" title="napari.components.ViewerModel.reset"><code class="xref py py-obj docutils literal notranslate"><span class="pre">reset</span></code></a>()</p></td>
 <td><p>Reset the state of the model to default values.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.components.ViewerModel.reset_view" title="napari.components.ViewerModel.reset_view"><code class="xref py py-obj docutils literal notranslate"><span class="pre">reset_view</span></code></a>(*[, margin, reset_camera_angle])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.components.ViewerModel.reset_view" title="napari.components.ViewerModel.reset_view"><code class="xref py py-obj docutils literal notranslate"><span class="pre">reset_view</span></code></a>(*[, margin, reset_camera_angle])</p></td>
 <td><p>Reset the camera and fit the current layers to the canvas.</p></td>
 </tr>
-<tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">schema</span></code>([by_alias, ref_template])</p></td>
+<tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">schema</span></code>([by_alias, ref_template])</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">schema_json</span></code>(*[, by_alias, ref_template])</p></td>
+<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">schema_json</span></code>(*[, by_alias, ref_template])</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.components.ViewerModel.update" title="napari.components.ViewerModel.update"><code class="xref py py-obj docutils literal notranslate"><span class="pre">update</span></code></a>(values[, recurse])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.components.ViewerModel.update" title="napari.components.ViewerModel.update"><code class="xref py py-obj docutils literal notranslate"><span class="pre">update</span></code></a>(values[, recurse])</p></td>
 <td><p>Update a model in place.</p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.components.ViewerModel.update_forward_refs" title="napari.components.ViewerModel.update_forward_refs"><code class="xref py py-obj docutils literal notranslate"><span class="pre">update_forward_refs</span></code></a>(**localns)</p></td>

--- a/0.6.5/api/napari.components.html
+++ b/0.6.5/api/napari.components.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/api/napari.html
+++ b/0.6.5/api/napari.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/api/napari.layers.Image.html
+++ b/0.6.5/api/napari.layers.Image.html
@@ -67,8 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
@@ -963,37 +963,37 @@ can be multidimensional for RGB or RGBA images if multidimensional is
 <tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">as_layer_data_tuple</span></code>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Image.bind_key" title="napari.layers.Image.bind_key"><code class="xref py py-obj docutils literal notranslate"><span class="pre">bind_key</span></code></a>(key_bind[, func, overwrite])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Image.bind_key" title="napari.layers.Image.bind_key"><code class="xref py py-obj docutils literal notranslate"><span class="pre">bind_key</span></code></a>(key_bind[, func, overwrite])</p></td>
 <td><p>Bind a key combination to a keymap.</p></td>
 </tr>
 <tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">block_update_properties</span></code>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Image.click_plane_from_click_data" title="napari.layers.Image.click_plane_from_click_data"><code class="xref py py-obj docutils literal notranslate"><span class="pre">click_plane_from_click_data</span></code></a>(click_position, ...)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Image.click_plane_from_click_data" title="napari.layers.Image.click_plane_from_click_data"><code class="xref py py-obj docutils literal notranslate"><span class="pre">click_plane_from_click_data</span></code></a>(click_position, ...)</p></td>
 <td><p>Calculate a (point, normal) plane parallel to the canvas in data coordinates, centered on the centre of rotation of the camera.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Image.create" title="napari.layers.Image.create"><code class="xref py py-obj docutils literal notranslate"><span class="pre">create</span></code></a>(data[, meta, layer_type])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Image.create" title="napari.layers.Image.create"><code class="xref py py-obj docutils literal notranslate"><span class="pre">create</span></code></a>(data[, meta, layer_type])</p></td>
 <td><p>Create layer from <cite>data</cite> of type <cite>layer_type</cite>.</p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Image.data_to_world" title="napari.layers.Image.data_to_world"><code class="xref py py-obj docutils literal notranslate"><span class="pre">data_to_world</span></code></a>(position)</p></td>
 <td><p>Convert from data coordinates to world coordinates.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Image.get_ray_intersections" title="napari.layers.Image.get_ray_intersections"><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_ray_intersections</span></code></a>(position, ...[, world])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Image.get_ray_intersections" title="napari.layers.Image.get_ray_intersections"><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_ray_intersections</span></code></a>(position, ...[, world])</p></td>
 <td><p>Get the start and end point for the ray extending from a point through the data bounding box.</p></td>
 </tr>
 <tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_source_str</span></code>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Image.get_status" title="napari.layers.Image.get_status"><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_status</span></code></a>([position, view_direction, ...])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Image.get_status" title="napari.layers.Image.get_status"><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_status</span></code></a>([position, view_direction, ...])</p></td>
 <td><p>Status message information of the data at a coordinate position.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Image.get_value" title="napari.layers.Image.get_value"><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_value</span></code></a>(position, *[, view_direction, ...])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Image.get_value" title="napari.layers.Image.get_value"><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_value</span></code></a>(position, *[, view_direction, ...])</p></td>
 <td><p>Value of the data at a position.</p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Image.projected_distance_from_mouse_drag" title="napari.layers.Image.projected_distance_from_mouse_drag"><code class="xref py py-obj docutils literal notranslate"><span class="pre">projected_distance_from_mouse_drag</span></code></a>(...)</p></td>
 <td><p>Calculate the length of the projection of a line between two mouse clicks onto a vector (or array of vectors) in data coordinates.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Image.refresh" title="napari.layers.Image.refresh"><code class="xref py py-obj docutils literal notranslate"><span class="pre">refresh</span></code></a>([event, thumbnail, data_displayed, ...])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Image.refresh" title="napari.layers.Image.refresh"><code class="xref py py-obj docutils literal notranslate"><span class="pre">refresh</span></code></a>([event, thumbnail, data_displayed, ...])</p></td>
 <td><p>Refresh all layer data based on current view slice.</p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Image.reset_contrast_limits" title="napari.layers.Image.reset_contrast_limits"><code class="xref py py-obj docutils literal notranslate"><span class="pre">reset_contrast_limits</span></code></a>([mode])</p></td>
@@ -1002,7 +1002,7 @@ can be multidimensional for RGB or RGBA images if multidimensional is
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Image.reset_contrast_limits_range" title="napari.layers.Image.reset_contrast_limits_range"><code class="xref py py-obj docutils literal notranslate"><span class="pre">reset_contrast_limits_range</span></code></a>([mode])</p></td>
 <td><p>Scale contrast limits range to data type if dtype is an integer, or use the current maximum data range otherwise.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Image.save" title="napari.layers.Image.save"><code class="xref py py-obj docutils literal notranslate"><span class="pre">save</span></code></a>(path[, plugin])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Image.save" title="napari.layers.Image.save"><code class="xref py py-obj docutils literal notranslate"><span class="pre">save</span></code></a>(path[, plugin])</p></td>
 <td><p>Save this layer to <code class="docutils literal notranslate"><span class="pre">path</span></code> with default (or specified) plugin.</p></td>
 </tr>
 <tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">set_view_slice</span></code>()</p></td>

--- a/0.6.5/api/napari.layers.Labels.html
+++ b/0.6.5/api/napari.layers.Labels.html
@@ -67,8 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
@@ -952,7 +952,7 @@ background label <cite>0</cite> is selected.</p>
 <tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">as_layer_data_tuple</span></code>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Labels.bind_key" title="napari.layers.Labels.bind_key"><code class="xref py py-obj docutils literal notranslate"><span class="pre">bind_key</span></code></a>(key_bind[, func, overwrite])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Labels.bind_key" title="napari.layers.Labels.bind_key"><code class="xref py py-obj docutils literal notranslate"><span class="pre">bind_key</span></code></a>(key_bind[, func, overwrite])</p></td>
 <td><p>Bind a key combination to a keymap.</p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Labels.block_history" title="napari.layers.Labels.block_history"><code class="xref py py-obj docutils literal notranslate"><span class="pre">block_history</span></code></a>()</p></td>
@@ -961,43 +961,43 @@ background label <cite>0</cite> is selected.</p>
 <tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">block_update_properties</span></code>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Labels.click_plane_from_click_data" title="napari.layers.Labels.click_plane_from_click_data"><code class="xref py py-obj docutils literal notranslate"><span class="pre">click_plane_from_click_data</span></code></a>(click_position, ...)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Labels.click_plane_from_click_data" title="napari.layers.Labels.click_plane_from_click_data"><code class="xref py py-obj docutils literal notranslate"><span class="pre">click_plane_from_click_data</span></code></a>(click_position, ...)</p></td>
 <td><p>Calculate a (point, normal) plane parallel to the canvas in data coordinates, centered on the centre of rotation of the camera.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Labels.create" title="napari.layers.Labels.create"><code class="xref py py-obj docutils literal notranslate"><span class="pre">create</span></code></a>(data[, meta, layer_type])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Labels.create" title="napari.layers.Labels.create"><code class="xref py py-obj docutils literal notranslate"><span class="pre">create</span></code></a>(data[, meta, layer_type])</p></td>
 <td><p>Create layer from <cite>data</cite> of type <cite>layer_type</cite>.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Labels.data_setitem" title="napari.layers.Labels.data_setitem"><code class="xref py py-obj docutils literal notranslate"><span class="pre">data_setitem</span></code></a>(indices, value[, refresh])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Labels.data_setitem" title="napari.layers.Labels.data_setitem"><code class="xref py py-obj docutils literal notranslate"><span class="pre">data_setitem</span></code></a>(indices, value[, refresh])</p></td>
 <td><p>Set <cite>indices</cite> in <cite>data</cite> to <cite>value</cite>, while writing to edit history.</p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Labels.data_to_world" title="napari.layers.Labels.data_to_world"><code class="xref py py-obj docutils literal notranslate"><span class="pre">data_to_world</span></code></a>(position)</p></td>
 <td><p>Convert from data coordinates to world coordinates.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Labels.fill" title="napari.layers.Labels.fill"><code class="xref py py-obj docutils literal notranslate"><span class="pre">fill</span></code></a>(coord, new_label[, refresh])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Labels.fill" title="napari.layers.Labels.fill"><code class="xref py py-obj docutils literal notranslate"><span class="pre">fill</span></code></a>(coord, new_label[, refresh])</p></td>
 <td><p>Replace an existing label with a new label, either just at the connected component if the <cite>contiguous</cite> flag is <cite>True</cite> or everywhere if it is <cite>False</cite>, working in the number of dimensions specified by the <cite>n_edit_dimensions</cite> flag.</p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Labels.get_color" title="napari.layers.Labels.get_color"><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_color</span></code></a>(label)</p></td>
 <td><p>Return the color corresponding to a specific label.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Labels.get_ray_intersections" title="napari.layers.Labels.get_ray_intersections"><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_ray_intersections</span></code></a>(position, ...[, world])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Labels.get_ray_intersections" title="napari.layers.Labels.get_ray_intersections"><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_ray_intersections</span></code></a>(position, ...[, world])</p></td>
 <td><p>Get the start and end point for the ray extending from a point through the data bounding box.</p></td>
 </tr>
 <tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_source_str</span></code>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Labels.get_status" title="napari.layers.Labels.get_status"><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_status</span></code></a>([position, view_direction, ...])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Labels.get_status" title="napari.layers.Labels.get_status"><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_status</span></code></a>([position, view_direction, ...])</p></td>
 <td><p>Status message information of the data at a coordinate position.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Labels.get_value" title="napari.layers.Labels.get_value"><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_value</span></code></a>(position, *[, view_direction, ...])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Labels.get_value" title="napari.layers.Labels.get_value"><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_value</span></code></a>(position, *[, view_direction, ...])</p></td>
 <td><p>Value of the data at a position.</p></td>
 </tr>
 <tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">new_colormap</span></code>([seed])</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Labels.paint" title="napari.layers.Labels.paint"><code class="xref py py-obj docutils literal notranslate"><span class="pre">paint</span></code></a>(coord, new_label[, refresh])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Labels.paint" title="napari.layers.Labels.paint"><code class="xref py py-obj docutils literal notranslate"><span class="pre">paint</span></code></a>(coord, new_label[, refresh])</p></td>
 <td><p>Paint over existing labels with a new label, using the selected brush shape and size, either only on the visible slice or in all n dimensions.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Labels.paint_polygon" title="napari.layers.Labels.paint_polygon"><code class="xref py py-obj docutils literal notranslate"><span class="pre">paint_polygon</span></code></a>(points, new_label)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Labels.paint_polygon" title="napari.layers.Labels.paint_polygon"><code class="xref py py-obj docutils literal notranslate"><span class="pre">paint_polygon</span></code></a>(points, new_label)</p></td>
 <td><p>Paint a polygon over existing labels with a new label.</p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Labels.projected_distance_from_mouse_drag" title="napari.layers.Labels.projected_distance_from_mouse_drag"><code class="xref py py-obj docutils literal notranslate"><span class="pre">projected_distance_from_mouse_drag</span></code></a>(...)</p></td>
@@ -1006,10 +1006,10 @@ background label <cite>0</cite> is selected.</p>
 <tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">redo</span></code>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Labels.refresh" title="napari.layers.Labels.refresh"><code class="xref py py-obj docutils literal notranslate"><span class="pre">refresh</span></code></a>([event, thumbnail, data_displayed, ...])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Labels.refresh" title="napari.layers.Labels.refresh"><code class="xref py py-obj docutils literal notranslate"><span class="pre">refresh</span></code></a>([event, thumbnail, data_displayed, ...])</p></td>
 <td><p>Refresh all layer data based on current view slice.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Labels.save" title="napari.layers.Labels.save"><code class="xref py py-obj docutils literal notranslate"><span class="pre">save</span></code></a>(path[, plugin])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Labels.save" title="napari.layers.Labels.save"><code class="xref py py-obj docutils literal notranslate"><span class="pre">save</span></code></a>(path[, plugin])</p></td>
 <td><p>Save this layer to <code class="docutils literal notranslate"><span class="pre">path</span></code> with default (or specified) plugin.</p></td>
 </tr>
 <tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">set_view_slice</span></code>()</p></td>

--- a/0.6.5/api/napari.layers.Layer.html
+++ b/0.6.5/api/napari.layers.Layer.html
@@ -67,8 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
@@ -1017,40 +1017,40 @@ of a viewer.</p>
 <tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">as_layer_data_tuple</span></code>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Layer.bind_key" title="napari.layers.Layer.bind_key"><code class="xref py py-obj docutils literal notranslate"><span class="pre">bind_key</span></code></a>(key_bind[, func, overwrite])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Layer.bind_key" title="napari.layers.Layer.bind_key"><code class="xref py py-obj docutils literal notranslate"><span class="pre">bind_key</span></code></a>(key_bind[, func, overwrite])</p></td>
 <td><p>Bind a key combination to a keymap.</p></td>
 </tr>
 <tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">block_update_properties</span></code>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Layer.click_plane_from_click_data" title="napari.layers.Layer.click_plane_from_click_data"><code class="xref py py-obj docutils literal notranslate"><span class="pre">click_plane_from_click_data</span></code></a>(click_position, ...)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Layer.click_plane_from_click_data" title="napari.layers.Layer.click_plane_from_click_data"><code class="xref py py-obj docutils literal notranslate"><span class="pre">click_plane_from_click_data</span></code></a>(click_position, ...)</p></td>
 <td><p>Calculate a (point, normal) plane parallel to the canvas in data coordinates, centered on the centre of rotation of the camera.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Layer.create" title="napari.layers.Layer.create"><code class="xref py py-obj docutils literal notranslate"><span class="pre">create</span></code></a>(data[, meta, layer_type])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Layer.create" title="napari.layers.Layer.create"><code class="xref py py-obj docutils literal notranslate"><span class="pre">create</span></code></a>(data[, meta, layer_type])</p></td>
 <td><p>Create layer from <cite>data</cite> of type <cite>layer_type</cite>.</p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Layer.data_to_world" title="napari.layers.Layer.data_to_world"><code class="xref py py-obj docutils literal notranslate"><span class="pre">data_to_world</span></code></a>(position)</p></td>
 <td><p>Convert from data coordinates to world coordinates.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Layer.get_ray_intersections" title="napari.layers.Layer.get_ray_intersections"><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_ray_intersections</span></code></a>(position, ...[, world])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Layer.get_ray_intersections" title="napari.layers.Layer.get_ray_intersections"><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_ray_intersections</span></code></a>(position, ...[, world])</p></td>
 <td><p>Get the start and end point for the ray extending from a point through the data bounding box.</p></td>
 </tr>
 <tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_source_str</span></code>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Layer.get_status" title="napari.layers.Layer.get_status"><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_status</span></code></a>([position, view_direction, ...])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Layer.get_status" title="napari.layers.Layer.get_status"><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_status</span></code></a>([position, view_direction, ...])</p></td>
 <td><p>Status message information of the data at a coordinate position.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Layer.get_value" title="napari.layers.Layer.get_value"><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_value</span></code></a>(position, *[, view_direction, ...])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Layer.get_value" title="napari.layers.Layer.get_value"><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_value</span></code></a>(position, *[, view_direction, ...])</p></td>
 <td><p>Value of the data at a position.</p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Layer.projected_distance_from_mouse_drag" title="napari.layers.Layer.projected_distance_from_mouse_drag"><code class="xref py py-obj docutils literal notranslate"><span class="pre">projected_distance_from_mouse_drag</span></code></a>(...)</p></td>
 <td><p>Calculate the length of the projection of a line between two mouse clicks onto a vector (or array of vectors) in data coordinates.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Layer.refresh" title="napari.layers.Layer.refresh"><code class="xref py py-obj docutils literal notranslate"><span class="pre">refresh</span></code></a>([event, thumbnail, data_displayed, ...])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Layer.refresh" title="napari.layers.Layer.refresh"><code class="xref py py-obj docutils literal notranslate"><span class="pre">refresh</span></code></a>([event, thumbnail, data_displayed, ...])</p></td>
 <td><p>Refresh all layer data based on current view slice.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Layer.save" title="napari.layers.Layer.save"><code class="xref py py-obj docutils literal notranslate"><span class="pre">save</span></code></a>(path[, plugin])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Layer.save" title="napari.layers.Layer.save"><code class="xref py py-obj docutils literal notranslate"><span class="pre">save</span></code></a>(path[, plugin])</p></td>
 <td><p>Save this layer to <code class="docutils literal notranslate"><span class="pre">path</span></code> with default (or specified) plugin.</p></td>
 </tr>
 <tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">set_view_slice</span></code>()</p></td>

--- a/0.6.5/api/napari.layers.Points.html
+++ b/0.6.5/api/napari.layers.Points.html
@@ -67,8 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
@@ -1127,16 +1127,16 @@ None after dragging is done.</p>
 <tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">as_layer_data_tuple</span></code>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Points.bind_key" title="napari.layers.Points.bind_key"><code class="xref py py-obj docutils literal notranslate"><span class="pre">bind_key</span></code></a>(key_bind[, func, overwrite])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Points.bind_key" title="napari.layers.Points.bind_key"><code class="xref py py-obj docutils literal notranslate"><span class="pre">bind_key</span></code></a>(key_bind[, func, overwrite])</p></td>
 <td><p>Bind a key combination to a keymap.</p></td>
 </tr>
 <tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">block_update_properties</span></code>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Points.click_plane_from_click_data" title="napari.layers.Points.click_plane_from_click_data"><code class="xref py py-obj docutils literal notranslate"><span class="pre">click_plane_from_click_data</span></code></a>(click_position, ...)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Points.click_plane_from_click_data" title="napari.layers.Points.click_plane_from_click_data"><code class="xref py py-obj docutils literal notranslate"><span class="pre">click_plane_from_click_data</span></code></a>(click_position, ...)</p></td>
 <td><p>Calculate a (point, normal) plane parallel to the canvas in data coordinates, centered on the centre of rotation of the camera.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Points.create" title="napari.layers.Points.create"><code class="xref py py-obj docutils literal notranslate"><span class="pre">create</span></code></a>(data[, meta, layer_type])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Points.create" title="napari.layers.Points.create"><code class="xref py py-obj docutils literal notranslate"><span class="pre">create</span></code></a>(data[, meta, layer_type])</p></td>
 <td><p>Create layer from <cite>data</cite> of type <cite>layer_type</cite>.</p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Points.data_to_world" title="napari.layers.Points.data_to_world"><code class="xref py py-obj docutils literal notranslate"><span class="pre">data_to_world</span></code></a>(position)</p></td>
@@ -1145,16 +1145,16 @@ None after dragging is done.</p>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Points.get_point_info" title="napari.layers.Points.get_point_info"><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_point_info</span></code></a>(index)</p></td>
 <td><p>Retrieve all available information about a point at the given index.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Points.get_ray_intersections" title="napari.layers.Points.get_ray_intersections"><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_ray_intersections</span></code></a>(position, ...[, world])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Points.get_ray_intersections" title="napari.layers.Points.get_ray_intersections"><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_ray_intersections</span></code></a>(position, ...[, world])</p></td>
 <td><p>Get the start and end point for the ray extending from a point through the displayed bounding box.</p></td>
 </tr>
 <tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_source_str</span></code>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Points.get_status" title="napari.layers.Points.get_status"><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_status</span></code></a>([position, view_direction, ...])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Points.get_status" title="napari.layers.Points.get_status"><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_status</span></code></a>([position, view_direction, ...])</p></td>
 <td><p>Status message information of the data at a coordinate position.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Points.get_value" title="napari.layers.Points.get_value"><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_value</span></code></a>(position, *[, view_direction, ...])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Points.get_value" title="napari.layers.Points.get_value"><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_value</span></code></a>(position, *[, view_direction, ...])</p></td>
 <td><p>Value of the data at a position.</p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Points.interaction_box" title="napari.layers.Points.interaction_box"><code class="xref py py-obj docutils literal notranslate"><span class="pre">interaction_box</span></code></a>(index)</p></td>
@@ -1166,7 +1166,7 @@ None after dragging is done.</p>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Points.projected_distance_from_mouse_drag" title="napari.layers.Points.projected_distance_from_mouse_drag"><code class="xref py py-obj docutils literal notranslate"><span class="pre">projected_distance_from_mouse_drag</span></code></a>(...)</p></td>
 <td><p>Calculate the length of the projection of a line between two mouse clicks onto a vector (or array of vectors) in data coordinates.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Points.refresh" title="napari.layers.Points.refresh"><code class="xref py py-obj docutils literal notranslate"><span class="pre">refresh</span></code></a>([event, thumbnail, data_displayed, ...])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Points.refresh" title="napari.layers.Points.refresh"><code class="xref py py-obj docutils literal notranslate"><span class="pre">refresh</span></code></a>([event, thumbnail, data_displayed, ...])</p></td>
 <td><p>Refresh all layer data based on current view slice.</p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Points.refresh_colors" title="napari.layers.Points.refresh_colors"><code class="xref py py-obj docutils literal notranslate"><span class="pre">refresh_colors</span></code></a>([update_color_mapping])</p></td>
@@ -1181,13 +1181,13 @@ None after dragging is done.</p>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Points.remove_selected" title="napari.layers.Points.remove_selected"><code class="xref py py-obj docutils literal notranslate"><span class="pre">remove_selected</span></code></a>()</p></td>
 <td><p>Remove all selected points.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Points.save" title="napari.layers.Points.save"><code class="xref py py-obj docutils literal notranslate"><span class="pre">save</span></code></a>(path[, plugin])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Points.save" title="napari.layers.Points.save"><code class="xref py py-obj docutils literal notranslate"><span class="pre">save</span></code></a>(path[, plugin])</p></td>
 <td><p>Save this layer to <code class="docutils literal notranslate"><span class="pre">path</span></code> with default (or specified) plugin.</p></td>
 </tr>
 <tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">set_view_slice</span></code>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Points.to_mask" title="napari.layers.Points.to_mask"><code class="xref py py-obj docutils literal notranslate"><span class="pre">to_mask</span></code></a>(*, shape[, data_to_world, ...])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Points.to_mask" title="napari.layers.Points.to_mask"><code class="xref py py-obj docutils literal notranslate"><span class="pre">to_mask</span></code></a>(*, shape[, data_to_world, ...])</p></td>
 <td><p>Return a binary mask array of all the points as balls.</p></td>
 </tr>
 <tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">update_highlight_visibility</span></code>(visible)</p></td>

--- a/0.6.5/api/napari.layers.Shapes.html
+++ b/0.6.5/api/napari.layers.Shapes.html
@@ -67,8 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
@@ -996,28 +996,28 @@ won’t update during interactive events</p>
 <p class="rubric">Methods</p>
 <div class="pst-scrollable-table-container"><table class="autosummary longtable table autosummary">
 <tbody>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Shapes.add" title="napari.layers.Shapes.add"><code class="xref py py-obj docutils literal notranslate"><span class="pre">add</span></code></a>(data, *[, shape_type, edge_width, ...])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Shapes.add" title="napari.layers.Shapes.add"><code class="xref py py-obj docutils literal notranslate"><span class="pre">add</span></code></a>(data, *[, shape_type, edge_width, ...])</p></td>
 <td><p>Add shapes to the current layer.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Shapes.add_ellipses" title="napari.layers.Shapes.add_ellipses"><code class="xref py py-obj docutils literal notranslate"><span class="pre">add_ellipses</span></code></a>(data, *[, edge_width, ...])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Shapes.add_ellipses" title="napari.layers.Shapes.add_ellipses"><code class="xref py py-obj docutils literal notranslate"><span class="pre">add_ellipses</span></code></a>(data, *[, edge_width, ...])</p></td>
 <td><p>Add ellipses to the current layer.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Shapes.add_lines" title="napari.layers.Shapes.add_lines"><code class="xref py py-obj docutils literal notranslate"><span class="pre">add_lines</span></code></a>(data, *[, edge_width, edge_color, ...])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Shapes.add_lines" title="napari.layers.Shapes.add_lines"><code class="xref py py-obj docutils literal notranslate"><span class="pre">add_lines</span></code></a>(data, *[, edge_width, edge_color, ...])</p></td>
 <td><p>Add lines to the current layer.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Shapes.add_paths" title="napari.layers.Shapes.add_paths"><code class="xref py py-obj docutils literal notranslate"><span class="pre">add_paths</span></code></a>(data, *[, edge_width, edge_color, ...])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Shapes.add_paths" title="napari.layers.Shapes.add_paths"><code class="xref py py-obj docutils literal notranslate"><span class="pre">add_paths</span></code></a>(data, *[, edge_width, edge_color, ...])</p></td>
 <td><p>Add paths to the current layer.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Shapes.add_polygons" title="napari.layers.Shapes.add_polygons"><code class="xref py py-obj docutils literal notranslate"><span class="pre">add_polygons</span></code></a>(data, *[, edge_width, ...])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Shapes.add_polygons" title="napari.layers.Shapes.add_polygons"><code class="xref py py-obj docutils literal notranslate"><span class="pre">add_polygons</span></code></a>(data, *[, edge_width, ...])</p></td>
 <td><p>Add polygons to the current layer.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Shapes.add_rectangles" title="napari.layers.Shapes.add_rectangles"><code class="xref py py-obj docutils literal notranslate"><span class="pre">add_rectangles</span></code></a>(data, *[, edge_width, ...])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Shapes.add_rectangles" title="napari.layers.Shapes.add_rectangles"><code class="xref py py-obj docutils literal notranslate"><span class="pre">add_rectangles</span></code></a>(data, *[, edge_width, ...])</p></td>
 <td><p>Add rectangles to the current layer.</p></td>
 </tr>
 <tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">as_layer_data_tuple</span></code>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Shapes.bind_key" title="napari.layers.Shapes.bind_key"><code class="xref py py-obj docutils literal notranslate"><span class="pre">bind_key</span></code></a>(key_bind[, func, overwrite])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Shapes.bind_key" title="napari.layers.Shapes.bind_key"><code class="xref py py-obj docutils literal notranslate"><span class="pre">bind_key</span></code></a>(key_bind[, func, overwrite])</p></td>
 <td><p>Bind a key combination to a keymap.</p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Shapes.block_thumbnail_update" title="napari.layers.Shapes.block_thumbnail_update"><code class="xref py py-obj docutils literal notranslate"><span class="pre">block_thumbnail_update</span></code></a>()</p></td>
@@ -1026,19 +1026,19 @@ won’t update during interactive events</p>
 <tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">block_update_properties</span></code>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Shapes.click_plane_from_click_data" title="napari.layers.Shapes.click_plane_from_click_data"><code class="xref py py-obj docutils literal notranslate"><span class="pre">click_plane_from_click_data</span></code></a>(click_position, ...)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Shapes.click_plane_from_click_data" title="napari.layers.Shapes.click_plane_from_click_data"><code class="xref py py-obj docutils literal notranslate"><span class="pre">click_plane_from_click_data</span></code></a>(click_position, ...)</p></td>
 <td><p>Calculate a (point, normal) plane parallel to the canvas in data coordinates, centered on the centre of rotation of the camera.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Shapes.create" title="napari.layers.Shapes.create"><code class="xref py py-obj docutils literal notranslate"><span class="pre">create</span></code></a>(data[, meta, layer_type])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Shapes.create" title="napari.layers.Shapes.create"><code class="xref py py-obj docutils literal notranslate"><span class="pre">create</span></code></a>(data[, meta, layer_type])</p></td>
 <td><p>Create layer from <cite>data</cite> of type <cite>layer_type</cite>.</p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Shapes.data_to_world" title="napari.layers.Shapes.data_to_world"><code class="xref py py-obj docutils literal notranslate"><span class="pre">data_to_world</span></code></a>(position)</p></td>
 <td><p>Convert from data coordinates to world coordinates.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Shapes.get_index_and_intersection" title="napari.layers.Shapes.get_index_and_intersection"><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_index_and_intersection</span></code></a>(position, ...)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Shapes.get_index_and_intersection" title="napari.layers.Shapes.get_index_and_intersection"><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_index_and_intersection</span></code></a>(position, ...)</p></td>
 <td><p>Get the shape index and intersection point of the first shape (i.e., closest to start_point) &quot;under&quot; a mouse click.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Shapes.get_ray_intersections" title="napari.layers.Shapes.get_ray_intersections"><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_ray_intersections</span></code></a>(position, ...[, world])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Shapes.get_ray_intersections" title="napari.layers.Shapes.get_ray_intersections"><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_ray_intersections</span></code></a>(position, ...[, world])</p></td>
 <td><p>Get the start and end point for the ray extending from a point through the data bounding box.</p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Shapes.get_shape_info" title="napari.layers.Shapes.get_shape_info"><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_shape_info</span></code></a>(index)</p></td>
@@ -1047,10 +1047,10 @@ won’t update during interactive events</p>
 <tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_source_str</span></code>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Shapes.get_status" title="napari.layers.Shapes.get_status"><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_status</span></code></a>([position, view_direction, ...])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Shapes.get_status" title="napari.layers.Shapes.get_status"><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_status</span></code></a>([position, view_direction, ...])</p></td>
 <td><p>Status message information of the data at a coordinate position.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Shapes.get_value" title="napari.layers.Shapes.get_value"><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_value</span></code></a>(position, *[, view_direction, ...])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Shapes.get_value" title="napari.layers.Shapes.get_value"><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_value</span></code></a>(position, *[, view_direction, ...])</p></td>
 <td><p>Value of the data at a position.</p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Shapes.interaction_box" title="napari.layers.Shapes.interaction_box"><code class="xref py py-obj docutils literal notranslate"><span class="pre">interaction_box</span></code></a>(index)</p></td>
@@ -1068,7 +1068,7 @@ won’t update during interactive events</p>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Shapes.projected_distance_from_mouse_drag" title="napari.layers.Shapes.projected_distance_from_mouse_drag"><code class="xref py py-obj docutils literal notranslate"><span class="pre">projected_distance_from_mouse_drag</span></code></a>(...)</p></td>
 <td><p>Calculate the length of the projection of a line between two mouse clicks onto a vector (or array of vectors) in data coordinates.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Shapes.refresh" title="napari.layers.Shapes.refresh"><code class="xref py py-obj docutils literal notranslate"><span class="pre">refresh</span></code></a>([event, thumbnail, data_displayed, ...])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Shapes.refresh" title="napari.layers.Shapes.refresh"><code class="xref py py-obj docutils literal notranslate"><span class="pre">refresh</span></code></a>([event, thumbnail, data_displayed, ...])</p></td>
 <td><p>Refresh all layer data based on current view slice.</p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Shapes.refresh_colors" title="napari.layers.Shapes.refresh_colors"><code class="xref py py-obj docutils literal notranslate"><span class="pre">refresh_colors</span></code></a>([update_color_mapping])</p></td>
@@ -1083,7 +1083,7 @@ won’t update during interactive events</p>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Shapes.remove_selected" title="napari.layers.Shapes.remove_selected"><code class="xref py py-obj docutils literal notranslate"><span class="pre">remove_selected</span></code></a>()</p></td>
 <td><p>Remove any selected shapes.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Shapes.save" title="napari.layers.Shapes.save"><code class="xref py py-obj docutils literal notranslate"><span class="pre">save</span></code></a>(path[, plugin])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Shapes.save" title="napari.layers.Shapes.save"><code class="xref py py-obj docutils literal notranslate"><span class="pre">save</span></code></a>(path[, plugin])</p></td>
 <td><p>Save this layer to <code class="docutils literal notranslate"><span class="pre">path</span></code> with default (or specified) plugin.</p></td>
 </tr>
 <tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">set_view_slice</span></code>()</p></td>

--- a/0.6.5/api/napari.layers.Surface.html
+++ b/0.6.5/api/napari.layers.Surface.html
@@ -67,8 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
@@ -896,37 +896,37 @@ in the currently viewed slice.</p>
 <tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">as_layer_data_tuple</span></code>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Surface.bind_key" title="napari.layers.Surface.bind_key"><code class="xref py py-obj docutils literal notranslate"><span class="pre">bind_key</span></code></a>(key_bind[, func, overwrite])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Surface.bind_key" title="napari.layers.Surface.bind_key"><code class="xref py py-obj docutils literal notranslate"><span class="pre">bind_key</span></code></a>(key_bind[, func, overwrite])</p></td>
 <td><p>Bind a key combination to a keymap.</p></td>
 </tr>
 <tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">block_update_properties</span></code>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Surface.click_plane_from_click_data" title="napari.layers.Surface.click_plane_from_click_data"><code class="xref py py-obj docutils literal notranslate"><span class="pre">click_plane_from_click_data</span></code></a>(click_position, ...)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Surface.click_plane_from_click_data" title="napari.layers.Surface.click_plane_from_click_data"><code class="xref py py-obj docutils literal notranslate"><span class="pre">click_plane_from_click_data</span></code></a>(click_position, ...)</p></td>
 <td><p>Calculate a (point, normal) plane parallel to the canvas in data coordinates, centered on the centre of rotation of the camera.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Surface.create" title="napari.layers.Surface.create"><code class="xref py py-obj docutils literal notranslate"><span class="pre">create</span></code></a>(data[, meta, layer_type])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Surface.create" title="napari.layers.Surface.create"><code class="xref py py-obj docutils literal notranslate"><span class="pre">create</span></code></a>(data[, meta, layer_type])</p></td>
 <td><p>Create layer from <cite>data</cite> of type <cite>layer_type</cite>.</p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Surface.data_to_world" title="napari.layers.Surface.data_to_world"><code class="xref py py-obj docutils literal notranslate"><span class="pre">data_to_world</span></code></a>(position)</p></td>
 <td><p>Convert from data coordinates to world coordinates.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Surface.get_ray_intersections" title="napari.layers.Surface.get_ray_intersections"><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_ray_intersections</span></code></a>(position, ...[, world])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Surface.get_ray_intersections" title="napari.layers.Surface.get_ray_intersections"><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_ray_intersections</span></code></a>(position, ...[, world])</p></td>
 <td><p>Get the start and end point for the ray extending from a point through the data bounding box.</p></td>
 </tr>
 <tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_source_str</span></code>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Surface.get_status" title="napari.layers.Surface.get_status"><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_status</span></code></a>([position, view_direction, ...])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Surface.get_status" title="napari.layers.Surface.get_status"><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_status</span></code></a>([position, view_direction, ...])</p></td>
 <td><p>Status message information of the data at a coordinate position.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Surface.get_value" title="napari.layers.Surface.get_value"><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_value</span></code></a>(position, *[, view_direction, ...])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Surface.get_value" title="napari.layers.Surface.get_value"><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_value</span></code></a>(position, *[, view_direction, ...])</p></td>
 <td><p>Value of the data at a position.</p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Surface.projected_distance_from_mouse_drag" title="napari.layers.Surface.projected_distance_from_mouse_drag"><code class="xref py py-obj docutils literal notranslate"><span class="pre">projected_distance_from_mouse_drag</span></code></a>(...)</p></td>
 <td><p>Calculate the length of the projection of a line between two mouse clicks onto a vector (or array of vectors) in data coordinates.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Surface.refresh" title="napari.layers.Surface.refresh"><code class="xref py py-obj docutils literal notranslate"><span class="pre">refresh</span></code></a>([event, thumbnail, data_displayed, ...])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Surface.refresh" title="napari.layers.Surface.refresh"><code class="xref py py-obj docutils literal notranslate"><span class="pre">refresh</span></code></a>([event, thumbnail, data_displayed, ...])</p></td>
 <td><p>Refresh all layer data based on current view slice.</p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Surface.reset_contrast_limits" title="napari.layers.Surface.reset_contrast_limits"><code class="xref py py-obj docutils literal notranslate"><span class="pre">reset_contrast_limits</span></code></a>([mode])</p></td>
@@ -935,7 +935,7 @@ in the currently viewed slice.</p>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Surface.reset_contrast_limits_range" title="napari.layers.Surface.reset_contrast_limits_range"><code class="xref py py-obj docutils literal notranslate"><span class="pre">reset_contrast_limits_range</span></code></a>([mode])</p></td>
 <td><p>Scale contrast limits range to data type if dtype is an integer, or use the current maximum data range otherwise.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Surface.save" title="napari.layers.Surface.save"><code class="xref py py-obj docutils literal notranslate"><span class="pre">save</span></code></a>(path[, plugin])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Surface.save" title="napari.layers.Surface.save"><code class="xref py py-obj docutils literal notranslate"><span class="pre">save</span></code></a>(path[, plugin])</p></td>
 <td><p>Save this layer to <code class="docutils literal notranslate"><span class="pre">path</span></code> with default (or specified) plugin.</p></td>
 </tr>
 <tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">set_view_slice</span></code>()</p></td>

--- a/0.6.5/api/napari.layers.Tracks.html
+++ b/0.6.5/api/napari.layers.Tracks.html
@@ -67,8 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
@@ -680,40 +680,40 @@ If not provided, the default units are assumed to be pixels.</p></li>
 <tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">as_layer_data_tuple</span></code>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Tracks.bind_key" title="napari.layers.Tracks.bind_key"><code class="xref py py-obj docutils literal notranslate"><span class="pre">bind_key</span></code></a>(key_bind[, func, overwrite])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Tracks.bind_key" title="napari.layers.Tracks.bind_key"><code class="xref py py-obj docutils literal notranslate"><span class="pre">bind_key</span></code></a>(key_bind[, func, overwrite])</p></td>
 <td><p>Bind a key combination to a keymap.</p></td>
 </tr>
 <tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">block_update_properties</span></code>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Tracks.click_plane_from_click_data" title="napari.layers.Tracks.click_plane_from_click_data"><code class="xref py py-obj docutils literal notranslate"><span class="pre">click_plane_from_click_data</span></code></a>(click_position, ...)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Tracks.click_plane_from_click_data" title="napari.layers.Tracks.click_plane_from_click_data"><code class="xref py py-obj docutils literal notranslate"><span class="pre">click_plane_from_click_data</span></code></a>(click_position, ...)</p></td>
 <td><p>Calculate a (point, normal) plane parallel to the canvas in data coordinates, centered on the centre of rotation of the camera.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Tracks.create" title="napari.layers.Tracks.create"><code class="xref py py-obj docutils literal notranslate"><span class="pre">create</span></code></a>(data[, meta, layer_type])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Tracks.create" title="napari.layers.Tracks.create"><code class="xref py py-obj docutils literal notranslate"><span class="pre">create</span></code></a>(data[, meta, layer_type])</p></td>
 <td><p>Create layer from <cite>data</cite> of type <cite>layer_type</cite>.</p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Tracks.data_to_world" title="napari.layers.Tracks.data_to_world"><code class="xref py py-obj docutils literal notranslate"><span class="pre">data_to_world</span></code></a>(position)</p></td>
 <td><p>Convert from data coordinates to world coordinates.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Tracks.get_ray_intersections" title="napari.layers.Tracks.get_ray_intersections"><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_ray_intersections</span></code></a>(position, ...[, world])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Tracks.get_ray_intersections" title="napari.layers.Tracks.get_ray_intersections"><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_ray_intersections</span></code></a>(position, ...[, world])</p></td>
 <td><p>Get the start and end point for the ray extending from a point through the data bounding box.</p></td>
 </tr>
 <tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_source_str</span></code>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Tracks.get_status" title="napari.layers.Tracks.get_status"><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_status</span></code></a>([position, view_direction, ...])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Tracks.get_status" title="napari.layers.Tracks.get_status"><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_status</span></code></a>([position, view_direction, ...])</p></td>
 <td><p>Status message information of the data at a coordinate position.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Tracks.get_value" title="napari.layers.Tracks.get_value"><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_value</span></code></a>(position, *[, view_direction, ...])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Tracks.get_value" title="napari.layers.Tracks.get_value"><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_value</span></code></a>(position, *[, view_direction, ...])</p></td>
 <td><p>Value of the data at a position.</p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Tracks.projected_distance_from_mouse_drag" title="napari.layers.Tracks.projected_distance_from_mouse_drag"><code class="xref py py-obj docutils literal notranslate"><span class="pre">projected_distance_from_mouse_drag</span></code></a>(...)</p></td>
 <td><p>Calculate the length of the projection of a line between two mouse clicks onto a vector (or array of vectors) in data coordinates.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Tracks.refresh" title="napari.layers.Tracks.refresh"><code class="xref py py-obj docutils literal notranslate"><span class="pre">refresh</span></code></a>([event, thumbnail, data_displayed, ...])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Tracks.refresh" title="napari.layers.Tracks.refresh"><code class="xref py py-obj docutils literal notranslate"><span class="pre">refresh</span></code></a>([event, thumbnail, data_displayed, ...])</p></td>
 <td><p>Refresh all layer data based on current view slice.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Tracks.save" title="napari.layers.Tracks.save"><code class="xref py py-obj docutils literal notranslate"><span class="pre">save</span></code></a>(path[, plugin])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Tracks.save" title="napari.layers.Tracks.save"><code class="xref py py-obj docutils literal notranslate"><span class="pre">save</span></code></a>(path[, plugin])</p></td>
 <td><p>Save this layer to <code class="docutils literal notranslate"><span class="pre">path</span></code> with default (or specified) plugin.</p></td>
 </tr>
 <tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">set_view_slice</span></code>()</p></td>

--- a/0.6.5/api/napari.layers.Vectors.html
+++ b/0.6.5/api/napari.layers.Vectors.html
@@ -67,8 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
@@ -878,43 +878,43 @@ subsampled.</p>
 <tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">as_layer_data_tuple</span></code>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Vectors.bind_key" title="napari.layers.Vectors.bind_key"><code class="xref py py-obj docutils literal notranslate"><span class="pre">bind_key</span></code></a>(key_bind[, func, overwrite])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Vectors.bind_key" title="napari.layers.Vectors.bind_key"><code class="xref py py-obj docutils literal notranslate"><span class="pre">bind_key</span></code></a>(key_bind[, func, overwrite])</p></td>
 <td><p>Bind a key combination to a keymap.</p></td>
 </tr>
 <tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">block_update_properties</span></code>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Vectors.click_plane_from_click_data" title="napari.layers.Vectors.click_plane_from_click_data"><code class="xref py py-obj docutils literal notranslate"><span class="pre">click_plane_from_click_data</span></code></a>(click_position, ...)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Vectors.click_plane_from_click_data" title="napari.layers.Vectors.click_plane_from_click_data"><code class="xref py py-obj docutils literal notranslate"><span class="pre">click_plane_from_click_data</span></code></a>(click_position, ...)</p></td>
 <td><p>Calculate a (point, normal) plane parallel to the canvas in data coordinates, centered on the centre of rotation of the camera.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Vectors.create" title="napari.layers.Vectors.create"><code class="xref py py-obj docutils literal notranslate"><span class="pre">create</span></code></a>(data[, meta, layer_type])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Vectors.create" title="napari.layers.Vectors.create"><code class="xref py py-obj docutils literal notranslate"><span class="pre">create</span></code></a>(data[, meta, layer_type])</p></td>
 <td><p>Create layer from <cite>data</cite> of type <cite>layer_type</cite>.</p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Vectors.data_to_world" title="napari.layers.Vectors.data_to_world"><code class="xref py py-obj docutils literal notranslate"><span class="pre">data_to_world</span></code></a>(position)</p></td>
 <td><p>Convert from data coordinates to world coordinates.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Vectors.get_ray_intersections" title="napari.layers.Vectors.get_ray_intersections"><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_ray_intersections</span></code></a>(position, ...[, world])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Vectors.get_ray_intersections" title="napari.layers.Vectors.get_ray_intersections"><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_ray_intersections</span></code></a>(position, ...[, world])</p></td>
 <td><p>Get the start and end point for the ray extending from a point through the data bounding box.</p></td>
 </tr>
 <tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_source_str</span></code>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Vectors.get_status" title="napari.layers.Vectors.get_status"><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_status</span></code></a>([position, view_direction, ...])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Vectors.get_status" title="napari.layers.Vectors.get_status"><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_status</span></code></a>([position, view_direction, ...])</p></td>
 <td><p>Status message information of the data at a coordinate position.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Vectors.get_value" title="napari.layers.Vectors.get_value"><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_value</span></code></a>(position, *[, view_direction, ...])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Vectors.get_value" title="napari.layers.Vectors.get_value"><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_value</span></code></a>(position, *[, view_direction, ...])</p></td>
 <td><p>Value of the data at a position.</p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Vectors.projected_distance_from_mouse_drag" title="napari.layers.Vectors.projected_distance_from_mouse_drag"><code class="xref py py-obj docutils literal notranslate"><span class="pre">projected_distance_from_mouse_drag</span></code></a>(...)</p></td>
 <td><p>Calculate the length of the projection of a line between two mouse clicks onto a vector (or array of vectors) in data coordinates.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Vectors.refresh" title="napari.layers.Vectors.refresh"><code class="xref py py-obj docutils literal notranslate"><span class="pre">refresh</span></code></a>([event, thumbnail, data_displayed, ...])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Vectors.refresh" title="napari.layers.Vectors.refresh"><code class="xref py py-obj docutils literal notranslate"><span class="pre">refresh</span></code></a>([event, thumbnail, data_displayed, ...])</p></td>
 <td><p>Refresh all layer data based on current view slice.</p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.layers.Vectors.refresh_colors" title="napari.layers.Vectors.refresh_colors"><code class="xref py py-obj docutils literal notranslate"><span class="pre">refresh_colors</span></code></a>([update_color_mapping])</p></td>
 <td><p>Calculate and update edge colors if using a cycle or color map</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Vectors.save" title="napari.layers.Vectors.save"><code class="xref py py-obj docutils literal notranslate"><span class="pre">save</span></code></a>(path[, plugin])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.layers.Vectors.save" title="napari.layers.Vectors.save"><code class="xref py py-obj docutils literal notranslate"><span class="pre">save</span></code></a>(path[, plugin])</p></td>
 <td><p>Save this layer to <code class="docutils literal notranslate"><span class="pre">path</span></code> with default (or specified) plugin.</p></td>
 </tr>
 <tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">set_view_slice</span></code>()</p></td>

--- a/0.6.5/api/napari.layers.html
+++ b/0.6.5/api/napari.layers.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/api/napari.plugins.html
+++ b/0.6.5/api/napari.plugins.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/api/napari.qt.QtToolTipLabel.html
+++ b/0.6.5/api/napari.qt.QtToolTipLabel.html
@@ -67,8 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
@@ -623,7 +623,7 @@
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.accessibleName" title="napari.qt.QtToolTipLabel.accessibleName"><code class="xref py py-obj docutils literal notranslate"><span class="pre">accessibleName</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.actionEvent" title="napari.qt.QtToolTipLabel.actionEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">actionEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.actionEvent" title="napari.qt.QtToolTipLabel.actionEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">actionEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.actions" title="napari.qt.QtToolTipLabel.actions"><code class="xref py py-obj docutils literal notranslate"><span class="pre">actions</span></code></a>(self)</p></td>
@@ -632,10 +632,10 @@
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.activateWindow" title="napari.qt.QtToolTipLabel.activateWindow"><code class="xref py py-obj docutils literal notranslate"><span class="pre">activateWindow</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.addAction" title="napari.qt.QtToolTipLabel.addAction"><code class="xref py py-obj docutils literal notranslate"><span class="pre">addAction</span></code></a>(self, action)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.addAction" title="napari.qt.QtToolTipLabel.addAction"><code class="xref py py-obj docutils literal notranslate"><span class="pre">addAction</span></code></a>(self, action)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.addActions" title="napari.qt.QtToolTipLabel.addActions"><code class="xref py py-obj docutils literal notranslate"><span class="pre">addActions</span></code></a>(self, actions)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.addActions" title="napari.qt.QtToolTipLabel.addActions"><code class="xref py py-obj docutils literal notranslate"><span class="pre">addActions</span></code></a>(self, actions)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.adjustSize" title="napari.qt.QtToolTipLabel.adjustSize"><code class="xref py py-obj docutils literal notranslate"><span class="pre">adjustSize</span></code></a>(self)</p></td>
@@ -653,19 +653,19 @@
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.baseSize" title="napari.qt.QtToolTipLabel.baseSize"><code class="xref py py-obj docutils literal notranslate"><span class="pre">baseSize</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.blockSignals" title="napari.qt.QtToolTipLabel.blockSignals"><code class="xref py py-obj docutils literal notranslate"><span class="pre">blockSignals</span></code></a>(self, b)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.blockSignals" title="napari.qt.QtToolTipLabel.blockSignals"><code class="xref py py-obj docutils literal notranslate"><span class="pre">blockSignals</span></code></a>(self, b)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.buddy" title="napari.qt.QtToolTipLabel.buddy"><code class="xref py py-obj docutils literal notranslate"><span class="pre">buddy</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.changeEvent" title="napari.qt.QtToolTipLabel.changeEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">changeEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.changeEvent" title="napari.qt.QtToolTipLabel.changeEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">changeEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.childAt" title="napari.qt.QtToolTipLabel.childAt"><code class="xref py py-obj docutils literal notranslate"><span class="pre">childAt</span></code></a>(-&gt; Optional[QWidget])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.childAt" title="napari.qt.QtToolTipLabel.childAt"><code class="xref py py-obj docutils literal notranslate"><span class="pre">childAt</span></code></a>(-&gt; Optional[QWidget])</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.childEvent" title="napari.qt.QtToolTipLabel.childEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">childEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.childEvent" title="napari.qt.QtToolTipLabel.childEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">childEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.children" title="napari.qt.QtToolTipLabel.children"><code class="xref py py-obj docutils literal notranslate"><span class="pre">children</span></code></a>(self)</p></td>
@@ -689,13 +689,13 @@
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.close" title="napari.qt.QtToolTipLabel.close"><code class="xref py py-obj docutils literal notranslate"><span class="pre">close</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.closeEvent" title="napari.qt.QtToolTipLabel.closeEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">closeEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.closeEvent" title="napari.qt.QtToolTipLabel.closeEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">closeEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.colorCount" title="napari.qt.QtToolTipLabel.colorCount"><code class="xref py py-obj docutils literal notranslate"><span class="pre">colorCount</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.connectNotify" title="napari.qt.QtToolTipLabel.connectNotify"><code class="xref py py-obj docutils literal notranslate"><span class="pre">connectNotify</span></code></a>(self, signal)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.connectNotify" title="napari.qt.QtToolTipLabel.connectNotify"><code class="xref py py-obj docutils literal notranslate"><span class="pre">connectNotify</span></code></a>(self, signal)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.contentsMargins" title="napari.qt.QtToolTipLabel.contentsMargins"><code class="xref py py-obj docutils literal notranslate"><span class="pre">contentsMargins</span></code></a>(self)</p></td>
@@ -704,22 +704,22 @@
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.contentsRect" title="napari.qt.QtToolTipLabel.contentsRect"><code class="xref py py-obj docutils literal notranslate"><span class="pre">contentsRect</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.contextMenuEvent" title="napari.qt.QtToolTipLabel.contextMenuEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">contextMenuEvent</span></code></a>(self, ev)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.contextMenuEvent" title="napari.qt.QtToolTipLabel.contextMenuEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">contextMenuEvent</span></code></a>(self, ev)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.contextMenuPolicy" title="napari.qt.QtToolTipLabel.contextMenuPolicy"><code class="xref py py-obj docutils literal notranslate"><span class="pre">contextMenuPolicy</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.create" title="napari.qt.QtToolTipLabel.create"><code class="xref py py-obj docutils literal notranslate"><span class="pre">create</span></code></a>(self[, window, initializeWindow, ...])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.create" title="napari.qt.QtToolTipLabel.create"><code class="xref py py-obj docutils literal notranslate"><span class="pre">create</span></code></a>(self[, window, initializeWindow, ...])</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.createWindowContainer" title="napari.qt.QtToolTipLabel.createWindowContainer"><code class="xref py py-obj docutils literal notranslate"><span class="pre">createWindowContainer</span></code></a>(window[, parent, flags])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.createWindowContainer" title="napari.qt.QtToolTipLabel.createWindowContainer"><code class="xref py py-obj docutils literal notranslate"><span class="pre">createWindowContainer</span></code></a>(window[, parent, flags])</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.cursor" title="napari.qt.QtToolTipLabel.cursor"><code class="xref py py-obj docutils literal notranslate"><span class="pre">cursor</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.customEvent" title="napari.qt.QtToolTipLabel.customEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">customEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.customEvent" title="napari.qt.QtToolTipLabel.customEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">customEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.deleteLater" title="napari.qt.QtToolTipLabel.deleteLater"><code class="xref py py-obj docutils literal notranslate"><span class="pre">deleteLater</span></code></a>(self)</p></td>
@@ -728,7 +728,7 @@
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.depth" title="napari.qt.QtToolTipLabel.depth"><code class="xref py py-obj docutils literal notranslate"><span class="pre">depth</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.destroy" title="napari.qt.QtToolTipLabel.destroy"><code class="xref py py-obj docutils literal notranslate"><span class="pre">destroy</span></code></a>(self[, destroyWindow, destroySubWindows])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.destroy" title="napari.qt.QtToolTipLabel.destroy"><code class="xref py py-obj docutils literal notranslate"><span class="pre">destroy</span></code></a>(self[, destroyWindow, destroySubWindows])</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.devType" title="napari.qt.QtToolTipLabel.devType"><code class="xref py py-obj docutils literal notranslate"><span class="pre">devType</span></code></a>(self)</p></td>
@@ -743,25 +743,25 @@
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.devicePixelRatioFScale" title="napari.qt.QtToolTipLabel.devicePixelRatioFScale"><code class="xref py py-obj docutils literal notranslate"><span class="pre">devicePixelRatioFScale</span></code></a>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.disconnect" title="napari.qt.QtToolTipLabel.disconnect"><code class="xref py py-obj docutils literal notranslate"><span class="pre">disconnect</span></code></a>(-&gt; bool)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.disconnect" title="napari.qt.QtToolTipLabel.disconnect"><code class="xref py py-obj docutils literal notranslate"><span class="pre">disconnect</span></code></a>(-&gt; bool)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.disconnectNotify" title="napari.qt.QtToolTipLabel.disconnectNotify"><code class="xref py py-obj docutils literal notranslate"><span class="pre">disconnectNotify</span></code></a>(self, signal)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.disconnectNotify" title="napari.qt.QtToolTipLabel.disconnectNotify"><code class="xref py py-obj docutils literal notranslate"><span class="pre">disconnectNotify</span></code></a>(self, signal)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.dragEnterEvent" title="napari.qt.QtToolTipLabel.dragEnterEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">dragEnterEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.dragEnterEvent" title="napari.qt.QtToolTipLabel.dragEnterEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">dragEnterEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.dragLeaveEvent" title="napari.qt.QtToolTipLabel.dragLeaveEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">dragLeaveEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.dragLeaveEvent" title="napari.qt.QtToolTipLabel.dragLeaveEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">dragLeaveEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.dragMoveEvent" title="napari.qt.QtToolTipLabel.dragMoveEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">dragMoveEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.dragMoveEvent" title="napari.qt.QtToolTipLabel.dragMoveEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">dragMoveEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.drawFrame" title="napari.qt.QtToolTipLabel.drawFrame"><code class="xref py py-obj docutils literal notranslate"><span class="pre">drawFrame</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.drawFrame" title="napari.qt.QtToolTipLabel.drawFrame"><code class="xref py py-obj docutils literal notranslate"><span class="pre">drawFrame</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.dropEvent" title="napari.qt.QtToolTipLabel.dropEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">dropEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.dropEvent" title="napari.qt.QtToolTipLabel.dropEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">dropEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.dumpObjectInfo" title="napari.qt.QtToolTipLabel.dumpObjectInfo"><code class="xref py py-obj docutils literal notranslate"><span class="pre">dumpObjectInfo</span></code></a>(self)</p></td>
@@ -782,31 +782,31 @@
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.enterEvent" title="napari.qt.QtToolTipLabel.enterEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">enterEvent</span></code></a>(event)</p></td>
 <td><p>Override to show tooltips instantly.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.event" title="napari.qt.QtToolTipLabel.event"><code class="xref py py-obj docutils literal notranslate"><span class="pre">event</span></code></a>(self, e)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.event" title="napari.qt.QtToolTipLabel.event"><code class="xref py py-obj docutils literal notranslate"><span class="pre">event</span></code></a>(self, e)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.eventFilter" title="napari.qt.QtToolTipLabel.eventFilter"><code class="xref py py-obj docutils literal notranslate"><span class="pre">eventFilter</span></code></a>(self, a0, a1)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.eventFilter" title="napari.qt.QtToolTipLabel.eventFilter"><code class="xref py py-obj docutils literal notranslate"><span class="pre">eventFilter</span></code></a>(self, a0, a1)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.find" title="napari.qt.QtToolTipLabel.find"><code class="xref py py-obj docutils literal notranslate"><span class="pre">find</span></code></a>(a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.findChild" title="napari.qt.QtToolTipLabel.findChild"><code class="xref py py-obj docutils literal notranslate"><span class="pre">findChild</span></code></a>(-&gt; QObjectT)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.findChild" title="napari.qt.QtToolTipLabel.findChild"><code class="xref py py-obj docutils literal notranslate"><span class="pre">findChild</span></code></a>(-&gt; QObjectT)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.findChildren" title="napari.qt.QtToolTipLabel.findChildren"><code class="xref py py-obj docutils literal notranslate"><span class="pre">findChildren</span></code></a>(...)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.focusInEvent" title="napari.qt.QtToolTipLabel.focusInEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">focusInEvent</span></code></a>(self, ev)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.focusInEvent" title="napari.qt.QtToolTipLabel.focusInEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">focusInEvent</span></code></a>(self, ev)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.focusNextChild" title="napari.qt.QtToolTipLabel.focusNextChild"><code class="xref py py-obj docutils literal notranslate"><span class="pre">focusNextChild</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.focusNextPrevChild" title="napari.qt.QtToolTipLabel.focusNextPrevChild"><code class="xref py py-obj docutils literal notranslate"><span class="pre">focusNextPrevChild</span></code></a>(self, next)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.focusNextPrevChild" title="napari.qt.QtToolTipLabel.focusNextPrevChild"><code class="xref py py-obj docutils literal notranslate"><span class="pre">focusNextPrevChild</span></code></a>(self, next)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.focusOutEvent" title="napari.qt.QtToolTipLabel.focusOutEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">focusOutEvent</span></code></a>(self, ev)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.focusOutEvent" title="napari.qt.QtToolTipLabel.focusOutEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">focusOutEvent</span></code></a>(self, ev)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.focusPolicy" title="napari.qt.QtToolTipLabel.focusPolicy"><code class="xref py py-obj docutils literal notranslate"><span class="pre">focusPolicy</span></code></a>(self)</p></td>
@@ -860,10 +860,10 @@
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.getContentsMargins" title="napari.qt.QtToolTipLabel.getContentsMargins"><code class="xref py py-obj docutils literal notranslate"><span class="pre">getContentsMargins</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.grab" title="napari.qt.QtToolTipLabel.grab"><code class="xref py py-obj docutils literal notranslate"><span class="pre">grab</span></code></a>(self[, rectangle])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.grab" title="napari.qt.QtToolTipLabel.grab"><code class="xref py py-obj docutils literal notranslate"><span class="pre">grab</span></code></a>(self[, rectangle])</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.grabGesture" title="napari.qt.QtToolTipLabel.grabGesture"><code class="xref py py-obj docutils literal notranslate"><span class="pre">grabGesture</span></code></a>(self, type[, flags])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.grabGesture" title="napari.qt.QtToolTipLabel.grabGesture"><code class="xref py py-obj docutils literal notranslate"><span class="pre">grabGesture</span></code></a>(self, type[, flags])</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.grabKeyboard" title="napari.qt.QtToolTipLabel.grabKeyboard"><code class="xref py py-obj docutils literal notranslate"><span class="pre">grabKeyboard</span></code></a>(self)</p></td>
@@ -872,7 +872,7 @@
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.grabMouse" title="napari.qt.QtToolTipLabel.grabMouse"><code class="xref py py-obj docutils literal notranslate"><span class="pre">grabMouse</span></code></a>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.grabShortcut" title="napari.qt.QtToolTipLabel.grabShortcut"><code class="xref py py-obj docutils literal notranslate"><span class="pre">grabShortcut</span></code></a>(self, key[, context])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.grabShortcut" title="napari.qt.QtToolTipLabel.grabShortcut"><code class="xref py py-obj docutils literal notranslate"><span class="pre">grabShortcut</span></code></a>(self, key[, context])</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.graphicsEffect" title="napari.qt.QtToolTipLabel.graphicsEffect"><code class="xref py py-obj docutils literal notranslate"><span class="pre">graphicsEffect</span></code></a>(self)</p></td>
@@ -902,7 +902,7 @@
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.height" title="napari.qt.QtToolTipLabel.height"><code class="xref py py-obj docutils literal notranslate"><span class="pre">height</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.heightForWidth" title="napari.qt.QtToolTipLabel.heightForWidth"><code class="xref py py-obj docutils literal notranslate"><span class="pre">heightForWidth</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.heightForWidth" title="napari.qt.QtToolTipLabel.heightForWidth"><code class="xref py py-obj docutils literal notranslate"><span class="pre">heightForWidth</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.heightMM" title="napari.qt.QtToolTipLabel.heightMM"><code class="xref py py-obj docutils literal notranslate"><span class="pre">heightMM</span></code></a>(self)</p></td>
@@ -911,49 +911,49 @@
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.hide" title="napari.qt.QtToolTipLabel.hide"><code class="xref py py-obj docutils literal notranslate"><span class="pre">hide</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.hideEvent" title="napari.qt.QtToolTipLabel.hideEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">hideEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.hideEvent" title="napari.qt.QtToolTipLabel.hideEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">hideEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.indent" title="napari.qt.QtToolTipLabel.indent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">indent</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.inherits" title="napari.qt.QtToolTipLabel.inherits"><code class="xref py py-obj docutils literal notranslate"><span class="pre">inherits</span></code></a>(self, classname)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.inherits" title="napari.qt.QtToolTipLabel.inherits"><code class="xref py py-obj docutils literal notranslate"><span class="pre">inherits</span></code></a>(self, classname)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.initPainter" title="napari.qt.QtToolTipLabel.initPainter"><code class="xref py py-obj docutils literal notranslate"><span class="pre">initPainter</span></code></a>(self, painter)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.initPainter" title="napari.qt.QtToolTipLabel.initPainter"><code class="xref py py-obj docutils literal notranslate"><span class="pre">initPainter</span></code></a>(self, painter)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.initStyleOption" title="napari.qt.QtToolTipLabel.initStyleOption"><code class="xref py py-obj docutils literal notranslate"><span class="pre">initStyleOption</span></code></a>(self, option)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.initStyleOption" title="napari.qt.QtToolTipLabel.initStyleOption"><code class="xref py py-obj docutils literal notranslate"><span class="pre">initStyleOption</span></code></a>(self, option)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.inputMethodEvent" title="napari.qt.QtToolTipLabel.inputMethodEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">inputMethodEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.inputMethodEvent" title="napari.qt.QtToolTipLabel.inputMethodEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">inputMethodEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.inputMethodHints" title="napari.qt.QtToolTipLabel.inputMethodHints"><code class="xref py py-obj docutils literal notranslate"><span class="pre">inputMethodHints</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.inputMethodQuery" title="napari.qt.QtToolTipLabel.inputMethodQuery"><code class="xref py py-obj docutils literal notranslate"><span class="pre">inputMethodQuery</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.inputMethodQuery" title="napari.qt.QtToolTipLabel.inputMethodQuery"><code class="xref py py-obj docutils literal notranslate"><span class="pre">inputMethodQuery</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.insertAction" title="napari.qt.QtToolTipLabel.insertAction"><code class="xref py py-obj docutils literal notranslate"><span class="pre">insertAction</span></code></a>(self, before, action)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.insertAction" title="napari.qt.QtToolTipLabel.insertAction"><code class="xref py py-obj docutils literal notranslate"><span class="pre">insertAction</span></code></a>(self, before, action)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.insertActions" title="napari.qt.QtToolTipLabel.insertActions"><code class="xref py py-obj docutils literal notranslate"><span class="pre">insertActions</span></code></a>(self, before, actions)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.insertActions" title="napari.qt.QtToolTipLabel.insertActions"><code class="xref py py-obj docutils literal notranslate"><span class="pre">insertActions</span></code></a>(self, before, actions)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.installEventFilter" title="napari.qt.QtToolTipLabel.installEventFilter"><code class="xref py py-obj docutils literal notranslate"><span class="pre">installEventFilter</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.installEventFilter" title="napari.qt.QtToolTipLabel.installEventFilter"><code class="xref py py-obj docutils literal notranslate"><span class="pre">installEventFilter</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.isActiveWindow" title="napari.qt.QtToolTipLabel.isActiveWindow"><code class="xref py py-obj docutils literal notranslate"><span class="pre">isActiveWindow</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.isAncestorOf" title="napari.qt.QtToolTipLabel.isAncestorOf"><code class="xref py py-obj docutils literal notranslate"><span class="pre">isAncestorOf</span></code></a>(self, child)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.isAncestorOf" title="napari.qt.QtToolTipLabel.isAncestorOf"><code class="xref py py-obj docutils literal notranslate"><span class="pre">isAncestorOf</span></code></a>(self, child)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.isEnabled" title="napari.qt.QtToolTipLabel.isEnabled"><code class="xref py py-obj docutils literal notranslate"><span class="pre">isEnabled</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.isEnabledTo" title="napari.qt.QtToolTipLabel.isEnabledTo"><code class="xref py py-obj docutils literal notranslate"><span class="pre">isEnabledTo</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.isEnabledTo" title="napari.qt.QtToolTipLabel.isEnabledTo"><code class="xref py py-obj docutils literal notranslate"><span class="pre">isEnabledTo</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.isFullScreen" title="napari.qt.QtToolTipLabel.isFullScreen"><code class="xref py py-obj docutils literal notranslate"><span class="pre">isFullScreen</span></code></a>(self)</p></td>
@@ -977,13 +977,13 @@
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.isRightToLeft" title="napari.qt.QtToolTipLabel.isRightToLeft"><code class="xref py py-obj docutils literal notranslate"><span class="pre">isRightToLeft</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.isSignalConnected" title="napari.qt.QtToolTipLabel.isSignalConnected"><code class="xref py py-obj docutils literal notranslate"><span class="pre">isSignalConnected</span></code></a>(self, signal)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.isSignalConnected" title="napari.qt.QtToolTipLabel.isSignalConnected"><code class="xref py py-obj docutils literal notranslate"><span class="pre">isSignalConnected</span></code></a>(self, signal)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.isVisible" title="napari.qt.QtToolTipLabel.isVisible"><code class="xref py py-obj docutils literal notranslate"><span class="pre">isVisible</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.isVisibleTo" title="napari.qt.QtToolTipLabel.isVisibleTo"><code class="xref py py-obj docutils literal notranslate"><span class="pre">isVisibleTo</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.isVisibleTo" title="napari.qt.QtToolTipLabel.isVisibleTo"><code class="xref py py-obj docutils literal notranslate"><span class="pre">isVisibleTo</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.isWidgetType" title="napari.qt.QtToolTipLabel.isWidgetType"><code class="xref py py-obj docutils literal notranslate"><span class="pre">isWidgetType</span></code></a>(self)</p></td>
@@ -998,16 +998,16 @@
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.isWindowType" title="napari.qt.QtToolTipLabel.isWindowType"><code class="xref py py-obj docutils literal notranslate"><span class="pre">isWindowType</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.keyPressEvent" title="napari.qt.QtToolTipLabel.keyPressEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">keyPressEvent</span></code></a>(self, ev)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.keyPressEvent" title="napari.qt.QtToolTipLabel.keyPressEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">keyPressEvent</span></code></a>(self, ev)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.keyReleaseEvent" title="napari.qt.QtToolTipLabel.keyReleaseEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">keyReleaseEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.keyReleaseEvent" title="napari.qt.QtToolTipLabel.keyReleaseEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">keyReleaseEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.keyboardGrabber" title="napari.qt.QtToolTipLabel.keyboardGrabber"><code class="xref py py-obj docutils literal notranslate"><span class="pre">keyboardGrabber</span></code></a>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.killTimer" title="napari.qt.QtToolTipLabel.killTimer"><code class="xref py py-obj docutils literal notranslate"><span class="pre">killTimer</span></code></a>(self, id)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.killTimer" title="napari.qt.QtToolTipLabel.killTimer"><code class="xref py py-obj docutils literal notranslate"><span class="pre">killTimer</span></code></a>(self, id)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.layout" title="napari.qt.QtToolTipLabel.layout"><code class="xref py py-obj docutils literal notranslate"><span class="pre">layout</span></code></a>(self)</p></td>
@@ -1016,7 +1016,7 @@
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.layoutDirection" title="napari.qt.QtToolTipLabel.layoutDirection"><code class="xref py py-obj docutils literal notranslate"><span class="pre">layoutDirection</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.leaveEvent" title="napari.qt.QtToolTipLabel.leaveEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">leaveEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.leaveEvent" title="napari.qt.QtToolTipLabel.leaveEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">leaveEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.lineWidth" title="napari.qt.QtToolTipLabel.lineWidth"><code class="xref py py-obj docutils literal notranslate"><span class="pre">lineWidth</span></code></a>(self)</p></td>
@@ -1034,22 +1034,22 @@
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.lower" title="napari.qt.QtToolTipLabel.lower"><code class="xref py py-obj docutils literal notranslate"><span class="pre">lower</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.mapFrom" title="napari.qt.QtToolTipLabel.mapFrom"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mapFrom</span></code></a>(self, a0, a1)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.mapFrom" title="napari.qt.QtToolTipLabel.mapFrom"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mapFrom</span></code></a>(self, a0, a1)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.mapFromGlobal" title="napari.qt.QtToolTipLabel.mapFromGlobal"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mapFromGlobal</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.mapFromGlobal" title="napari.qt.QtToolTipLabel.mapFromGlobal"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mapFromGlobal</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.mapFromParent" title="napari.qt.QtToolTipLabel.mapFromParent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mapFromParent</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.mapFromParent" title="napari.qt.QtToolTipLabel.mapFromParent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mapFromParent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.mapTo" title="napari.qt.QtToolTipLabel.mapTo"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mapTo</span></code></a>(self, a0, a1)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.mapTo" title="napari.qt.QtToolTipLabel.mapTo"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mapTo</span></code></a>(self, a0, a1)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.mapToGlobal" title="napari.qt.QtToolTipLabel.mapToGlobal"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mapToGlobal</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.mapToGlobal" title="napari.qt.QtToolTipLabel.mapToGlobal"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mapToGlobal</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.mapToParent" title="napari.qt.QtToolTipLabel.mapToParent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mapToParent</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.mapToParent" title="napari.qt.QtToolTipLabel.mapToParent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mapToParent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.margin" title="napari.qt.QtToolTipLabel.margin"><code class="xref py py-obj docutils literal notranslate"><span class="pre">margin</span></code></a>(self)</p></td>
@@ -1070,7 +1070,7 @@
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.metaObject" title="napari.qt.QtToolTipLabel.metaObject"><code class="xref py py-obj docutils literal notranslate"><span class="pre">metaObject</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.metric" title="napari.qt.QtToolTipLabel.metric"><code class="xref py py-obj docutils literal notranslate"><span class="pre">metric</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.metric" title="napari.qt.QtToolTipLabel.metric"><code class="xref py py-obj docutils literal notranslate"><span class="pre">metric</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.midLineWidth" title="napari.qt.QtToolTipLabel.midLineWidth"><code class="xref py py-obj docutils literal notranslate"><span class="pre">midLineWidth</span></code></a>(self)</p></td>
@@ -1088,34 +1088,34 @@
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.minimumWidth" title="napari.qt.QtToolTipLabel.minimumWidth"><code class="xref py py-obj docutils literal notranslate"><span class="pre">minimumWidth</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.mouseDoubleClickEvent" title="napari.qt.QtToolTipLabel.mouseDoubleClickEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mouseDoubleClickEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.mouseDoubleClickEvent" title="napari.qt.QtToolTipLabel.mouseDoubleClickEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mouseDoubleClickEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.mouseGrabber" title="napari.qt.QtToolTipLabel.mouseGrabber"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mouseGrabber</span></code></a>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.mouseMoveEvent" title="napari.qt.QtToolTipLabel.mouseMoveEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mouseMoveEvent</span></code></a>(self, ev)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.mouseMoveEvent" title="napari.qt.QtToolTipLabel.mouseMoveEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mouseMoveEvent</span></code></a>(self, ev)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.mousePressEvent" title="napari.qt.QtToolTipLabel.mousePressEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mousePressEvent</span></code></a>(self, ev)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.mousePressEvent" title="napari.qt.QtToolTipLabel.mousePressEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mousePressEvent</span></code></a>(self, ev)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.mouseReleaseEvent" title="napari.qt.QtToolTipLabel.mouseReleaseEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mouseReleaseEvent</span></code></a>(self, ev)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.mouseReleaseEvent" title="napari.qt.QtToolTipLabel.mouseReleaseEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mouseReleaseEvent</span></code></a>(self, ev)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.move" title="napari.qt.QtToolTipLabel.move"><code class="xref py py-obj docutils literal notranslate"><span class="pre">move</span></code></a>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.moveEvent" title="napari.qt.QtToolTipLabel.moveEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">moveEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.moveEvent" title="napari.qt.QtToolTipLabel.moveEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">moveEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.moveToThread" title="napari.qt.QtToolTipLabel.moveToThread"><code class="xref py py-obj docutils literal notranslate"><span class="pre">moveToThread</span></code></a>(self, thread)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.moveToThread" title="napari.qt.QtToolTipLabel.moveToThread"><code class="xref py py-obj docutils literal notranslate"><span class="pre">moveToThread</span></code></a>(self, thread)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.movie" title="napari.qt.QtToolTipLabel.movie"><code class="xref py py-obj docutils literal notranslate"><span class="pre">movie</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.nativeEvent" title="napari.qt.QtToolTipLabel.nativeEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">nativeEvent</span></code></a>(self, eventType, message)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.nativeEvent" title="napari.qt.QtToolTipLabel.nativeEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">nativeEvent</span></code></a>(self, eventType, message)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.nativeParentWidget" title="napari.qt.QtToolTipLabel.nativeParentWidget"><code class="xref py py-obj docutils literal notranslate"><span class="pre">nativeParentWidget</span></code></a>(self)</p></td>
@@ -1133,16 +1133,16 @@
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.openExternalLinks" title="napari.qt.QtToolTipLabel.openExternalLinks"><code class="xref py py-obj docutils literal notranslate"><span class="pre">openExternalLinks</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.overrideWindowFlags" title="napari.qt.QtToolTipLabel.overrideWindowFlags"><code class="xref py py-obj docutils literal notranslate"><span class="pre">overrideWindowFlags</span></code></a>(self, type)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.overrideWindowFlags" title="napari.qt.QtToolTipLabel.overrideWindowFlags"><code class="xref py py-obj docutils literal notranslate"><span class="pre">overrideWindowFlags</span></code></a>(self, type)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.overrideWindowState" title="napari.qt.QtToolTipLabel.overrideWindowState"><code class="xref py py-obj docutils literal notranslate"><span class="pre">overrideWindowState</span></code></a>(self, state)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.overrideWindowState" title="napari.qt.QtToolTipLabel.overrideWindowState"><code class="xref py py-obj docutils literal notranslate"><span class="pre">overrideWindowState</span></code></a>(self, state)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.paintEngine" title="napari.qt.QtToolTipLabel.paintEngine"><code class="xref py py-obj docutils literal notranslate"><span class="pre">paintEngine</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.paintEvent" title="napari.qt.QtToolTipLabel.paintEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">paintEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.paintEvent" title="napari.qt.QtToolTipLabel.paintEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">paintEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.paintingActive" title="napari.qt.QtToolTipLabel.paintingActive"><code class="xref py py-obj docutils literal notranslate"><span class="pre">paintingActive</span></code></a>(self)</p></td>
@@ -1175,7 +1175,7 @@
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.previousInFocusChain" title="napari.qt.QtToolTipLabel.previousInFocusChain"><code class="xref py py-obj docutils literal notranslate"><span class="pre">previousInFocusChain</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.property" title="napari.qt.QtToolTipLabel.property"><code class="xref py py-obj docutils literal notranslate"><span class="pre">property</span></code></a>(self, name)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.property" title="napari.qt.QtToolTipLabel.property"><code class="xref py py-obj docutils literal notranslate"><span class="pre">property</span></code></a>(self, name)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.pyqtConfigure" title="napari.qt.QtToolTipLabel.pyqtConfigure"><code class="xref py py-obj docutils literal notranslate"><span class="pre">pyqtConfigure</span></code></a>(...)</p></td>
@@ -1184,7 +1184,7 @@
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.raise_" title="napari.qt.QtToolTipLabel.raise_"><code class="xref py py-obj docutils literal notranslate"><span class="pre">raise_</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.receivers" title="napari.qt.QtToolTipLabel.receivers"><code class="xref py py-obj docutils literal notranslate"><span class="pre">receivers</span></code></a>(self, signal)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.receivers" title="napari.qt.QtToolTipLabel.receivers"><code class="xref py py-obj docutils literal notranslate"><span class="pre">receivers</span></code></a>(self, signal)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.rect" title="napari.qt.QtToolTipLabel.rect"><code class="xref py py-obj docutils literal notranslate"><span class="pre">rect</span></code></a>(self)</p></td>
@@ -1196,29 +1196,29 @@
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.releaseMouse" title="napari.qt.QtToolTipLabel.releaseMouse"><code class="xref py py-obj docutils literal notranslate"><span class="pre">releaseMouse</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.releaseShortcut" title="napari.qt.QtToolTipLabel.releaseShortcut"><code class="xref py py-obj docutils literal notranslate"><span class="pre">releaseShortcut</span></code></a>(self, id)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.releaseShortcut" title="napari.qt.QtToolTipLabel.releaseShortcut"><code class="xref py py-obj docutils literal notranslate"><span class="pre">releaseShortcut</span></code></a>(self, id)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.removeAction" title="napari.qt.QtToolTipLabel.removeAction"><code class="xref py py-obj docutils literal notranslate"><span class="pre">removeAction</span></code></a>(self, action)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.removeAction" title="napari.qt.QtToolTipLabel.removeAction"><code class="xref py py-obj docutils literal notranslate"><span class="pre">removeAction</span></code></a>(self, action)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.removeEventFilter" title="napari.qt.QtToolTipLabel.removeEventFilter"><code class="xref py py-obj docutils literal notranslate"><span class="pre">removeEventFilter</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.removeEventFilter" title="napari.qt.QtToolTipLabel.removeEventFilter"><code class="xref py py-obj docutils literal notranslate"><span class="pre">removeEventFilter</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.render" title="napari.qt.QtToolTipLabel.render"><code class="xref py py-obj docutils literal notranslate"><span class="pre">render</span></code></a>(, sourceRegion, flags, ...)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.render" title="napari.qt.QtToolTipLabel.render"><code class="xref py py-obj docutils literal notranslate"><span class="pre">render</span></code></a>(, sourceRegion, flags, ...)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.repaint" title="napari.qt.QtToolTipLabel.repaint"><code class="xref py py-obj docutils literal notranslate"><span class="pre">repaint</span></code></a>(-&gt; None
- -&gt; None)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.repaint" title="napari.qt.QtToolTipLabel.repaint"><code class="xref py py-obj docutils literal notranslate"><span class="pre">repaint</span></code></a>(-&gt; None
+ -&gt; None)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.resize" title="napari.qt.QtToolTipLabel.resize"><code class="xref py py-obj docutils literal notranslate"><span class="pre">resize</span></code></a>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.resizeEvent" title="napari.qt.QtToolTipLabel.resizeEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">resizeEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.resizeEvent" title="napari.qt.QtToolTipLabel.resizeEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">resizeEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.restoreGeometry" title="napari.qt.QtToolTipLabel.restoreGeometry"><code class="xref py py-obj docutils literal notranslate"><span class="pre">restoreGeometry</span></code></a>(self, geometry)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.restoreGeometry" title="napari.qt.QtToolTipLabel.restoreGeometry"><code class="xref py py-obj docutils literal notranslate"><span class="pre">restoreGeometry</span></code></a>(self, geometry)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.saveGeometry" title="napari.qt.QtToolTipLabel.saveGeometry"><code class="xref py py-obj docutils literal notranslate"><span class="pre">saveGeometry</span></code></a>(self)</p></td>
@@ -1242,178 +1242,178 @@
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.senderSignalIndex" title="napari.qt.QtToolTipLabel.senderSignalIndex"><code class="xref py py-obj docutils literal notranslate"><span class="pre">senderSignalIndex</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setAcceptDrops" title="napari.qt.QtToolTipLabel.setAcceptDrops"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setAcceptDrops</span></code></a>(self, on)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setAcceptDrops" title="napari.qt.QtToolTipLabel.setAcceptDrops"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setAcceptDrops</span></code></a>(self, on)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setAccessibleDescription" title="napari.qt.QtToolTipLabel.setAccessibleDescription"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setAccessibleDescription</span></code></a>(self, description)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setAccessibleDescription" title="napari.qt.QtToolTipLabel.setAccessibleDescription"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setAccessibleDescription</span></code></a>(self, description)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setAccessibleName" title="napari.qt.QtToolTipLabel.setAccessibleName"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setAccessibleName</span></code></a>(self, name)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setAccessibleName" title="napari.qt.QtToolTipLabel.setAccessibleName"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setAccessibleName</span></code></a>(self, name)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setAlignment" title="napari.qt.QtToolTipLabel.setAlignment"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setAlignment</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setAlignment" title="napari.qt.QtToolTipLabel.setAlignment"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setAlignment</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setAttribute" title="napari.qt.QtToolTipLabel.setAttribute"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setAttribute</span></code></a>(self, attribute[, on])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setAttribute" title="napari.qt.QtToolTipLabel.setAttribute"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setAttribute</span></code></a>(self, attribute[, on])</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setAutoFillBackground" title="napari.qt.QtToolTipLabel.setAutoFillBackground"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setAutoFillBackground</span></code></a>(self, enabled)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setAutoFillBackground" title="napari.qt.QtToolTipLabel.setAutoFillBackground"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setAutoFillBackground</span></code></a>(self, enabled)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setBackgroundRole" title="napari.qt.QtToolTipLabel.setBackgroundRole"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setBackgroundRole</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setBackgroundRole" title="napari.qt.QtToolTipLabel.setBackgroundRole"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setBackgroundRole</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setBaseSize" title="napari.qt.QtToolTipLabel.setBaseSize"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setBaseSize</span></code></a>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setBuddy" title="napari.qt.QtToolTipLabel.setBuddy"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setBuddy</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setBuddy" title="napari.qt.QtToolTipLabel.setBuddy"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setBuddy</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setContentsMargins" title="napari.qt.QtToolTipLabel.setContentsMargins"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setContentsMargins</span></code></a>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setContextMenuPolicy" title="napari.qt.QtToolTipLabel.setContextMenuPolicy"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setContextMenuPolicy</span></code></a>(self, policy)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setContextMenuPolicy" title="napari.qt.QtToolTipLabel.setContextMenuPolicy"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setContextMenuPolicy</span></code></a>(self, policy)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setCursor" title="napari.qt.QtToolTipLabel.setCursor"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setCursor</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setCursor" title="napari.qt.QtToolTipLabel.setCursor"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setCursor</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setDisabled" title="napari.qt.QtToolTipLabel.setDisabled"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setDisabled</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setDisabled" title="napari.qt.QtToolTipLabel.setDisabled"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setDisabled</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setEnabled" title="napari.qt.QtToolTipLabel.setEnabled"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setEnabled</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setEnabled" title="napari.qt.QtToolTipLabel.setEnabled"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setEnabled</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setFixedHeight" title="napari.qt.QtToolTipLabel.setFixedHeight"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setFixedHeight</span></code></a>(self, h)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setFixedHeight" title="napari.qt.QtToolTipLabel.setFixedHeight"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setFixedHeight</span></code></a>(self, h)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setFixedSize" title="napari.qt.QtToolTipLabel.setFixedSize"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setFixedSize</span></code></a>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setFixedWidth" title="napari.qt.QtToolTipLabel.setFixedWidth"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setFixedWidth</span></code></a>(self, w)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setFixedWidth" title="napari.qt.QtToolTipLabel.setFixedWidth"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setFixedWidth</span></code></a>(self, w)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setFocus" title="napari.qt.QtToolTipLabel.setFocus"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setFocus</span></code></a>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setFocusPolicy" title="napari.qt.QtToolTipLabel.setFocusPolicy"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setFocusPolicy</span></code></a>(self, policy)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setFocusPolicy" title="napari.qt.QtToolTipLabel.setFocusPolicy"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setFocusPolicy</span></code></a>(self, policy)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setFocusProxy" title="napari.qt.QtToolTipLabel.setFocusProxy"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setFocusProxy</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setFocusProxy" title="napari.qt.QtToolTipLabel.setFocusProxy"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setFocusProxy</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setFont" title="napari.qt.QtToolTipLabel.setFont"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setFont</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setFont" title="napari.qt.QtToolTipLabel.setFont"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setFont</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setForegroundRole" title="napari.qt.QtToolTipLabel.setForegroundRole"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setForegroundRole</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setForegroundRole" title="napari.qt.QtToolTipLabel.setForegroundRole"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setForegroundRole</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setFrameRect" title="napari.qt.QtToolTipLabel.setFrameRect"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setFrameRect</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setFrameRect" title="napari.qt.QtToolTipLabel.setFrameRect"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setFrameRect</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setFrameShadow" title="napari.qt.QtToolTipLabel.setFrameShadow"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setFrameShadow</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setFrameShadow" title="napari.qt.QtToolTipLabel.setFrameShadow"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setFrameShadow</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setFrameShape" title="napari.qt.QtToolTipLabel.setFrameShape"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setFrameShape</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setFrameShape" title="napari.qt.QtToolTipLabel.setFrameShape"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setFrameShape</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setFrameStyle" title="napari.qt.QtToolTipLabel.setFrameStyle"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setFrameStyle</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setFrameStyle" title="napari.qt.QtToolTipLabel.setFrameStyle"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setFrameStyle</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setGeometry" title="napari.qt.QtToolTipLabel.setGeometry"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setGeometry</span></code></a>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setGraphicsEffect" title="napari.qt.QtToolTipLabel.setGraphicsEffect"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setGraphicsEffect</span></code></a>(self, effect)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setGraphicsEffect" title="napari.qt.QtToolTipLabel.setGraphicsEffect"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setGraphicsEffect</span></code></a>(self, effect)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setHidden" title="napari.qt.QtToolTipLabel.setHidden"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setHidden</span></code></a>(self, hidden)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setHidden" title="napari.qt.QtToolTipLabel.setHidden"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setHidden</span></code></a>(self, hidden)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setIndent" title="napari.qt.QtToolTipLabel.setIndent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setIndent</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setIndent" title="napari.qt.QtToolTipLabel.setIndent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setIndent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setInputMethodHints" title="napari.qt.QtToolTipLabel.setInputMethodHints"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setInputMethodHints</span></code></a>(self, hints)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setInputMethodHints" title="napari.qt.QtToolTipLabel.setInputMethodHints"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setInputMethodHints</span></code></a>(self, hints)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setLayout" title="napari.qt.QtToolTipLabel.setLayout"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setLayout</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setLayout" title="napari.qt.QtToolTipLabel.setLayout"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setLayout</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setLayoutDirection" title="napari.qt.QtToolTipLabel.setLayoutDirection"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setLayoutDirection</span></code></a>(self, direction)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setLayoutDirection" title="napari.qt.QtToolTipLabel.setLayoutDirection"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setLayoutDirection</span></code></a>(self, direction)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setLineWidth" title="napari.qt.QtToolTipLabel.setLineWidth"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setLineWidth</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setLineWidth" title="napari.qt.QtToolTipLabel.setLineWidth"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setLineWidth</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setLocale" title="napari.qt.QtToolTipLabel.setLocale"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setLocale</span></code></a>(self, locale)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setLocale" title="napari.qt.QtToolTipLabel.setLocale"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setLocale</span></code></a>(self, locale)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setMargin" title="napari.qt.QtToolTipLabel.setMargin"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setMargin</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setMargin" title="napari.qt.QtToolTipLabel.setMargin"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setMargin</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setMask" title="napari.qt.QtToolTipLabel.setMask"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setMask</span></code></a>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setMaximumHeight" title="napari.qt.QtToolTipLabel.setMaximumHeight"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setMaximumHeight</span></code></a>(self, maxh)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setMaximumHeight" title="napari.qt.QtToolTipLabel.setMaximumHeight"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setMaximumHeight</span></code></a>(self, maxh)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setMaximumSize" title="napari.qt.QtToolTipLabel.setMaximumSize"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setMaximumSize</span></code></a>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setMaximumWidth" title="napari.qt.QtToolTipLabel.setMaximumWidth"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setMaximumWidth</span></code></a>(self, maxw)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setMaximumWidth" title="napari.qt.QtToolTipLabel.setMaximumWidth"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setMaximumWidth</span></code></a>(self, maxw)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setMidLineWidth" title="napari.qt.QtToolTipLabel.setMidLineWidth"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setMidLineWidth</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setMidLineWidth" title="napari.qt.QtToolTipLabel.setMidLineWidth"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setMidLineWidth</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setMinimumHeight" title="napari.qt.QtToolTipLabel.setMinimumHeight"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setMinimumHeight</span></code></a>(self, minh)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setMinimumHeight" title="napari.qt.QtToolTipLabel.setMinimumHeight"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setMinimumHeight</span></code></a>(self, minh)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setMinimumSize" title="napari.qt.QtToolTipLabel.setMinimumSize"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setMinimumSize</span></code></a>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setMinimumWidth" title="napari.qt.QtToolTipLabel.setMinimumWidth"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setMinimumWidth</span></code></a>(self, minw)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setMinimumWidth" title="napari.qt.QtToolTipLabel.setMinimumWidth"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setMinimumWidth</span></code></a>(self, minw)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setMouseTracking" title="napari.qt.QtToolTipLabel.setMouseTracking"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setMouseTracking</span></code></a>(self, enable)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setMouseTracking" title="napari.qt.QtToolTipLabel.setMouseTracking"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setMouseTracking</span></code></a>(self, enable)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setMovie" title="napari.qt.QtToolTipLabel.setMovie"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setMovie</span></code></a>(self, movie)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setMovie" title="napari.qt.QtToolTipLabel.setMovie"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setMovie</span></code></a>(self, movie)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setNum" title="napari.qt.QtToolTipLabel.setNum"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setNum</span></code></a>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setObjectName" title="napari.qt.QtToolTipLabel.setObjectName"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setObjectName</span></code></a>(self, name)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setObjectName" title="napari.qt.QtToolTipLabel.setObjectName"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setObjectName</span></code></a>(self, name)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setOpenExternalLinks" title="napari.qt.QtToolTipLabel.setOpenExternalLinks"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setOpenExternalLinks</span></code></a>(self, open)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setOpenExternalLinks" title="napari.qt.QtToolTipLabel.setOpenExternalLinks"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setOpenExternalLinks</span></code></a>(self, open)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setPalette" title="napari.qt.QtToolTipLabel.setPalette"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setPalette</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setPalette" title="napari.qt.QtToolTipLabel.setPalette"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setPalette</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setParent" title="napari.qt.QtToolTipLabel.setParent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setParent</span></code></a>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setPicture" title="napari.qt.QtToolTipLabel.setPicture"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setPicture</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setPicture" title="napari.qt.QtToolTipLabel.setPicture"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setPicture</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setPixmap" title="napari.qt.QtToolTipLabel.setPixmap"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setPixmap</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setPixmap" title="napari.qt.QtToolTipLabel.setPixmap"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setPixmap</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setProperty" title="napari.qt.QtToolTipLabel.setProperty"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setProperty</span></code></a>(self, name, value)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setProperty" title="napari.qt.QtToolTipLabel.setProperty"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setProperty</span></code></a>(self, name, value)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setScaledContents" title="napari.qt.QtToolTipLabel.setScaledContents"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setScaledContents</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setScaledContents" title="napari.qt.QtToolTipLabel.setScaledContents"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setScaledContents</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setSelection" title="napari.qt.QtToolTipLabel.setSelection"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setSelection</span></code></a>(self, a0, a1)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setSelection" title="napari.qt.QtToolTipLabel.setSelection"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setSelection</span></code></a>(self, a0, a1)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setShortcutAutoRepeat" title="napari.qt.QtToolTipLabel.setShortcutAutoRepeat"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setShortcutAutoRepeat</span></code></a>(self, id[, enabled])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setShortcutAutoRepeat" title="napari.qt.QtToolTipLabel.setShortcutAutoRepeat"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setShortcutAutoRepeat</span></code></a>(self, id[, enabled])</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setShortcutEnabled" title="napari.qt.QtToolTipLabel.setShortcutEnabled"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setShortcutEnabled</span></code></a>(self, id[, enabled])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setShortcutEnabled" title="napari.qt.QtToolTipLabel.setShortcutEnabled"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setShortcutEnabled</span></code></a>(self, id[, enabled])</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setSizeIncrement" title="napari.qt.QtToolTipLabel.setSizeIncrement"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setSizeIncrement</span></code></a>()</p></td>
@@ -1422,79 +1422,79 @@
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setSizePolicy" title="napari.qt.QtToolTipLabel.setSizePolicy"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setSizePolicy</span></code></a>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setStatusTip" title="napari.qt.QtToolTipLabel.setStatusTip"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setStatusTip</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setStatusTip" title="napari.qt.QtToolTipLabel.setStatusTip"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setStatusTip</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setStyle" title="napari.qt.QtToolTipLabel.setStyle"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setStyle</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setStyle" title="napari.qt.QtToolTipLabel.setStyle"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setStyle</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setStyleSheet" title="napari.qt.QtToolTipLabel.setStyleSheet"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setStyleSheet</span></code></a>(self, styleSheet)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setStyleSheet" title="napari.qt.QtToolTipLabel.setStyleSheet"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setStyleSheet</span></code></a>(self, styleSheet)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setTabOrder" title="napari.qt.QtToolTipLabel.setTabOrder"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setTabOrder</span></code></a>(a0, a1)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setTabOrder" title="napari.qt.QtToolTipLabel.setTabOrder"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setTabOrder</span></code></a>(a0, a1)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setTabletTracking" title="napari.qt.QtToolTipLabel.setTabletTracking"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setTabletTracking</span></code></a>(self, enable)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setTabletTracking" title="napari.qt.QtToolTipLabel.setTabletTracking"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setTabletTracking</span></code></a>(self, enable)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setText" title="napari.qt.QtToolTipLabel.setText"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setText</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setText" title="napari.qt.QtToolTipLabel.setText"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setText</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setTextFormat" title="napari.qt.QtToolTipLabel.setTextFormat"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setTextFormat</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setTextFormat" title="napari.qt.QtToolTipLabel.setTextFormat"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setTextFormat</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setTextInteractionFlags" title="napari.qt.QtToolTipLabel.setTextInteractionFlags"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setTextInteractionFlags</span></code></a>(self, flags)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setTextInteractionFlags" title="napari.qt.QtToolTipLabel.setTextInteractionFlags"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setTextInteractionFlags</span></code></a>(self, flags)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setToolTip" title="napari.qt.QtToolTipLabel.setToolTip"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setToolTip</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setToolTip" title="napari.qt.QtToolTipLabel.setToolTip"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setToolTip</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setToolTipDuration" title="napari.qt.QtToolTipLabel.setToolTipDuration"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setToolTipDuration</span></code></a>(self, msec)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setToolTipDuration" title="napari.qt.QtToolTipLabel.setToolTipDuration"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setToolTipDuration</span></code></a>(self, msec)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setUpdatesEnabled" title="napari.qt.QtToolTipLabel.setUpdatesEnabled"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setUpdatesEnabled</span></code></a>(self, enable)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setUpdatesEnabled" title="napari.qt.QtToolTipLabel.setUpdatesEnabled"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setUpdatesEnabled</span></code></a>(self, enable)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setVisible" title="napari.qt.QtToolTipLabel.setVisible"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setVisible</span></code></a>(self, visible)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setVisible" title="napari.qt.QtToolTipLabel.setVisible"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setVisible</span></code></a>(self, visible)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setWhatsThis" title="napari.qt.QtToolTipLabel.setWhatsThis"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWhatsThis</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setWhatsThis" title="napari.qt.QtToolTipLabel.setWhatsThis"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWhatsThis</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setWindowFilePath" title="napari.qt.QtToolTipLabel.setWindowFilePath"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowFilePath</span></code></a>(self, filePath)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setWindowFilePath" title="napari.qt.QtToolTipLabel.setWindowFilePath"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowFilePath</span></code></a>(self, filePath)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setWindowFlag" title="napari.qt.QtToolTipLabel.setWindowFlag"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowFlag</span></code></a>(self, a0[, on])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setWindowFlag" title="napari.qt.QtToolTipLabel.setWindowFlag"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowFlag</span></code></a>(self, a0[, on])</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setWindowFlags" title="napari.qt.QtToolTipLabel.setWindowFlags"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowFlags</span></code></a>(self, type)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setWindowFlags" title="napari.qt.QtToolTipLabel.setWindowFlags"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowFlags</span></code></a>(self, type)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setWindowIcon" title="napari.qt.QtToolTipLabel.setWindowIcon"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowIcon</span></code></a>(self, icon)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setWindowIcon" title="napari.qt.QtToolTipLabel.setWindowIcon"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowIcon</span></code></a>(self, icon)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setWindowIconText" title="napari.qt.QtToolTipLabel.setWindowIconText"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowIconText</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setWindowIconText" title="napari.qt.QtToolTipLabel.setWindowIconText"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowIconText</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setWindowModality" title="napari.qt.QtToolTipLabel.setWindowModality"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowModality</span></code></a>(self, windowModality)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setWindowModality" title="napari.qt.QtToolTipLabel.setWindowModality"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowModality</span></code></a>(self, windowModality)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setWindowModified" title="napari.qt.QtToolTipLabel.setWindowModified"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowModified</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setWindowModified" title="napari.qt.QtToolTipLabel.setWindowModified"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowModified</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setWindowOpacity" title="napari.qt.QtToolTipLabel.setWindowOpacity"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowOpacity</span></code></a>(self, level)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setWindowOpacity" title="napari.qt.QtToolTipLabel.setWindowOpacity"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowOpacity</span></code></a>(self, level)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setWindowRole" title="napari.qt.QtToolTipLabel.setWindowRole"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowRole</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setWindowRole" title="napari.qt.QtToolTipLabel.setWindowRole"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowRole</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setWindowState" title="napari.qt.QtToolTipLabel.setWindowState"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowState</span></code></a>(self, state)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setWindowState" title="napari.qt.QtToolTipLabel.setWindowState"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowState</span></code></a>(self, state)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setWindowTitle" title="napari.qt.QtToolTipLabel.setWindowTitle"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowTitle</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setWindowTitle" title="napari.qt.QtToolTipLabel.setWindowTitle"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowTitle</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setWordWrap" title="napari.qt.QtToolTipLabel.setWordWrap"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWordWrap</span></code></a>(self, on)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.setWordWrap" title="napari.qt.QtToolTipLabel.setWordWrap"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWordWrap</span></code></a>(self, on)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.sharedPainter" title="napari.qt.QtToolTipLabel.sharedPainter"><code class="xref py py-obj docutils literal notranslate"><span class="pre">sharedPainter</span></code></a>(self)</p></td>
@@ -1503,7 +1503,7 @@
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.show" title="napari.qt.QtToolTipLabel.show"><code class="xref py py-obj docutils literal notranslate"><span class="pre">show</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.showEvent" title="napari.qt.QtToolTipLabel.showEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">showEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.showEvent" title="napari.qt.QtToolTipLabel.showEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">showEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.showFullScreen" title="napari.qt.QtToolTipLabel.showFullScreen"><code class="xref py py-obj docutils literal notranslate"><span class="pre">showFullScreen</span></code></a>(self)</p></td>
@@ -1533,10 +1533,10 @@
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.sizePolicy" title="napari.qt.QtToolTipLabel.sizePolicy"><code class="xref py py-obj docutils literal notranslate"><span class="pre">sizePolicy</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.stackUnder" title="napari.qt.QtToolTipLabel.stackUnder"><code class="xref py py-obj docutils literal notranslate"><span class="pre">stackUnder</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.stackUnder" title="napari.qt.QtToolTipLabel.stackUnder"><code class="xref py py-obj docutils literal notranslate"><span class="pre">stackUnder</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.startTimer" title="napari.qt.QtToolTipLabel.startTimer"><code class="xref py py-obj docutils literal notranslate"><span class="pre">startTimer</span></code></a>(self, interval[, timerType])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.startTimer" title="napari.qt.QtToolTipLabel.startTimer"><code class="xref py py-obj docutils literal notranslate"><span class="pre">startTimer</span></code></a>(self, interval[, timerType])</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.statusTip" title="napari.qt.QtToolTipLabel.statusTip"><code class="xref py py-obj docutils literal notranslate"><span class="pre">statusTip</span></code></a>(self)</p></td>
@@ -1548,10 +1548,10 @@
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.styleSheet" title="napari.qt.QtToolTipLabel.styleSheet"><code class="xref py py-obj docutils literal notranslate"><span class="pre">styleSheet</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.tabletEvent" title="napari.qt.QtToolTipLabel.tabletEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">tabletEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.tabletEvent" title="napari.qt.QtToolTipLabel.tabletEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">tabletEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.testAttribute" title="napari.qt.QtToolTipLabel.testAttribute"><code class="xref py py-obj docutils literal notranslate"><span class="pre">testAttribute</span></code></a>(self, attribute)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.testAttribute" title="napari.qt.QtToolTipLabel.testAttribute"><code class="xref py py-obj docutils literal notranslate"><span class="pre">testAttribute</span></code></a>(self, attribute)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.text" title="napari.qt.QtToolTipLabel.text"><code class="xref py py-obj docutils literal notranslate"><span class="pre">text</span></code></a>(self)</p></td>
@@ -1566,7 +1566,7 @@
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.thread" title="napari.qt.QtToolTipLabel.thread"><code class="xref py py-obj docutils literal notranslate"><span class="pre">thread</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.timerEvent" title="napari.qt.QtToolTipLabel.timerEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">timerEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.timerEvent" title="napari.qt.QtToolTipLabel.timerEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">timerEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.toolTip" title="napari.qt.QtToolTipLabel.toolTip"><code class="xref py py-obj docutils literal notranslate"><span class="pre">toolTip</span></code></a>(self)</p></td>
@@ -1575,13 +1575,13 @@
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.toolTipDuration" title="napari.qt.QtToolTipLabel.toolTipDuration"><code class="xref py py-obj docutils literal notranslate"><span class="pre">toolTipDuration</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.tr" title="napari.qt.QtToolTipLabel.tr"><code class="xref py py-obj docutils literal notranslate"><span class="pre">tr</span></code></a>(self, sourceText[, disambiguation, n])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.tr" title="napari.qt.QtToolTipLabel.tr"><code class="xref py py-obj docutils literal notranslate"><span class="pre">tr</span></code></a>(self, sourceText[, disambiguation, n])</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.underMouse" title="napari.qt.QtToolTipLabel.underMouse"><code class="xref py py-obj docutils literal notranslate"><span class="pre">underMouse</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.ungrabGesture" title="napari.qt.QtToolTipLabel.ungrabGesture"><code class="xref py py-obj docutils literal notranslate"><span class="pre">ungrabGesture</span></code></a>(self, type)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.ungrabGesture" title="napari.qt.QtToolTipLabel.ungrabGesture"><code class="xref py py-obj docutils literal notranslate"><span class="pre">ungrabGesture</span></code></a>(self, type)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.unsetCursor" title="napari.qt.QtToolTipLabel.unsetCursor"><code class="xref py py-obj docutils literal notranslate"><span class="pre">unsetCursor</span></code></a>(self)</p></td>
@@ -1593,8 +1593,8 @@
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.unsetLocale" title="napari.qt.QtToolTipLabel.unsetLocale"><code class="xref py py-obj docutils literal notranslate"><span class="pre">unsetLocale</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.update" title="napari.qt.QtToolTipLabel.update"><code class="xref py py-obj docutils literal notranslate"><span class="pre">update</span></code></a>(-&gt; None
- -&gt; None)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.update" title="napari.qt.QtToolTipLabel.update"><code class="xref py py-obj docutils literal notranslate"><span class="pre">update</span></code></a>(-&gt; None
+ -&gt; None)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.updateGeometry" title="napari.qt.QtToolTipLabel.updateGeometry"><code class="xref py py-obj docutils literal notranslate"><span class="pre">updateGeometry</span></code></a>(self)</p></td>
@@ -1612,7 +1612,7 @@
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.whatsThis" title="napari.qt.QtToolTipLabel.whatsThis"><code class="xref py py-obj docutils literal notranslate"><span class="pre">whatsThis</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.wheelEvent" title="napari.qt.QtToolTipLabel.wheelEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">wheelEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.wheelEvent" title="napari.qt.QtToolTipLabel.wheelEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">wheelEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtToolTipLabel.width" title="napari.qt.QtToolTipLabel.width"><code class="xref py py-obj docutils literal notranslate"><span class="pre">width</span></code></a>(self)</p></td>

--- a/0.6.5/api/napari.qt.QtViewer.html
+++ b/0.6.5/api/napari.qt.QtViewer.html
@@ -67,8 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
@@ -723,7 +723,7 @@ have a custom canvas here.</p>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.accessibleName" title="napari.qt.QtViewer.accessibleName"><code class="xref py py-obj docutils literal notranslate"><span class="pre">accessibleName</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.actionEvent" title="napari.qt.QtViewer.actionEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">actionEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.actionEvent" title="napari.qt.QtViewer.actionEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">actionEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.actions" title="napari.qt.QtViewer.actions"><code class="xref py py-obj docutils literal notranslate"><span class="pre">actions</span></code></a>(self)</p></td>
@@ -732,13 +732,13 @@ have a custom canvas here.</p>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.activateWindow" title="napari.qt.QtViewer.activateWindow"><code class="xref py py-obj docutils literal notranslate"><span class="pre">activateWindow</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.addAction" title="napari.qt.QtViewer.addAction"><code class="xref py py-obj docutils literal notranslate"><span class="pre">addAction</span></code></a>(self, action)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.addAction" title="napari.qt.QtViewer.addAction"><code class="xref py py-obj docutils literal notranslate"><span class="pre">addAction</span></code></a>(self, action)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.addActions" title="napari.qt.QtViewer.addActions"><code class="xref py py-obj docutils literal notranslate"><span class="pre">addActions</span></code></a>(self, actions)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.addActions" title="napari.qt.QtViewer.addActions"><code class="xref py py-obj docutils literal notranslate"><span class="pre">addActions</span></code></a>(self, actions)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.addWidget" title="napari.qt.QtViewer.addWidget"><code class="xref py py-obj docutils literal notranslate"><span class="pre">addWidget</span></code></a>(self, widget)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.addWidget" title="napari.qt.QtViewer.addWidget"><code class="xref py py-obj docutils literal notranslate"><span class="pre">addWidget</span></code></a>(self, widget)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.add_to_console_backlog" title="napari.qt.QtViewer.add_to_console_backlog"><code class="xref py py-obj docutils literal notranslate"><span class="pre">add_to_console_backlog</span></code></a>(variables)</p></td>
@@ -756,16 +756,16 @@ have a custom canvas here.</p>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.baseSize" title="napari.qt.QtViewer.baseSize"><code class="xref py py-obj docutils literal notranslate"><span class="pre">baseSize</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.blockSignals" title="napari.qt.QtViewer.blockSignals"><code class="xref py py-obj docutils literal notranslate"><span class="pre">blockSignals</span></code></a>(self, b)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.blockSignals" title="napari.qt.QtViewer.blockSignals"><code class="xref py py-obj docutils literal notranslate"><span class="pre">blockSignals</span></code></a>(self, b)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.changeEvent" title="napari.qt.QtViewer.changeEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">changeEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.changeEvent" title="napari.qt.QtViewer.changeEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">changeEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.childAt" title="napari.qt.QtViewer.childAt"><code class="xref py py-obj docutils literal notranslate"><span class="pre">childAt</span></code></a>(-&gt; Optional[QWidget])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.childAt" title="napari.qt.QtViewer.childAt"><code class="xref py py-obj docutils literal notranslate"><span class="pre">childAt</span></code></a>(-&gt; Optional[QWidget])</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.childEvent" title="napari.qt.QtViewer.childEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">childEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.childEvent" title="napari.qt.QtViewer.childEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">childEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.children" title="napari.qt.QtViewer.children"><code class="xref py py-obj docutils literal notranslate"><span class="pre">children</span></code></a>(self)</p></td>
@@ -795,13 +795,13 @@ have a custom canvas here.</p>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.closeEvent" title="napari.qt.QtViewer.closeEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">closeEvent</span></code></a>(event)</p></td>
 <td><p>Cleanup and close.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.closestLegalPosition" title="napari.qt.QtViewer.closestLegalPosition"><code class="xref py py-obj docutils literal notranslate"><span class="pre">closestLegalPosition</span></code></a>(self, a0, a1)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.closestLegalPosition" title="napari.qt.QtViewer.closestLegalPosition"><code class="xref py py-obj docutils literal notranslate"><span class="pre">closestLegalPosition</span></code></a>(self, a0, a1)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.colorCount" title="napari.qt.QtViewer.colorCount"><code class="xref py py-obj docutils literal notranslate"><span class="pre">colorCount</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.connectNotify" title="napari.qt.QtViewer.connectNotify"><code class="xref py py-obj docutils literal notranslate"><span class="pre">connectNotify</span></code></a>(self, signal)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.connectNotify" title="napari.qt.QtViewer.connectNotify"><code class="xref py py-obj docutils literal notranslate"><span class="pre">connectNotify</span></code></a>(self, signal)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.contentsMargins" title="napari.qt.QtViewer.contentsMargins"><code class="xref py py-obj docutils literal notranslate"><span class="pre">contentsMargins</span></code></a>(self)</p></td>
@@ -810,7 +810,7 @@ have a custom canvas here.</p>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.contentsRect" title="napari.qt.QtViewer.contentsRect"><code class="xref py py-obj docutils literal notranslate"><span class="pre">contentsRect</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.contextMenuEvent" title="napari.qt.QtViewer.contextMenuEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">contextMenuEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.contextMenuEvent" title="napari.qt.QtViewer.contextMenuEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">contextMenuEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.contextMenuPolicy" title="napari.qt.QtViewer.contextMenuPolicy"><code class="xref py py-obj docutils literal notranslate"><span class="pre">contextMenuPolicy</span></code></a>(self)</p></td>
@@ -819,19 +819,19 @@ have a custom canvas here.</p>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.count" title="napari.qt.QtViewer.count"><code class="xref py py-obj docutils literal notranslate"><span class="pre">count</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.create" title="napari.qt.QtViewer.create"><code class="xref py py-obj docutils literal notranslate"><span class="pre">create</span></code></a>(self[, window, initializeWindow, ...])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.create" title="napari.qt.QtViewer.create"><code class="xref py py-obj docutils literal notranslate"><span class="pre">create</span></code></a>(self[, window, initializeWindow, ...])</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.createHandle" title="napari.qt.QtViewer.createHandle"><code class="xref py py-obj docutils literal notranslate"><span class="pre">createHandle</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.createWindowContainer" title="napari.qt.QtViewer.createWindowContainer"><code class="xref py py-obj docutils literal notranslate"><span class="pre">createWindowContainer</span></code></a>(window[, parent, flags])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.createWindowContainer" title="napari.qt.QtViewer.createWindowContainer"><code class="xref py py-obj docutils literal notranslate"><span class="pre">createWindowContainer</span></code></a>(window[, parent, flags])</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.cursor" title="napari.qt.QtViewer.cursor"><code class="xref py py-obj docutils literal notranslate"><span class="pre">cursor</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.customEvent" title="napari.qt.QtViewer.customEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">customEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.customEvent" title="napari.qt.QtViewer.customEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">customEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.deleteLater" title="napari.qt.QtViewer.deleteLater"><code class="xref py py-obj docutils literal notranslate"><span class="pre">deleteLater</span></code></a>(self)</p></td>
@@ -840,7 +840,7 @@ have a custom canvas here.</p>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.depth" title="napari.qt.QtViewer.depth"><code class="xref py py-obj docutils literal notranslate"><span class="pre">depth</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.destroy" title="napari.qt.QtViewer.destroy"><code class="xref py py-obj docutils literal notranslate"><span class="pre">destroy</span></code></a>(self[, destroyWindow, destroySubWindows])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.destroy" title="napari.qt.QtViewer.destroy"><code class="xref py py-obj docutils literal notranslate"><span class="pre">destroy</span></code></a>(self[, destroyWindow, destroySubWindows])</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.devType" title="napari.qt.QtViewer.devType"><code class="xref py py-obj docutils literal notranslate"><span class="pre">devType</span></code></a>(self)</p></td>
@@ -855,22 +855,22 @@ have a custom canvas here.</p>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.devicePixelRatioFScale" title="napari.qt.QtViewer.devicePixelRatioFScale"><code class="xref py py-obj docutils literal notranslate"><span class="pre">devicePixelRatioFScale</span></code></a>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.disconnect" title="napari.qt.QtViewer.disconnect"><code class="xref py py-obj docutils literal notranslate"><span class="pre">disconnect</span></code></a>(-&gt; bool)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.disconnect" title="napari.qt.QtViewer.disconnect"><code class="xref py py-obj docutils literal notranslate"><span class="pre">disconnect</span></code></a>(-&gt; bool)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.disconnectNotify" title="napari.qt.QtViewer.disconnectNotify"><code class="xref py py-obj docutils literal notranslate"><span class="pre">disconnectNotify</span></code></a>(self, signal)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.disconnectNotify" title="napari.qt.QtViewer.disconnectNotify"><code class="xref py py-obj docutils literal notranslate"><span class="pre">disconnectNotify</span></code></a>(self, signal)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.dragEnterEvent" title="napari.qt.QtViewer.dragEnterEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">dragEnterEvent</span></code></a>(event)</p></td>
 <td><p>Ignore event if not dragging &amp; dropping a file or URL to open.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.dragLeaveEvent" title="napari.qt.QtViewer.dragLeaveEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">dragLeaveEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.dragLeaveEvent" title="napari.qt.QtViewer.dragLeaveEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">dragLeaveEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.dragMoveEvent" title="napari.qt.QtViewer.dragMoveEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">dragMoveEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.dragMoveEvent" title="napari.qt.QtViewer.dragMoveEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">dragMoveEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.drawFrame" title="napari.qt.QtViewer.drawFrame"><code class="xref py py-obj docutils literal notranslate"><span class="pre">drawFrame</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.drawFrame" title="napari.qt.QtViewer.drawFrame"><code class="xref py py-obj docutils literal notranslate"><span class="pre">drawFrame</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.dropEvent" title="napari.qt.QtViewer.dropEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">dropEvent</span></code></a>(event)</p></td>
@@ -891,40 +891,40 @@ have a custom canvas here.</p>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.ensurePolished" title="napari.qt.QtViewer.ensurePolished"><code class="xref py py-obj docutils literal notranslate"><span class="pre">ensurePolished</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.enterEvent" title="napari.qt.QtViewer.enterEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">enterEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.enterEvent" title="napari.qt.QtViewer.enterEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">enterEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.event" title="napari.qt.QtViewer.event"><code class="xref py py-obj docutils literal notranslate"><span class="pre">event</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.event" title="napari.qt.QtViewer.event"><code class="xref py py-obj docutils literal notranslate"><span class="pre">event</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.eventFilter" title="napari.qt.QtViewer.eventFilter"><code class="xref py py-obj docutils literal notranslate"><span class="pre">eventFilter</span></code></a>(self, a0, a1)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.eventFilter" title="napari.qt.QtViewer.eventFilter"><code class="xref py py-obj docutils literal notranslate"><span class="pre">eventFilter</span></code></a>(self, a0, a1)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.export_figure" title="napari.qt.QtViewer.export_figure"><code class="xref py py-obj docutils literal notranslate"><span class="pre">export_figure</span></code></a>([path, scale, flash])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.export_figure" title="napari.qt.QtViewer.export_figure"><code class="xref py py-obj docutils literal notranslate"><span class="pre">export_figure</span></code></a>([path, scale, flash])</p></td>
 <td><p>Export an image of the full extent of the displayed layer data.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.export_rois" title="napari.qt.QtViewer.export_rois"><code class="xref py py-obj docutils literal notranslate"><span class="pre">export_rois</span></code></a>(rois[, paths, scale])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.export_rois" title="napari.qt.QtViewer.export_rois"><code class="xref py py-obj docutils literal notranslate"><span class="pre">export_rois</span></code></a>(rois[, paths, scale])</p></td>
 <td><p>Export the given rectangular rois to specified file paths.</p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.find" title="napari.qt.QtViewer.find"><code class="xref py py-obj docutils literal notranslate"><span class="pre">find</span></code></a>(a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.findChild" title="napari.qt.QtViewer.findChild"><code class="xref py py-obj docutils literal notranslate"><span class="pre">findChild</span></code></a>(-&gt; QObjectT)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.findChild" title="napari.qt.QtViewer.findChild"><code class="xref py py-obj docutils literal notranslate"><span class="pre">findChild</span></code></a>(-&gt; QObjectT)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.findChildren" title="napari.qt.QtViewer.findChildren"><code class="xref py py-obj docutils literal notranslate"><span class="pre">findChildren</span></code></a>(...)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.focusInEvent" title="napari.qt.QtViewer.focusInEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">focusInEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.focusInEvent" title="napari.qt.QtViewer.focusInEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">focusInEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.focusNextChild" title="napari.qt.QtViewer.focusNextChild"><code class="xref py py-obj docutils literal notranslate"><span class="pre">focusNextChild</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.focusNextPrevChild" title="napari.qt.QtViewer.focusNextPrevChild"><code class="xref py py-obj docutils literal notranslate"><span class="pre">focusNextPrevChild</span></code></a>(self, next)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.focusNextPrevChild" title="napari.qt.QtViewer.focusNextPrevChild"><code class="xref py py-obj docutils literal notranslate"><span class="pre">focusNextPrevChild</span></code></a>(self, next)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.focusOutEvent" title="napari.qt.QtViewer.focusOutEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">focusOutEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.focusOutEvent" title="napari.qt.QtViewer.focusOutEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">focusOutEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.focusPolicy" title="napari.qt.QtViewer.focusPolicy"><code class="xref py py-obj docutils literal notranslate"><span class="pre">focusPolicy</span></code></a>(self)</p></td>
@@ -978,13 +978,13 @@ have a custom canvas here.</p>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.getContentsMargins" title="napari.qt.QtViewer.getContentsMargins"><code class="xref py py-obj docutils literal notranslate"><span class="pre">getContentsMargins</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.getRange" title="napari.qt.QtViewer.getRange"><code class="xref py py-obj docutils literal notranslate"><span class="pre">getRange</span></code></a>(self, index)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.getRange" title="napari.qt.QtViewer.getRange"><code class="xref py py-obj docutils literal notranslate"><span class="pre">getRange</span></code></a>(self, index)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.grab" title="napari.qt.QtViewer.grab"><code class="xref py py-obj docutils literal notranslate"><span class="pre">grab</span></code></a>(self[, rectangle])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.grab" title="napari.qt.QtViewer.grab"><code class="xref py py-obj docutils literal notranslate"><span class="pre">grab</span></code></a>(self[, rectangle])</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.grabGesture" title="napari.qt.QtViewer.grabGesture"><code class="xref py py-obj docutils literal notranslate"><span class="pre">grabGesture</span></code></a>(self, type[, flags])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.grabGesture" title="napari.qt.QtViewer.grabGesture"><code class="xref py py-obj docutils literal notranslate"><span class="pre">grabGesture</span></code></a>(self, type[, flags])</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.grabKeyboard" title="napari.qt.QtViewer.grabKeyboard"><code class="xref py py-obj docutils literal notranslate"><span class="pre">grabKeyboard</span></code></a>(self)</p></td>
@@ -993,7 +993,7 @@ have a custom canvas here.</p>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.grabMouse" title="napari.qt.QtViewer.grabMouse"><code class="xref py py-obj docutils literal notranslate"><span class="pre">grabMouse</span></code></a>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.grabShortcut" title="napari.qt.QtViewer.grabShortcut"><code class="xref py py-obj docutils literal notranslate"><span class="pre">grabShortcut</span></code></a>(self, key[, context])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.grabShortcut" title="napari.qt.QtViewer.grabShortcut"><code class="xref py py-obj docutils literal notranslate"><span class="pre">grabShortcut</span></code></a>(self, key[, context])</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.graphicsEffect" title="napari.qt.QtViewer.graphicsEffect"><code class="xref py py-obj docutils literal notranslate"><span class="pre">graphicsEffect</span></code></a>(self)</p></td>
@@ -1002,7 +1002,7 @@ have a custom canvas here.</p>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.graphicsProxyWidget" title="napari.qt.QtViewer.graphicsProxyWidget"><code class="xref py py-obj docutils literal notranslate"><span class="pre">graphicsProxyWidget</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.handle" title="napari.qt.QtViewer.handle"><code class="xref py py-obj docutils literal notranslate"><span class="pre">handle</span></code></a>(self, index)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.handle" title="napari.qt.QtViewer.handle"><code class="xref py py-obj docutils literal notranslate"><span class="pre">handle</span></code></a>(self, index)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.handleWidth" title="napari.qt.QtViewer.handleWidth"><code class="xref py py-obj docutils literal notranslate"><span class="pre">handleWidth</span></code></a>(self)</p></td>
@@ -1023,7 +1023,7 @@ have a custom canvas here.</p>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.height" title="napari.qt.QtViewer.height"><code class="xref py py-obj docutils literal notranslate"><span class="pre">height</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.heightForWidth" title="napari.qt.QtViewer.heightForWidth"><code class="xref py py-obj docutils literal notranslate"><span class="pre">heightForWidth</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.heightForWidth" title="napari.qt.QtViewer.heightForWidth"><code class="xref py py-obj docutils literal notranslate"><span class="pre">heightForWidth</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.heightMM" title="napari.qt.QtViewer.heightMM"><code class="xref py py-obj docutils literal notranslate"><span class="pre">heightMM</span></code></a>(self)</p></td>
@@ -1032,55 +1032,55 @@ have a custom canvas here.</p>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.hide" title="napari.qt.QtViewer.hide"><code class="xref py py-obj docutils literal notranslate"><span class="pre">hide</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.hideEvent" title="napari.qt.QtViewer.hideEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">hideEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.hideEvent" title="napari.qt.QtViewer.hideEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">hideEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.indexOf" title="napari.qt.QtViewer.indexOf"><code class="xref py py-obj docutils literal notranslate"><span class="pre">indexOf</span></code></a>(self, w)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.indexOf" title="napari.qt.QtViewer.indexOf"><code class="xref py py-obj docutils literal notranslate"><span class="pre">indexOf</span></code></a>(self, w)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.inherits" title="napari.qt.QtViewer.inherits"><code class="xref py py-obj docutils literal notranslate"><span class="pre">inherits</span></code></a>(self, classname)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.inherits" title="napari.qt.QtViewer.inherits"><code class="xref py py-obj docutils literal notranslate"><span class="pre">inherits</span></code></a>(self, classname)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.initPainter" title="napari.qt.QtViewer.initPainter"><code class="xref py py-obj docutils literal notranslate"><span class="pre">initPainter</span></code></a>(self, painter)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.initPainter" title="napari.qt.QtViewer.initPainter"><code class="xref py py-obj docutils literal notranslate"><span class="pre">initPainter</span></code></a>(self, painter)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.initStyleOption" title="napari.qt.QtViewer.initStyleOption"><code class="xref py py-obj docutils literal notranslate"><span class="pre">initStyleOption</span></code></a>(self, option)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.initStyleOption" title="napari.qt.QtViewer.initStyleOption"><code class="xref py py-obj docutils literal notranslate"><span class="pre">initStyleOption</span></code></a>(self, option)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.inputMethodEvent" title="napari.qt.QtViewer.inputMethodEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">inputMethodEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.inputMethodEvent" title="napari.qt.QtViewer.inputMethodEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">inputMethodEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.inputMethodHints" title="napari.qt.QtViewer.inputMethodHints"><code class="xref py py-obj docutils literal notranslate"><span class="pre">inputMethodHints</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.inputMethodQuery" title="napari.qt.QtViewer.inputMethodQuery"><code class="xref py py-obj docutils literal notranslate"><span class="pre">inputMethodQuery</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.inputMethodQuery" title="napari.qt.QtViewer.inputMethodQuery"><code class="xref py py-obj docutils literal notranslate"><span class="pre">inputMethodQuery</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.insertAction" title="napari.qt.QtViewer.insertAction"><code class="xref py py-obj docutils literal notranslate"><span class="pre">insertAction</span></code></a>(self, before, action)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.insertAction" title="napari.qt.QtViewer.insertAction"><code class="xref py py-obj docutils literal notranslate"><span class="pre">insertAction</span></code></a>(self, before, action)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.insertActions" title="napari.qt.QtViewer.insertActions"><code class="xref py py-obj docutils literal notranslate"><span class="pre">insertActions</span></code></a>(self, before, actions)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.insertActions" title="napari.qt.QtViewer.insertActions"><code class="xref py py-obj docutils literal notranslate"><span class="pre">insertActions</span></code></a>(self, before, actions)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.insertWidget" title="napari.qt.QtViewer.insertWidget"><code class="xref py py-obj docutils literal notranslate"><span class="pre">insertWidget</span></code></a>(self, index, widget)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.insertWidget" title="napari.qt.QtViewer.insertWidget"><code class="xref py py-obj docutils literal notranslate"><span class="pre">insertWidget</span></code></a>(self, index, widget)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.installEventFilter" title="napari.qt.QtViewer.installEventFilter"><code class="xref py py-obj docutils literal notranslate"><span class="pre">installEventFilter</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.installEventFilter" title="napari.qt.QtViewer.installEventFilter"><code class="xref py py-obj docutils literal notranslate"><span class="pre">installEventFilter</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.isActiveWindow" title="napari.qt.QtViewer.isActiveWindow"><code class="xref py py-obj docutils literal notranslate"><span class="pre">isActiveWindow</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.isAncestorOf" title="napari.qt.QtViewer.isAncestorOf"><code class="xref py py-obj docutils literal notranslate"><span class="pre">isAncestorOf</span></code></a>(self, child)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.isAncestorOf" title="napari.qt.QtViewer.isAncestorOf"><code class="xref py py-obj docutils literal notranslate"><span class="pre">isAncestorOf</span></code></a>(self, child)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.isCollapsible" title="napari.qt.QtViewer.isCollapsible"><code class="xref py py-obj docutils literal notranslate"><span class="pre">isCollapsible</span></code></a>(self, index)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.isCollapsible" title="napari.qt.QtViewer.isCollapsible"><code class="xref py py-obj docutils literal notranslate"><span class="pre">isCollapsible</span></code></a>(self, index)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.isEnabled" title="napari.qt.QtViewer.isEnabled"><code class="xref py py-obj docutils literal notranslate"><span class="pre">isEnabled</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.isEnabledTo" title="napari.qt.QtViewer.isEnabledTo"><code class="xref py py-obj docutils literal notranslate"><span class="pre">isEnabledTo</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.isEnabledTo" title="napari.qt.QtViewer.isEnabledTo"><code class="xref py py-obj docutils literal notranslate"><span class="pre">isEnabledTo</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.isFullScreen" title="napari.qt.QtViewer.isFullScreen"><code class="xref py py-obj docutils literal notranslate"><span class="pre">isFullScreen</span></code></a>(self)</p></td>
@@ -1104,13 +1104,13 @@ have a custom canvas here.</p>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.isRightToLeft" title="napari.qt.QtViewer.isRightToLeft"><code class="xref py py-obj docutils literal notranslate"><span class="pre">isRightToLeft</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.isSignalConnected" title="napari.qt.QtViewer.isSignalConnected"><code class="xref py py-obj docutils literal notranslate"><span class="pre">isSignalConnected</span></code></a>(self, signal)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.isSignalConnected" title="napari.qt.QtViewer.isSignalConnected"><code class="xref py py-obj docutils literal notranslate"><span class="pre">isSignalConnected</span></code></a>(self, signal)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.isVisible" title="napari.qt.QtViewer.isVisible"><code class="xref py py-obj docutils literal notranslate"><span class="pre">isVisible</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.isVisibleTo" title="napari.qt.QtViewer.isVisibleTo"><code class="xref py py-obj docutils literal notranslate"><span class="pre">isVisibleTo</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.isVisibleTo" title="napari.qt.QtViewer.isVisibleTo"><code class="xref py py-obj docutils literal notranslate"><span class="pre">isVisibleTo</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.isWidgetType" title="napari.qt.QtViewer.isWidgetType"><code class="xref py py-obj docutils literal notranslate"><span class="pre">isWidgetType</span></code></a>(self)</p></td>
@@ -1134,7 +1134,7 @@ have a custom canvas here.</p>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.keyboardGrabber" title="napari.qt.QtViewer.keyboardGrabber"><code class="xref py py-obj docutils literal notranslate"><span class="pre">keyboardGrabber</span></code></a>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.killTimer" title="napari.qt.QtViewer.killTimer"><code class="xref py py-obj docutils literal notranslate"><span class="pre">killTimer</span></code></a>(self, id)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.killTimer" title="napari.qt.QtViewer.killTimer"><code class="xref py py-obj docutils literal notranslate"><span class="pre">killTimer</span></code></a>(self, id)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.layout" title="napari.qt.QtViewer.layout"><code class="xref py py-obj docutils literal notranslate"><span class="pre">layout</span></code></a>(self)</p></td>
@@ -1143,7 +1143,7 @@ have a custom canvas here.</p>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.layoutDirection" title="napari.qt.QtViewer.layoutDirection"><code class="xref py py-obj docutils literal notranslate"><span class="pre">layoutDirection</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.leaveEvent" title="napari.qt.QtViewer.leaveEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">leaveEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.leaveEvent" title="napari.qt.QtViewer.leaveEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">leaveEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.lineWidth" title="napari.qt.QtViewer.lineWidth"><code class="xref py py-obj docutils literal notranslate"><span class="pre">lineWidth</span></code></a>(self)</p></td>
@@ -1161,22 +1161,22 @@ have a custom canvas here.</p>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.lower" title="napari.qt.QtViewer.lower"><code class="xref py py-obj docutils literal notranslate"><span class="pre">lower</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.mapFrom" title="napari.qt.QtViewer.mapFrom"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mapFrom</span></code></a>(self, a0, a1)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.mapFrom" title="napari.qt.QtViewer.mapFrom"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mapFrom</span></code></a>(self, a0, a1)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.mapFromGlobal" title="napari.qt.QtViewer.mapFromGlobal"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mapFromGlobal</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.mapFromGlobal" title="napari.qt.QtViewer.mapFromGlobal"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mapFromGlobal</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.mapFromParent" title="napari.qt.QtViewer.mapFromParent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mapFromParent</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.mapFromParent" title="napari.qt.QtViewer.mapFromParent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mapFromParent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.mapTo" title="napari.qt.QtViewer.mapTo"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mapTo</span></code></a>(self, a0, a1)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.mapTo" title="napari.qt.QtViewer.mapTo"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mapTo</span></code></a>(self, a0, a1)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.mapToGlobal" title="napari.qt.QtViewer.mapToGlobal"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mapToGlobal</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.mapToGlobal" title="napari.qt.QtViewer.mapToGlobal"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mapToGlobal</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.mapToParent" title="napari.qt.QtViewer.mapToParent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mapToParent</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.mapToParent" title="napari.qt.QtViewer.mapToParent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mapToParent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.mask" title="napari.qt.QtViewer.mask"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mask</span></code></a>(self)</p></td>
@@ -1194,7 +1194,7 @@ have a custom canvas here.</p>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.metaObject" title="napari.qt.QtViewer.metaObject"><code class="xref py py-obj docutils literal notranslate"><span class="pre">metaObject</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.metric" title="napari.qt.QtViewer.metric"><code class="xref py py-obj docutils literal notranslate"><span class="pre">metric</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.metric" title="napari.qt.QtViewer.metric"><code class="xref py py-obj docutils literal notranslate"><span class="pre">metric</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.midLineWidth" title="napari.qt.QtViewer.midLineWidth"><code class="xref py py-obj docutils literal notranslate"><span class="pre">midLineWidth</span></code></a>(self)</p></td>
@@ -1212,34 +1212,34 @@ have a custom canvas here.</p>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.minimumWidth" title="napari.qt.QtViewer.minimumWidth"><code class="xref py py-obj docutils literal notranslate"><span class="pre">minimumWidth</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.mouseDoubleClickEvent" title="napari.qt.QtViewer.mouseDoubleClickEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mouseDoubleClickEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.mouseDoubleClickEvent" title="napari.qt.QtViewer.mouseDoubleClickEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mouseDoubleClickEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.mouseGrabber" title="napari.qt.QtViewer.mouseGrabber"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mouseGrabber</span></code></a>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.mouseMoveEvent" title="napari.qt.QtViewer.mouseMoveEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mouseMoveEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.mouseMoveEvent" title="napari.qt.QtViewer.mouseMoveEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mouseMoveEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.mousePressEvent" title="napari.qt.QtViewer.mousePressEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mousePressEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.mousePressEvent" title="napari.qt.QtViewer.mousePressEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mousePressEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.mouseReleaseEvent" title="napari.qt.QtViewer.mouseReleaseEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mouseReleaseEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.mouseReleaseEvent" title="napari.qt.QtViewer.mouseReleaseEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mouseReleaseEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.move" title="napari.qt.QtViewer.move"><code class="xref py py-obj docutils literal notranslate"><span class="pre">move</span></code></a>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.moveEvent" title="napari.qt.QtViewer.moveEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">moveEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.moveEvent" title="napari.qt.QtViewer.moveEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">moveEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.moveSplitter" title="napari.qt.QtViewer.moveSplitter"><code class="xref py py-obj docutils literal notranslate"><span class="pre">moveSplitter</span></code></a>(self, pos, index)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.moveSplitter" title="napari.qt.QtViewer.moveSplitter"><code class="xref py py-obj docutils literal notranslate"><span class="pre">moveSplitter</span></code></a>(self, pos, index)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.moveToThread" title="napari.qt.QtViewer.moveToThread"><code class="xref py py-obj docutils literal notranslate"><span class="pre">moveToThread</span></code></a>(self, thread)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.moveToThread" title="napari.qt.QtViewer.moveToThread"><code class="xref py py-obj docutils literal notranslate"><span class="pre">moveToThread</span></code></a>(self, thread)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.nativeEvent" title="napari.qt.QtViewer.nativeEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">nativeEvent</span></code></a>(self, eventType, message)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.nativeEvent" title="napari.qt.QtViewer.nativeEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">nativeEvent</span></code></a>(self, eventType, message)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.nativeParentWidget" title="napari.qt.QtViewer.nativeParentWidget"><code class="xref py py-obj docutils literal notranslate"><span class="pre">nativeParentWidget</span></code></a>(self)</p></td>
@@ -1260,16 +1260,16 @@ have a custom canvas here.</p>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.orientation" title="napari.qt.QtViewer.orientation"><code class="xref py py-obj docutils literal notranslate"><span class="pre">orientation</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.overrideWindowFlags" title="napari.qt.QtViewer.overrideWindowFlags"><code class="xref py py-obj docutils literal notranslate"><span class="pre">overrideWindowFlags</span></code></a>(self, type)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.overrideWindowFlags" title="napari.qt.QtViewer.overrideWindowFlags"><code class="xref py py-obj docutils literal notranslate"><span class="pre">overrideWindowFlags</span></code></a>(self, type)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.overrideWindowState" title="napari.qt.QtViewer.overrideWindowState"><code class="xref py py-obj docutils literal notranslate"><span class="pre">overrideWindowState</span></code></a>(self, state)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.overrideWindowState" title="napari.qt.QtViewer.overrideWindowState"><code class="xref py py-obj docutils literal notranslate"><span class="pre">overrideWindowState</span></code></a>(self, state)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.paintEngine" title="napari.qt.QtViewer.paintEngine"><code class="xref py py-obj docutils literal notranslate"><span class="pre">paintEngine</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.paintEvent" title="napari.qt.QtViewer.paintEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">paintEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.paintEvent" title="napari.qt.QtViewer.paintEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">paintEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.paintingActive" title="napari.qt.QtViewer.paintingActive"><code class="xref py py-obj docutils literal notranslate"><span class="pre">paintingActive</span></code></a>(self)</p></td>
@@ -1296,7 +1296,7 @@ have a custom canvas here.</p>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.previousInFocusChain" title="napari.qt.QtViewer.previousInFocusChain"><code class="xref py py-obj docutils literal notranslate"><span class="pre">previousInFocusChain</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.property" title="napari.qt.QtViewer.property"><code class="xref py py-obj docutils literal notranslate"><span class="pre">property</span></code></a>(self, name)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.property" title="napari.qt.QtViewer.property"><code class="xref py py-obj docutils literal notranslate"><span class="pre">property</span></code></a>(self, name)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.pyqtConfigure" title="napari.qt.QtViewer.pyqtConfigure"><code class="xref py py-obj docutils literal notranslate"><span class="pre">pyqtConfigure</span></code></a>(...)</p></td>
@@ -1305,7 +1305,7 @@ have a custom canvas here.</p>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.raise_" title="napari.qt.QtViewer.raise_"><code class="xref py py-obj docutils literal notranslate"><span class="pre">raise_</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.receivers" title="napari.qt.QtViewer.receivers"><code class="xref py py-obj docutils literal notranslate"><span class="pre">receivers</span></code></a>(self, signal)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.receivers" title="napari.qt.QtViewer.receivers"><code class="xref py py-obj docutils literal notranslate"><span class="pre">receivers</span></code></a>(self, signal)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.rect" title="napari.qt.QtViewer.rect"><code class="xref py py-obj docutils literal notranslate"><span class="pre">rect</span></code></a>(self)</p></td>
@@ -1320,38 +1320,38 @@ have a custom canvas here.</p>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.releaseMouse" title="napari.qt.QtViewer.releaseMouse"><code class="xref py py-obj docutils literal notranslate"><span class="pre">releaseMouse</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.releaseShortcut" title="napari.qt.QtViewer.releaseShortcut"><code class="xref py py-obj docutils literal notranslate"><span class="pre">releaseShortcut</span></code></a>(self, id)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.releaseShortcut" title="napari.qt.QtViewer.releaseShortcut"><code class="xref py py-obj docutils literal notranslate"><span class="pre">releaseShortcut</span></code></a>(self, id)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.removeAction" title="napari.qt.QtViewer.removeAction"><code class="xref py py-obj docutils literal notranslate"><span class="pre">removeAction</span></code></a>(self, action)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.removeAction" title="napari.qt.QtViewer.removeAction"><code class="xref py py-obj docutils literal notranslate"><span class="pre">removeAction</span></code></a>(self, action)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.removeEventFilter" title="napari.qt.QtViewer.removeEventFilter"><code class="xref py py-obj docutils literal notranslate"><span class="pre">removeEventFilter</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.removeEventFilter" title="napari.qt.QtViewer.removeEventFilter"><code class="xref py py-obj docutils literal notranslate"><span class="pre">removeEventFilter</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.render" title="napari.qt.QtViewer.render"><code class="xref py py-obj docutils literal notranslate"><span class="pre">render</span></code></a>(, sourceRegion, flags, ...)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.render" title="napari.qt.QtViewer.render"><code class="xref py py-obj docutils literal notranslate"><span class="pre">render</span></code></a>(, sourceRegion, flags, ...)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.repaint" title="napari.qt.QtViewer.repaint"><code class="xref py py-obj docutils literal notranslate"><span class="pre">repaint</span></code></a>(-&gt; None
- -&gt; None)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.repaint" title="napari.qt.QtViewer.repaint"><code class="xref py py-obj docutils literal notranslate"><span class="pre">repaint</span></code></a>(-&gt; None
+ -&gt; None)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.replaceWidget" title="napari.qt.QtViewer.replaceWidget"><code class="xref py py-obj docutils literal notranslate"><span class="pre">replaceWidget</span></code></a>(self, index, widget)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.replaceWidget" title="napari.qt.QtViewer.replaceWidget"><code class="xref py py-obj docutils literal notranslate"><span class="pre">replaceWidget</span></code></a>(self, index, widget)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.resize" title="napari.qt.QtViewer.resize"><code class="xref py py-obj docutils literal notranslate"><span class="pre">resize</span></code></a>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.resizeEvent" title="napari.qt.QtViewer.resizeEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">resizeEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.resizeEvent" title="napari.qt.QtViewer.resizeEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">resizeEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.resize_canvas" title="napari.qt.QtViewer.resize_canvas"><code class="xref py py-obj docutils literal notranslate"><span class="pre">resize_canvas</span></code></a>(size, scale)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.resize_canvas" title="napari.qt.QtViewer.resize_canvas"><code class="xref py py-obj docutils literal notranslate"><span class="pre">resize_canvas</span></code></a>(size, scale)</p></td>
 <td><p>Temporarily, safely, resize the canvas</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.restoreGeometry" title="napari.qt.QtViewer.restoreGeometry"><code class="xref py py-obj docutils literal notranslate"><span class="pre">restoreGeometry</span></code></a>(self, geometry)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.restoreGeometry" title="napari.qt.QtViewer.restoreGeometry"><code class="xref py py-obj docutils literal notranslate"><span class="pre">restoreGeometry</span></code></a>(self, geometry)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.restoreState" title="napari.qt.QtViewer.restoreState"><code class="xref py py-obj docutils literal notranslate"><span class="pre">restoreState</span></code></a>(self, state)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.restoreState" title="napari.qt.QtViewer.restoreState"><code class="xref py py-obj docutils literal notranslate"><span class="pre">restoreState</span></code></a>(self, state)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.saveGeometry" title="napari.qt.QtViewer.saveGeometry"><code class="xref py py-obj docutils literal notranslate"><span class="pre">saveGeometry</span></code></a>(self)</p></td>
@@ -1363,7 +1363,7 @@ have a custom canvas here.</p>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.screen" title="napari.qt.QtViewer.screen"><code class="xref py py-obj docutils literal notranslate"><span class="pre">screen</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.screenshot" title="napari.qt.QtViewer.screenshot"><code class="xref py py-obj docutils literal notranslate"><span class="pre">screenshot</span></code></a>([path, flash, size, scale, ...])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.screenshot" title="napari.qt.QtViewer.screenshot"><code class="xref py py-obj docutils literal notranslate"><span class="pre">screenshot</span></code></a>([path, flash, size, scale, ...])</p></td>
 <td><p>Take currently displayed screen and convert to an image array.</p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.scroll" title="napari.qt.QtViewer.scroll"><code class="xref py py-obj docutils literal notranslate"><span class="pre">scroll</span></code></a>()</p></td>
@@ -1375,163 +1375,163 @@ have a custom canvas here.</p>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.senderSignalIndex" title="napari.qt.QtViewer.senderSignalIndex"><code class="xref py py-obj docutils literal notranslate"><span class="pre">senderSignalIndex</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setAcceptDrops" title="napari.qt.QtViewer.setAcceptDrops"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setAcceptDrops</span></code></a>(self, on)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setAcceptDrops" title="napari.qt.QtViewer.setAcceptDrops"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setAcceptDrops</span></code></a>(self, on)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setAccessibleDescription" title="napari.qt.QtViewer.setAccessibleDescription"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setAccessibleDescription</span></code></a>(self, description)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setAccessibleDescription" title="napari.qt.QtViewer.setAccessibleDescription"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setAccessibleDescription</span></code></a>(self, description)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setAccessibleName" title="napari.qt.QtViewer.setAccessibleName"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setAccessibleName</span></code></a>(self, name)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setAccessibleName" title="napari.qt.QtViewer.setAccessibleName"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setAccessibleName</span></code></a>(self, name)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setAttribute" title="napari.qt.QtViewer.setAttribute"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setAttribute</span></code></a>(self, attribute[, on])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setAttribute" title="napari.qt.QtViewer.setAttribute"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setAttribute</span></code></a>(self, attribute[, on])</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setAutoFillBackground" title="napari.qt.QtViewer.setAutoFillBackground"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setAutoFillBackground</span></code></a>(self, enabled)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setAutoFillBackground" title="napari.qt.QtViewer.setAutoFillBackground"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setAutoFillBackground</span></code></a>(self, enabled)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setBackgroundRole" title="napari.qt.QtViewer.setBackgroundRole"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setBackgroundRole</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setBackgroundRole" title="napari.qt.QtViewer.setBackgroundRole"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setBackgroundRole</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setBaseSize" title="napari.qt.QtViewer.setBaseSize"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setBaseSize</span></code></a>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setChildrenCollapsible" title="napari.qt.QtViewer.setChildrenCollapsible"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setChildrenCollapsible</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setChildrenCollapsible" title="napari.qt.QtViewer.setChildrenCollapsible"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setChildrenCollapsible</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setCollapsible" title="napari.qt.QtViewer.setCollapsible"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setCollapsible</span></code></a>(self, index, a1)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setCollapsible" title="napari.qt.QtViewer.setCollapsible"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setCollapsible</span></code></a>(self, index, a1)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setContentsMargins" title="napari.qt.QtViewer.setContentsMargins"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setContentsMargins</span></code></a>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setContextMenuPolicy" title="napari.qt.QtViewer.setContextMenuPolicy"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setContextMenuPolicy</span></code></a>(self, policy)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setContextMenuPolicy" title="napari.qt.QtViewer.setContextMenuPolicy"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setContextMenuPolicy</span></code></a>(self, policy)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setCursor" title="napari.qt.QtViewer.setCursor"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setCursor</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setCursor" title="napari.qt.QtViewer.setCursor"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setCursor</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setDisabled" title="napari.qt.QtViewer.setDisabled"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setDisabled</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setDisabled" title="napari.qt.QtViewer.setDisabled"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setDisabled</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setEnabled" title="napari.qt.QtViewer.setEnabled"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setEnabled</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setEnabled" title="napari.qt.QtViewer.setEnabled"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setEnabled</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setFixedHeight" title="napari.qt.QtViewer.setFixedHeight"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setFixedHeight</span></code></a>(self, h)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setFixedHeight" title="napari.qt.QtViewer.setFixedHeight"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setFixedHeight</span></code></a>(self, h)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setFixedSize" title="napari.qt.QtViewer.setFixedSize"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setFixedSize</span></code></a>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setFixedWidth" title="napari.qt.QtViewer.setFixedWidth"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setFixedWidth</span></code></a>(self, w)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setFixedWidth" title="napari.qt.QtViewer.setFixedWidth"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setFixedWidth</span></code></a>(self, w)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setFocus" title="napari.qt.QtViewer.setFocus"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setFocus</span></code></a>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setFocusPolicy" title="napari.qt.QtViewer.setFocusPolicy"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setFocusPolicy</span></code></a>(self, policy)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setFocusPolicy" title="napari.qt.QtViewer.setFocusPolicy"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setFocusPolicy</span></code></a>(self, policy)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setFocusProxy" title="napari.qt.QtViewer.setFocusProxy"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setFocusProxy</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setFocusProxy" title="napari.qt.QtViewer.setFocusProxy"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setFocusProxy</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setFont" title="napari.qt.QtViewer.setFont"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setFont</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setFont" title="napari.qt.QtViewer.setFont"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setFont</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setForegroundRole" title="napari.qt.QtViewer.setForegroundRole"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setForegroundRole</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setForegroundRole" title="napari.qt.QtViewer.setForegroundRole"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setForegroundRole</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setFrameRect" title="napari.qt.QtViewer.setFrameRect"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setFrameRect</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setFrameRect" title="napari.qt.QtViewer.setFrameRect"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setFrameRect</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setFrameShadow" title="napari.qt.QtViewer.setFrameShadow"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setFrameShadow</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setFrameShadow" title="napari.qt.QtViewer.setFrameShadow"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setFrameShadow</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setFrameShape" title="napari.qt.QtViewer.setFrameShape"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setFrameShape</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setFrameShape" title="napari.qt.QtViewer.setFrameShape"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setFrameShape</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setFrameStyle" title="napari.qt.QtViewer.setFrameStyle"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setFrameStyle</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setFrameStyle" title="napari.qt.QtViewer.setFrameStyle"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setFrameStyle</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setGeometry" title="napari.qt.QtViewer.setGeometry"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setGeometry</span></code></a>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setGraphicsEffect" title="napari.qt.QtViewer.setGraphicsEffect"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setGraphicsEffect</span></code></a>(self, effect)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setGraphicsEffect" title="napari.qt.QtViewer.setGraphicsEffect"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setGraphicsEffect</span></code></a>(self, effect)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setHandleWidth" title="napari.qt.QtViewer.setHandleWidth"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setHandleWidth</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setHandleWidth" title="napari.qt.QtViewer.setHandleWidth"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setHandleWidth</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setHidden" title="napari.qt.QtViewer.setHidden"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setHidden</span></code></a>(self, hidden)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setHidden" title="napari.qt.QtViewer.setHidden"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setHidden</span></code></a>(self, hidden)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setInputMethodHints" title="napari.qt.QtViewer.setInputMethodHints"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setInputMethodHints</span></code></a>(self, hints)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setInputMethodHints" title="napari.qt.QtViewer.setInputMethodHints"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setInputMethodHints</span></code></a>(self, hints)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setLayout" title="napari.qt.QtViewer.setLayout"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setLayout</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setLayout" title="napari.qt.QtViewer.setLayout"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setLayout</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setLayoutDirection" title="napari.qt.QtViewer.setLayoutDirection"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setLayoutDirection</span></code></a>(self, direction)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setLayoutDirection" title="napari.qt.QtViewer.setLayoutDirection"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setLayoutDirection</span></code></a>(self, direction)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setLineWidth" title="napari.qt.QtViewer.setLineWidth"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setLineWidth</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setLineWidth" title="napari.qt.QtViewer.setLineWidth"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setLineWidth</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setLocale" title="napari.qt.QtViewer.setLocale"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setLocale</span></code></a>(self, locale)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setLocale" title="napari.qt.QtViewer.setLocale"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setLocale</span></code></a>(self, locale)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setMask" title="napari.qt.QtViewer.setMask"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setMask</span></code></a>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setMaximumHeight" title="napari.qt.QtViewer.setMaximumHeight"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setMaximumHeight</span></code></a>(self, maxh)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setMaximumHeight" title="napari.qt.QtViewer.setMaximumHeight"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setMaximumHeight</span></code></a>(self, maxh)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setMaximumSize" title="napari.qt.QtViewer.setMaximumSize"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setMaximumSize</span></code></a>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setMaximumWidth" title="napari.qt.QtViewer.setMaximumWidth"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setMaximumWidth</span></code></a>(self, maxw)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setMaximumWidth" title="napari.qt.QtViewer.setMaximumWidth"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setMaximumWidth</span></code></a>(self, maxw)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setMidLineWidth" title="napari.qt.QtViewer.setMidLineWidth"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setMidLineWidth</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setMidLineWidth" title="napari.qt.QtViewer.setMidLineWidth"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setMidLineWidth</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setMinimumHeight" title="napari.qt.QtViewer.setMinimumHeight"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setMinimumHeight</span></code></a>(self, minh)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setMinimumHeight" title="napari.qt.QtViewer.setMinimumHeight"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setMinimumHeight</span></code></a>(self, minh)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setMinimumSize" title="napari.qt.QtViewer.setMinimumSize"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setMinimumSize</span></code></a>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setMinimumWidth" title="napari.qt.QtViewer.setMinimumWidth"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setMinimumWidth</span></code></a>(self, minw)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setMinimumWidth" title="napari.qt.QtViewer.setMinimumWidth"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setMinimumWidth</span></code></a>(self, minw)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setMouseTracking" title="napari.qt.QtViewer.setMouseTracking"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setMouseTracking</span></code></a>(self, enable)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setMouseTracking" title="napari.qt.QtViewer.setMouseTracking"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setMouseTracking</span></code></a>(self, enable)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setObjectName" title="napari.qt.QtViewer.setObjectName"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setObjectName</span></code></a>(self, name)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setObjectName" title="napari.qt.QtViewer.setObjectName"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setObjectName</span></code></a>(self, name)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setOpaqueResize" title="napari.qt.QtViewer.setOpaqueResize"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setOpaqueResize</span></code></a>(self[, opaque])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setOpaqueResize" title="napari.qt.QtViewer.setOpaqueResize"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setOpaqueResize</span></code></a>(self[, opaque])</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setOrientation" title="napari.qt.QtViewer.setOrientation"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setOrientation</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setOrientation" title="napari.qt.QtViewer.setOrientation"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setOrientation</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setPalette" title="napari.qt.QtViewer.setPalette"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setPalette</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setPalette" title="napari.qt.QtViewer.setPalette"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setPalette</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setParent" title="napari.qt.QtViewer.setParent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setParent</span></code></a>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setProperty" title="napari.qt.QtViewer.setProperty"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setProperty</span></code></a>(self, name, value)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setProperty" title="napari.qt.QtViewer.setProperty"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setProperty</span></code></a>(self, name, value)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setRubberBand" title="napari.qt.QtViewer.setRubberBand"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setRubberBand</span></code></a>(self, position)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setRubberBand" title="napari.qt.QtViewer.setRubberBand"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setRubberBand</span></code></a>(self, position)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setShortcutAutoRepeat" title="napari.qt.QtViewer.setShortcutAutoRepeat"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setShortcutAutoRepeat</span></code></a>(self, id[, enabled])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setShortcutAutoRepeat" title="napari.qt.QtViewer.setShortcutAutoRepeat"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setShortcutAutoRepeat</span></code></a>(self, id[, enabled])</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setShortcutEnabled" title="napari.qt.QtViewer.setShortcutEnabled"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setShortcutEnabled</span></code></a>(self, id[, enabled])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setShortcutEnabled" title="napari.qt.QtViewer.setShortcutEnabled"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setShortcutEnabled</span></code></a>(self, id[, enabled])</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setSizeIncrement" title="napari.qt.QtViewer.setSizeIncrement"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setSizeIncrement</span></code></a>()</p></td>
@@ -1540,73 +1540,73 @@ have a custom canvas here.</p>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setSizePolicy" title="napari.qt.QtViewer.setSizePolicy"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setSizePolicy</span></code></a>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setSizes" title="napari.qt.QtViewer.setSizes"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setSizes</span></code></a>(self, list)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setSizes" title="napari.qt.QtViewer.setSizes"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setSizes</span></code></a>(self, list)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setStatusTip" title="napari.qt.QtViewer.setStatusTip"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setStatusTip</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setStatusTip" title="napari.qt.QtViewer.setStatusTip"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setStatusTip</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setStretchFactor" title="napari.qt.QtViewer.setStretchFactor"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setStretchFactor</span></code></a>(self, index, stretch)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setStretchFactor" title="napari.qt.QtViewer.setStretchFactor"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setStretchFactor</span></code></a>(self, index, stretch)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setStyle" title="napari.qt.QtViewer.setStyle"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setStyle</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setStyle" title="napari.qt.QtViewer.setStyle"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setStyle</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setStyleSheet" title="napari.qt.QtViewer.setStyleSheet"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setStyleSheet</span></code></a>(self, styleSheet)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setStyleSheet" title="napari.qt.QtViewer.setStyleSheet"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setStyleSheet</span></code></a>(self, styleSheet)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setTabOrder" title="napari.qt.QtViewer.setTabOrder"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setTabOrder</span></code></a>(a0, a1)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setTabOrder" title="napari.qt.QtViewer.setTabOrder"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setTabOrder</span></code></a>(a0, a1)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setTabletTracking" title="napari.qt.QtViewer.setTabletTracking"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setTabletTracking</span></code></a>(self, enable)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setTabletTracking" title="napari.qt.QtViewer.setTabletTracking"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setTabletTracking</span></code></a>(self, enable)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setToolTip" title="napari.qt.QtViewer.setToolTip"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setToolTip</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setToolTip" title="napari.qt.QtViewer.setToolTip"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setToolTip</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setToolTipDuration" title="napari.qt.QtViewer.setToolTipDuration"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setToolTipDuration</span></code></a>(self, msec)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setToolTipDuration" title="napari.qt.QtViewer.setToolTipDuration"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setToolTipDuration</span></code></a>(self, msec)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setUpdatesEnabled" title="napari.qt.QtViewer.setUpdatesEnabled"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setUpdatesEnabled</span></code></a>(self, enable)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setUpdatesEnabled" title="napari.qt.QtViewer.setUpdatesEnabled"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setUpdatesEnabled</span></code></a>(self, enable)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setVisible" title="napari.qt.QtViewer.setVisible"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setVisible</span></code></a>(self, visible)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setVisible" title="napari.qt.QtViewer.setVisible"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setVisible</span></code></a>(self, visible)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setWhatsThis" title="napari.qt.QtViewer.setWhatsThis"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWhatsThis</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setWhatsThis" title="napari.qt.QtViewer.setWhatsThis"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWhatsThis</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setWindowFilePath" title="napari.qt.QtViewer.setWindowFilePath"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowFilePath</span></code></a>(self, filePath)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setWindowFilePath" title="napari.qt.QtViewer.setWindowFilePath"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowFilePath</span></code></a>(self, filePath)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setWindowFlag" title="napari.qt.QtViewer.setWindowFlag"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowFlag</span></code></a>(self, a0[, on])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setWindowFlag" title="napari.qt.QtViewer.setWindowFlag"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowFlag</span></code></a>(self, a0[, on])</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setWindowFlags" title="napari.qt.QtViewer.setWindowFlags"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowFlags</span></code></a>(self, type)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setWindowFlags" title="napari.qt.QtViewer.setWindowFlags"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowFlags</span></code></a>(self, type)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setWindowIcon" title="napari.qt.QtViewer.setWindowIcon"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowIcon</span></code></a>(self, icon)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setWindowIcon" title="napari.qt.QtViewer.setWindowIcon"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowIcon</span></code></a>(self, icon)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setWindowIconText" title="napari.qt.QtViewer.setWindowIconText"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowIconText</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setWindowIconText" title="napari.qt.QtViewer.setWindowIconText"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowIconText</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setWindowModality" title="napari.qt.QtViewer.setWindowModality"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowModality</span></code></a>(self, windowModality)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setWindowModality" title="napari.qt.QtViewer.setWindowModality"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowModality</span></code></a>(self, windowModality)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setWindowModified" title="napari.qt.QtViewer.setWindowModified"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowModified</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setWindowModified" title="napari.qt.QtViewer.setWindowModified"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowModified</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setWindowOpacity" title="napari.qt.QtViewer.setWindowOpacity"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowOpacity</span></code></a>(self, level)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setWindowOpacity" title="napari.qt.QtViewer.setWindowOpacity"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowOpacity</span></code></a>(self, level)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setWindowRole" title="napari.qt.QtViewer.setWindowRole"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowRole</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setWindowRole" title="napari.qt.QtViewer.setWindowRole"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowRole</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setWindowState" title="napari.qt.QtViewer.setWindowState"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowState</span></code></a>(self, state)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setWindowState" title="napari.qt.QtViewer.setWindowState"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowState</span></code></a>(self, state)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setWindowTitle" title="napari.qt.QtViewer.setWindowTitle"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowTitle</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.setWindowTitle" title="napari.qt.QtViewer.setWindowTitle"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowTitle</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.set_welcome_visible" title="napari.qt.QtViewer.set_welcome_visible"><code class="xref py py-obj docutils literal notranslate"><span class="pre">set_welcome_visible</span></code></a>(visible)</p></td>
@@ -1618,7 +1618,7 @@ have a custom canvas here.</p>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.show" title="napari.qt.QtViewer.show"><code class="xref py py-obj docutils literal notranslate"><span class="pre">show</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.showEvent" title="napari.qt.QtViewer.showEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">showEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.showEvent" title="napari.qt.QtViewer.showEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">showEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.showFullScreen" title="napari.qt.QtViewer.showFullScreen"><code class="xref py py-obj docutils literal notranslate"><span class="pre">showFullScreen</span></code></a>(self)</p></td>
@@ -1651,10 +1651,10 @@ have a custom canvas here.</p>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.sizes" title="napari.qt.QtViewer.sizes"><code class="xref py py-obj docutils literal notranslate"><span class="pre">sizes</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.stackUnder" title="napari.qt.QtViewer.stackUnder"><code class="xref py py-obj docutils literal notranslate"><span class="pre">stackUnder</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.stackUnder" title="napari.qt.QtViewer.stackUnder"><code class="xref py py-obj docutils literal notranslate"><span class="pre">stackUnder</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.startTimer" title="napari.qt.QtViewer.startTimer"><code class="xref py py-obj docutils literal notranslate"><span class="pre">startTimer</span></code></a>(self, interval[, timerType])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.startTimer" title="napari.qt.QtViewer.startTimer"><code class="xref py py-obj docutils literal notranslate"><span class="pre">startTimer</span></code></a>(self, interval[, timerType])</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.statusTip" title="napari.qt.QtViewer.statusTip"><code class="xref py py-obj docutils literal notranslate"><span class="pre">statusTip</span></code></a>(self)</p></td>
@@ -1666,16 +1666,16 @@ have a custom canvas here.</p>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.styleSheet" title="napari.qt.QtViewer.styleSheet"><code class="xref py py-obj docutils literal notranslate"><span class="pre">styleSheet</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.tabletEvent" title="napari.qt.QtViewer.tabletEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">tabletEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.tabletEvent" title="napari.qt.QtViewer.tabletEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">tabletEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.testAttribute" title="napari.qt.QtViewer.testAttribute"><code class="xref py py-obj docutils literal notranslate"><span class="pre">testAttribute</span></code></a>(self, attribute)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.testAttribute" title="napari.qt.QtViewer.testAttribute"><code class="xref py py-obj docutils literal notranslate"><span class="pre">testAttribute</span></code></a>(self, attribute)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.thread" title="napari.qt.QtViewer.thread"><code class="xref py py-obj docutils literal notranslate"><span class="pre">thread</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.timerEvent" title="napari.qt.QtViewer.timerEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">timerEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.timerEvent" title="napari.qt.QtViewer.timerEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">timerEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.toggle_console_visibility" title="napari.qt.QtViewer.toggle_console_visibility"><code class="xref py py-obj docutils literal notranslate"><span class="pre">toggle_console_visibility</span></code></a>([event])</p></td>
@@ -1687,13 +1687,13 @@ have a custom canvas here.</p>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.toolTipDuration" title="napari.qt.QtViewer.toolTipDuration"><code class="xref py py-obj docutils literal notranslate"><span class="pre">toolTipDuration</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.tr" title="napari.qt.QtViewer.tr"><code class="xref py py-obj docutils literal notranslate"><span class="pre">tr</span></code></a>(self, sourceText[, disambiguation, n])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.tr" title="napari.qt.QtViewer.tr"><code class="xref py py-obj docutils literal notranslate"><span class="pre">tr</span></code></a>(self, sourceText[, disambiguation, n])</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.underMouse" title="napari.qt.QtViewer.underMouse"><code class="xref py py-obj docutils literal notranslate"><span class="pre">underMouse</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.ungrabGesture" title="napari.qt.QtViewer.ungrabGesture"><code class="xref py py-obj docutils literal notranslate"><span class="pre">ungrabGesture</span></code></a>(self, type)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.ungrabGesture" title="napari.qt.QtViewer.ungrabGesture"><code class="xref py py-obj docutils literal notranslate"><span class="pre">ungrabGesture</span></code></a>(self, type)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.unsetCursor" title="napari.qt.QtViewer.unsetCursor"><code class="xref py py-obj docutils literal notranslate"><span class="pre">unsetCursor</span></code></a>(self)</p></td>
@@ -1705,8 +1705,8 @@ have a custom canvas here.</p>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.unsetLocale" title="napari.qt.QtViewer.unsetLocale"><code class="xref py py-obj docutils literal notranslate"><span class="pre">unsetLocale</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.update" title="napari.qt.QtViewer.update"><code class="xref py py-obj docutils literal notranslate"><span class="pre">update</span></code></a>(-&gt; None
- -&gt; None)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.update" title="napari.qt.QtViewer.update"><code class="xref py py-obj docutils literal notranslate"><span class="pre">update</span></code></a>(-&gt; None
+ -&gt; None)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.updateGeometry" title="napari.qt.QtViewer.updateGeometry"><code class="xref py py-obj docutils literal notranslate"><span class="pre">updateGeometry</span></code></a>(self)</p></td>
@@ -1724,10 +1724,10 @@ have a custom canvas here.</p>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.whatsThis" title="napari.qt.QtViewer.whatsThis"><code class="xref py py-obj docutils literal notranslate"><span class="pre">whatsThis</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.wheelEvent" title="napari.qt.QtViewer.wheelEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">wheelEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.wheelEvent" title="napari.qt.QtViewer.wheelEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">wheelEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.widget" title="napari.qt.QtViewer.widget"><code class="xref py py-obj docutils literal notranslate"><span class="pre">widget</span></code></a>(self, index)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewer.widget" title="napari.qt.QtViewer.widget"><code class="xref py py-obj docutils literal notranslate"><span class="pre">widget</span></code></a>(self, index)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewer.width" title="napari.qt.QtViewer.width"><code class="xref py py-obj docutils literal notranslate"><span class="pre">width</span></code></a>(self)</p></td>

--- a/0.6.5/api/napari.qt.QtViewerButtons.html
+++ b/0.6.5/api/napari.qt.QtViewerButtons.html
@@ -67,8 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
@@ -705,7 +705,7 @@
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.accessibleName" title="napari.qt.QtViewerButtons.accessibleName"><code class="xref py py-obj docutils literal notranslate"><span class="pre">accessibleName</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.actionEvent" title="napari.qt.QtViewerButtons.actionEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">actionEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.actionEvent" title="napari.qt.QtViewerButtons.actionEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">actionEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.actions" title="napari.qt.QtViewerButtons.actions"><code class="xref py py-obj docutils literal notranslate"><span class="pre">actions</span></code></a>(self)</p></td>
@@ -714,10 +714,10 @@
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.activateWindow" title="napari.qt.QtViewerButtons.activateWindow"><code class="xref py py-obj docutils literal notranslate"><span class="pre">activateWindow</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.addAction" title="napari.qt.QtViewerButtons.addAction"><code class="xref py py-obj docutils literal notranslate"><span class="pre">addAction</span></code></a>(self, action)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.addAction" title="napari.qt.QtViewerButtons.addAction"><code class="xref py py-obj docutils literal notranslate"><span class="pre">addAction</span></code></a>(self, action)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.addActions" title="napari.qt.QtViewerButtons.addActions"><code class="xref py py-obj docutils literal notranslate"><span class="pre">addActions</span></code></a>(self, actions)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.addActions" title="napari.qt.QtViewerButtons.addActions"><code class="xref py py-obj docutils literal notranslate"><span class="pre">addActions</span></code></a>(self, actions)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.adjustSize" title="napari.qt.QtViewerButtons.adjustSize"><code class="xref py py-obj docutils literal notranslate"><span class="pre">adjustSize</span></code></a>(self)</p></td>
@@ -732,16 +732,16 @@
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.baseSize" title="napari.qt.QtViewerButtons.baseSize"><code class="xref py py-obj docutils literal notranslate"><span class="pre">baseSize</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.blockSignals" title="napari.qt.QtViewerButtons.blockSignals"><code class="xref py py-obj docutils literal notranslate"><span class="pre">blockSignals</span></code></a>(self, b)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.blockSignals" title="napari.qt.QtViewerButtons.blockSignals"><code class="xref py py-obj docutils literal notranslate"><span class="pre">blockSignals</span></code></a>(self, b)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.changeEvent" title="napari.qt.QtViewerButtons.changeEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">changeEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.changeEvent" title="napari.qt.QtViewerButtons.changeEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">changeEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.childAt" title="napari.qt.QtViewerButtons.childAt"><code class="xref py py-obj docutils literal notranslate"><span class="pre">childAt</span></code></a>(-&gt; Optional[QWidget])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.childAt" title="napari.qt.QtViewerButtons.childAt"><code class="xref py py-obj docutils literal notranslate"><span class="pre">childAt</span></code></a>(-&gt; Optional[QWidget])</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.childEvent" title="napari.qt.QtViewerButtons.childEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">childEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.childEvent" title="napari.qt.QtViewerButtons.childEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">childEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.children" title="napari.qt.QtViewerButtons.children"><code class="xref py py-obj docutils literal notranslate"><span class="pre">children</span></code></a>(self)</p></td>
@@ -762,13 +762,13 @@
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.close" title="napari.qt.QtViewerButtons.close"><code class="xref py py-obj docutils literal notranslate"><span class="pre">close</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.closeEvent" title="napari.qt.QtViewerButtons.closeEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">closeEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.closeEvent" title="napari.qt.QtViewerButtons.closeEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">closeEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.colorCount" title="napari.qt.QtViewerButtons.colorCount"><code class="xref py py-obj docutils literal notranslate"><span class="pre">colorCount</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.connectNotify" title="napari.qt.QtViewerButtons.connectNotify"><code class="xref py py-obj docutils literal notranslate"><span class="pre">connectNotify</span></code></a>(self, signal)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.connectNotify" title="napari.qt.QtViewerButtons.connectNotify"><code class="xref py py-obj docutils literal notranslate"><span class="pre">connectNotify</span></code></a>(self, signal)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.contentsMargins" title="napari.qt.QtViewerButtons.contentsMargins"><code class="xref py py-obj docutils literal notranslate"><span class="pre">contentsMargins</span></code></a>(self)</p></td>
@@ -777,22 +777,22 @@
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.contentsRect" title="napari.qt.QtViewerButtons.contentsRect"><code class="xref py py-obj docutils literal notranslate"><span class="pre">contentsRect</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.contextMenuEvent" title="napari.qt.QtViewerButtons.contextMenuEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">contextMenuEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.contextMenuEvent" title="napari.qt.QtViewerButtons.contextMenuEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">contextMenuEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.contextMenuPolicy" title="napari.qt.QtViewerButtons.contextMenuPolicy"><code class="xref py py-obj docutils literal notranslate"><span class="pre">contextMenuPolicy</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.create" title="napari.qt.QtViewerButtons.create"><code class="xref py py-obj docutils literal notranslate"><span class="pre">create</span></code></a>(self[, window, initializeWindow, ...])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.create" title="napari.qt.QtViewerButtons.create"><code class="xref py py-obj docutils literal notranslate"><span class="pre">create</span></code></a>(self[, window, initializeWindow, ...])</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.createWindowContainer" title="napari.qt.QtViewerButtons.createWindowContainer"><code class="xref py py-obj docutils literal notranslate"><span class="pre">createWindowContainer</span></code></a>(window[, parent, flags])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.createWindowContainer" title="napari.qt.QtViewerButtons.createWindowContainer"><code class="xref py py-obj docutils literal notranslate"><span class="pre">createWindowContainer</span></code></a>(window[, parent, flags])</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.cursor" title="napari.qt.QtViewerButtons.cursor"><code class="xref py py-obj docutils literal notranslate"><span class="pre">cursor</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.customEvent" title="napari.qt.QtViewerButtons.customEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">customEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.customEvent" title="napari.qt.QtViewerButtons.customEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">customEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.deleteLater" title="napari.qt.QtViewerButtons.deleteLater"><code class="xref py py-obj docutils literal notranslate"><span class="pre">deleteLater</span></code></a>(self)</p></td>
@@ -801,7 +801,7 @@
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.depth" title="napari.qt.QtViewerButtons.depth"><code class="xref py py-obj docutils literal notranslate"><span class="pre">depth</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.destroy" title="napari.qt.QtViewerButtons.destroy"><code class="xref py py-obj docutils literal notranslate"><span class="pre">destroy</span></code></a>(self[, destroyWindow, destroySubWindows])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.destroy" title="napari.qt.QtViewerButtons.destroy"><code class="xref py py-obj docutils literal notranslate"><span class="pre">destroy</span></code></a>(self[, destroyWindow, destroySubWindows])</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.devType" title="napari.qt.QtViewerButtons.devType"><code class="xref py py-obj docutils literal notranslate"><span class="pre">devType</span></code></a>(self)</p></td>
@@ -816,25 +816,25 @@
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.devicePixelRatioFScale" title="napari.qt.QtViewerButtons.devicePixelRatioFScale"><code class="xref py py-obj docutils literal notranslate"><span class="pre">devicePixelRatioFScale</span></code></a>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.disconnect" title="napari.qt.QtViewerButtons.disconnect"><code class="xref py py-obj docutils literal notranslate"><span class="pre">disconnect</span></code></a>(-&gt; bool)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.disconnect" title="napari.qt.QtViewerButtons.disconnect"><code class="xref py py-obj docutils literal notranslate"><span class="pre">disconnect</span></code></a>(-&gt; bool)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.disconnectNotify" title="napari.qt.QtViewerButtons.disconnectNotify"><code class="xref py py-obj docutils literal notranslate"><span class="pre">disconnectNotify</span></code></a>(self, signal)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.disconnectNotify" title="napari.qt.QtViewerButtons.disconnectNotify"><code class="xref py py-obj docutils literal notranslate"><span class="pre">disconnectNotify</span></code></a>(self, signal)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.dragEnterEvent" title="napari.qt.QtViewerButtons.dragEnterEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">dragEnterEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.dragEnterEvent" title="napari.qt.QtViewerButtons.dragEnterEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">dragEnterEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.dragLeaveEvent" title="napari.qt.QtViewerButtons.dragLeaveEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">dragLeaveEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.dragLeaveEvent" title="napari.qt.QtViewerButtons.dragLeaveEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">dragLeaveEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.dragMoveEvent" title="napari.qt.QtViewerButtons.dragMoveEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">dragMoveEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.dragMoveEvent" title="napari.qt.QtViewerButtons.dragMoveEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">dragMoveEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.drawFrame" title="napari.qt.QtViewerButtons.drawFrame"><code class="xref py py-obj docutils literal notranslate"><span class="pre">drawFrame</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.drawFrame" title="napari.qt.QtViewerButtons.drawFrame"><code class="xref py py-obj docutils literal notranslate"><span class="pre">drawFrame</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.dropEvent" title="napari.qt.QtViewerButtons.dropEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">dropEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.dropEvent" title="napari.qt.QtViewerButtons.dropEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">dropEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.dumpObjectInfo" title="napari.qt.QtViewerButtons.dumpObjectInfo"><code class="xref py py-obj docutils literal notranslate"><span class="pre">dumpObjectInfo</span></code></a>(self)</p></td>
@@ -852,34 +852,34 @@
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.ensurePolished" title="napari.qt.QtViewerButtons.ensurePolished"><code class="xref py py-obj docutils literal notranslate"><span class="pre">ensurePolished</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.enterEvent" title="napari.qt.QtViewerButtons.enterEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">enterEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.enterEvent" title="napari.qt.QtViewerButtons.enterEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">enterEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.event" title="napari.qt.QtViewerButtons.event"><code class="xref py py-obj docutils literal notranslate"><span class="pre">event</span></code></a>(self, e)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.event" title="napari.qt.QtViewerButtons.event"><code class="xref py py-obj docutils literal notranslate"><span class="pre">event</span></code></a>(self, e)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.eventFilter" title="napari.qt.QtViewerButtons.eventFilter"><code class="xref py py-obj docutils literal notranslate"><span class="pre">eventFilter</span></code></a>(qobject, event)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.eventFilter" title="napari.qt.QtViewerButtons.eventFilter"><code class="xref py py-obj docutils literal notranslate"><span class="pre">eventFilter</span></code></a>(qobject, event)</p></td>
 <td><p>Have Alt/Option key rotate layers with the transpose button.</p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.find" title="napari.qt.QtViewerButtons.find"><code class="xref py py-obj docutils literal notranslate"><span class="pre">find</span></code></a>(a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.findChild" title="napari.qt.QtViewerButtons.findChild"><code class="xref py py-obj docutils literal notranslate"><span class="pre">findChild</span></code></a>(-&gt; QObjectT)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.findChild" title="napari.qt.QtViewerButtons.findChild"><code class="xref py py-obj docutils literal notranslate"><span class="pre">findChild</span></code></a>(-&gt; QObjectT)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.findChildren" title="napari.qt.QtViewerButtons.findChildren"><code class="xref py py-obj docutils literal notranslate"><span class="pre">findChildren</span></code></a>(...)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.focusInEvent" title="napari.qt.QtViewerButtons.focusInEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">focusInEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.focusInEvent" title="napari.qt.QtViewerButtons.focusInEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">focusInEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.focusNextChild" title="napari.qt.QtViewerButtons.focusNextChild"><code class="xref py py-obj docutils literal notranslate"><span class="pre">focusNextChild</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.focusNextPrevChild" title="napari.qt.QtViewerButtons.focusNextPrevChild"><code class="xref py py-obj docutils literal notranslate"><span class="pre">focusNextPrevChild</span></code></a>(self, next)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.focusNextPrevChild" title="napari.qt.QtViewerButtons.focusNextPrevChild"><code class="xref py py-obj docutils literal notranslate"><span class="pre">focusNextPrevChild</span></code></a>(self, next)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.focusOutEvent" title="napari.qt.QtViewerButtons.focusOutEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">focusOutEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.focusOutEvent" title="napari.qt.QtViewerButtons.focusOutEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">focusOutEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.focusPolicy" title="napari.qt.QtViewerButtons.focusPolicy"><code class="xref py py-obj docutils literal notranslate"><span class="pre">focusPolicy</span></code></a>(self)</p></td>
@@ -933,10 +933,10 @@
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.getContentsMargins" title="napari.qt.QtViewerButtons.getContentsMargins"><code class="xref py py-obj docutils literal notranslate"><span class="pre">getContentsMargins</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.grab" title="napari.qt.QtViewerButtons.grab"><code class="xref py py-obj docutils literal notranslate"><span class="pre">grab</span></code></a>(self[, rectangle])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.grab" title="napari.qt.QtViewerButtons.grab"><code class="xref py py-obj docutils literal notranslate"><span class="pre">grab</span></code></a>(self[, rectangle])</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.grabGesture" title="napari.qt.QtViewerButtons.grabGesture"><code class="xref py py-obj docutils literal notranslate"><span class="pre">grabGesture</span></code></a>(self, type[, flags])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.grabGesture" title="napari.qt.QtViewerButtons.grabGesture"><code class="xref py py-obj docutils literal notranslate"><span class="pre">grabGesture</span></code></a>(self, type[, flags])</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.grabKeyboard" title="napari.qt.QtViewerButtons.grabKeyboard"><code class="xref py py-obj docutils literal notranslate"><span class="pre">grabKeyboard</span></code></a>(self)</p></td>
@@ -945,7 +945,7 @@
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.grabMouse" title="napari.qt.QtViewerButtons.grabMouse"><code class="xref py py-obj docutils literal notranslate"><span class="pre">grabMouse</span></code></a>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.grabShortcut" title="napari.qt.QtViewerButtons.grabShortcut"><code class="xref py py-obj docutils literal notranslate"><span class="pre">grabShortcut</span></code></a>(self, key[, context])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.grabShortcut" title="napari.qt.QtViewerButtons.grabShortcut"><code class="xref py py-obj docutils literal notranslate"><span class="pre">grabShortcut</span></code></a>(self, key[, context])</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.graphicsEffect" title="napari.qt.QtViewerButtons.graphicsEffect"><code class="xref py py-obj docutils literal notranslate"><span class="pre">graphicsEffect</span></code></a>(self)</p></td>
@@ -969,7 +969,7 @@
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.height" title="napari.qt.QtViewerButtons.height"><code class="xref py py-obj docutils literal notranslate"><span class="pre">height</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.heightForWidth" title="napari.qt.QtViewerButtons.heightForWidth"><code class="xref py py-obj docutils literal notranslate"><span class="pre">heightForWidth</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.heightForWidth" title="napari.qt.QtViewerButtons.heightForWidth"><code class="xref py py-obj docutils literal notranslate"><span class="pre">heightForWidth</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.heightMM" title="napari.qt.QtViewerButtons.heightMM"><code class="xref py py-obj docutils literal notranslate"><span class="pre">heightMM</span></code></a>(self)</p></td>
@@ -978,46 +978,46 @@
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.hide" title="napari.qt.QtViewerButtons.hide"><code class="xref py py-obj docutils literal notranslate"><span class="pre">hide</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.hideEvent" title="napari.qt.QtViewerButtons.hideEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">hideEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.hideEvent" title="napari.qt.QtViewerButtons.hideEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">hideEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.inherits" title="napari.qt.QtViewerButtons.inherits"><code class="xref py py-obj docutils literal notranslate"><span class="pre">inherits</span></code></a>(self, classname)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.inherits" title="napari.qt.QtViewerButtons.inherits"><code class="xref py py-obj docutils literal notranslate"><span class="pre">inherits</span></code></a>(self, classname)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.initPainter" title="napari.qt.QtViewerButtons.initPainter"><code class="xref py py-obj docutils literal notranslate"><span class="pre">initPainter</span></code></a>(self, painter)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.initPainter" title="napari.qt.QtViewerButtons.initPainter"><code class="xref py py-obj docutils literal notranslate"><span class="pre">initPainter</span></code></a>(self, painter)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.initStyleOption" title="napari.qt.QtViewerButtons.initStyleOption"><code class="xref py py-obj docutils literal notranslate"><span class="pre">initStyleOption</span></code></a>(self, option)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.initStyleOption" title="napari.qt.QtViewerButtons.initStyleOption"><code class="xref py py-obj docutils literal notranslate"><span class="pre">initStyleOption</span></code></a>(self, option)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.inputMethodEvent" title="napari.qt.QtViewerButtons.inputMethodEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">inputMethodEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.inputMethodEvent" title="napari.qt.QtViewerButtons.inputMethodEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">inputMethodEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.inputMethodHints" title="napari.qt.QtViewerButtons.inputMethodHints"><code class="xref py py-obj docutils literal notranslate"><span class="pre">inputMethodHints</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.inputMethodQuery" title="napari.qt.QtViewerButtons.inputMethodQuery"><code class="xref py py-obj docutils literal notranslate"><span class="pre">inputMethodQuery</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.inputMethodQuery" title="napari.qt.QtViewerButtons.inputMethodQuery"><code class="xref py py-obj docutils literal notranslate"><span class="pre">inputMethodQuery</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.insertAction" title="napari.qt.QtViewerButtons.insertAction"><code class="xref py py-obj docutils literal notranslate"><span class="pre">insertAction</span></code></a>(self, before, action)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.insertAction" title="napari.qt.QtViewerButtons.insertAction"><code class="xref py py-obj docutils literal notranslate"><span class="pre">insertAction</span></code></a>(self, before, action)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.insertActions" title="napari.qt.QtViewerButtons.insertActions"><code class="xref py py-obj docutils literal notranslate"><span class="pre">insertActions</span></code></a>(self, before, actions)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.insertActions" title="napari.qt.QtViewerButtons.insertActions"><code class="xref py py-obj docutils literal notranslate"><span class="pre">insertActions</span></code></a>(self, before, actions)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.installEventFilter" title="napari.qt.QtViewerButtons.installEventFilter"><code class="xref py py-obj docutils literal notranslate"><span class="pre">installEventFilter</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.installEventFilter" title="napari.qt.QtViewerButtons.installEventFilter"><code class="xref py py-obj docutils literal notranslate"><span class="pre">installEventFilter</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.isActiveWindow" title="napari.qt.QtViewerButtons.isActiveWindow"><code class="xref py py-obj docutils literal notranslate"><span class="pre">isActiveWindow</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.isAncestorOf" title="napari.qt.QtViewerButtons.isAncestorOf"><code class="xref py py-obj docutils literal notranslate"><span class="pre">isAncestorOf</span></code></a>(self, child)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.isAncestorOf" title="napari.qt.QtViewerButtons.isAncestorOf"><code class="xref py py-obj docutils literal notranslate"><span class="pre">isAncestorOf</span></code></a>(self, child)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.isEnabled" title="napari.qt.QtViewerButtons.isEnabled"><code class="xref py py-obj docutils literal notranslate"><span class="pre">isEnabled</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.isEnabledTo" title="napari.qt.QtViewerButtons.isEnabledTo"><code class="xref py py-obj docutils literal notranslate"><span class="pre">isEnabledTo</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.isEnabledTo" title="napari.qt.QtViewerButtons.isEnabledTo"><code class="xref py py-obj docutils literal notranslate"><span class="pre">isEnabledTo</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.isFullScreen" title="napari.qt.QtViewerButtons.isFullScreen"><code class="xref py py-obj docutils literal notranslate"><span class="pre">isFullScreen</span></code></a>(self)</p></td>
@@ -1041,13 +1041,13 @@
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.isRightToLeft" title="napari.qt.QtViewerButtons.isRightToLeft"><code class="xref py py-obj docutils literal notranslate"><span class="pre">isRightToLeft</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.isSignalConnected" title="napari.qt.QtViewerButtons.isSignalConnected"><code class="xref py py-obj docutils literal notranslate"><span class="pre">isSignalConnected</span></code></a>(self, signal)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.isSignalConnected" title="napari.qt.QtViewerButtons.isSignalConnected"><code class="xref py py-obj docutils literal notranslate"><span class="pre">isSignalConnected</span></code></a>(self, signal)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.isVisible" title="napari.qt.QtViewerButtons.isVisible"><code class="xref py py-obj docutils literal notranslate"><span class="pre">isVisible</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.isVisibleTo" title="napari.qt.QtViewerButtons.isVisibleTo"><code class="xref py py-obj docutils literal notranslate"><span class="pre">isVisibleTo</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.isVisibleTo" title="napari.qt.QtViewerButtons.isVisibleTo"><code class="xref py py-obj docutils literal notranslate"><span class="pre">isVisibleTo</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.isWidgetType" title="napari.qt.QtViewerButtons.isWidgetType"><code class="xref py py-obj docutils literal notranslate"><span class="pre">isWidgetType</span></code></a>(self)</p></td>
@@ -1062,16 +1062,16 @@
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.isWindowType" title="napari.qt.QtViewerButtons.isWindowType"><code class="xref py py-obj docutils literal notranslate"><span class="pre">isWindowType</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.keyPressEvent" title="napari.qt.QtViewerButtons.keyPressEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">keyPressEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.keyPressEvent" title="napari.qt.QtViewerButtons.keyPressEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">keyPressEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.keyReleaseEvent" title="napari.qt.QtViewerButtons.keyReleaseEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">keyReleaseEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.keyReleaseEvent" title="napari.qt.QtViewerButtons.keyReleaseEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">keyReleaseEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.keyboardGrabber" title="napari.qt.QtViewerButtons.keyboardGrabber"><code class="xref py py-obj docutils literal notranslate"><span class="pre">keyboardGrabber</span></code></a>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.killTimer" title="napari.qt.QtViewerButtons.killTimer"><code class="xref py py-obj docutils literal notranslate"><span class="pre">killTimer</span></code></a>(self, id)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.killTimer" title="napari.qt.QtViewerButtons.killTimer"><code class="xref py py-obj docutils literal notranslate"><span class="pre">killTimer</span></code></a>(self, id)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.layout" title="napari.qt.QtViewerButtons.layout"><code class="xref py py-obj docutils literal notranslate"><span class="pre">layout</span></code></a>(self)</p></td>
@@ -1080,7 +1080,7 @@
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.layoutDirection" title="napari.qt.QtViewerButtons.layoutDirection"><code class="xref py py-obj docutils literal notranslate"><span class="pre">layoutDirection</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.leaveEvent" title="napari.qt.QtViewerButtons.leaveEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">leaveEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.leaveEvent" title="napari.qt.QtViewerButtons.leaveEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">leaveEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.lineWidth" title="napari.qt.QtViewerButtons.lineWidth"><code class="xref py py-obj docutils literal notranslate"><span class="pre">lineWidth</span></code></a>(self)</p></td>
@@ -1098,22 +1098,22 @@
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.lower" title="napari.qt.QtViewerButtons.lower"><code class="xref py py-obj docutils literal notranslate"><span class="pre">lower</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.mapFrom" title="napari.qt.QtViewerButtons.mapFrom"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mapFrom</span></code></a>(self, a0, a1)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.mapFrom" title="napari.qt.QtViewerButtons.mapFrom"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mapFrom</span></code></a>(self, a0, a1)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.mapFromGlobal" title="napari.qt.QtViewerButtons.mapFromGlobal"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mapFromGlobal</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.mapFromGlobal" title="napari.qt.QtViewerButtons.mapFromGlobal"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mapFromGlobal</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.mapFromParent" title="napari.qt.QtViewerButtons.mapFromParent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mapFromParent</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.mapFromParent" title="napari.qt.QtViewerButtons.mapFromParent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mapFromParent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.mapTo" title="napari.qt.QtViewerButtons.mapTo"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mapTo</span></code></a>(self, a0, a1)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.mapTo" title="napari.qt.QtViewerButtons.mapTo"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mapTo</span></code></a>(self, a0, a1)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.mapToGlobal" title="napari.qt.QtViewerButtons.mapToGlobal"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mapToGlobal</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.mapToGlobal" title="napari.qt.QtViewerButtons.mapToGlobal"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mapToGlobal</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.mapToParent" title="napari.qt.QtViewerButtons.mapToParent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mapToParent</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.mapToParent" title="napari.qt.QtViewerButtons.mapToParent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mapToParent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.mask" title="napari.qt.QtViewerButtons.mask"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mask</span></code></a>(self)</p></td>
@@ -1131,7 +1131,7 @@
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.metaObject" title="napari.qt.QtViewerButtons.metaObject"><code class="xref py py-obj docutils literal notranslate"><span class="pre">metaObject</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.metric" title="napari.qt.QtViewerButtons.metric"><code class="xref py py-obj docutils literal notranslate"><span class="pre">metric</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.metric" title="napari.qt.QtViewerButtons.metric"><code class="xref py py-obj docutils literal notranslate"><span class="pre">metric</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.midLineWidth" title="napari.qt.QtViewerButtons.midLineWidth"><code class="xref py py-obj docutils literal notranslate"><span class="pre">midLineWidth</span></code></a>(self)</p></td>
@@ -1149,31 +1149,31 @@
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.minimumWidth" title="napari.qt.QtViewerButtons.minimumWidth"><code class="xref py py-obj docutils literal notranslate"><span class="pre">minimumWidth</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.mouseDoubleClickEvent" title="napari.qt.QtViewerButtons.mouseDoubleClickEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mouseDoubleClickEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.mouseDoubleClickEvent" title="napari.qt.QtViewerButtons.mouseDoubleClickEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mouseDoubleClickEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.mouseGrabber" title="napari.qt.QtViewerButtons.mouseGrabber"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mouseGrabber</span></code></a>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.mouseMoveEvent" title="napari.qt.QtViewerButtons.mouseMoveEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mouseMoveEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.mouseMoveEvent" title="napari.qt.QtViewerButtons.mouseMoveEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mouseMoveEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.mousePressEvent" title="napari.qt.QtViewerButtons.mousePressEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mousePressEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.mousePressEvent" title="napari.qt.QtViewerButtons.mousePressEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mousePressEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.mouseReleaseEvent" title="napari.qt.QtViewerButtons.mouseReleaseEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mouseReleaseEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.mouseReleaseEvent" title="napari.qt.QtViewerButtons.mouseReleaseEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mouseReleaseEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.move" title="napari.qt.QtViewerButtons.move"><code class="xref py py-obj docutils literal notranslate"><span class="pre">move</span></code></a>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.moveEvent" title="napari.qt.QtViewerButtons.moveEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">moveEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.moveEvent" title="napari.qt.QtViewerButtons.moveEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">moveEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.moveToThread" title="napari.qt.QtViewerButtons.moveToThread"><code class="xref py py-obj docutils literal notranslate"><span class="pre">moveToThread</span></code></a>(self, thread)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.moveToThread" title="napari.qt.QtViewerButtons.moveToThread"><code class="xref py py-obj docutils literal notranslate"><span class="pre">moveToThread</span></code></a>(self, thread)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.nativeEvent" title="napari.qt.QtViewerButtons.nativeEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">nativeEvent</span></code></a>(self, eventType, message)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.nativeEvent" title="napari.qt.QtViewerButtons.nativeEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">nativeEvent</span></code></a>(self, eventType, message)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.nativeParentWidget" title="napari.qt.QtViewerButtons.nativeParentWidget"><code class="xref py py-obj docutils literal notranslate"><span class="pre">nativeParentWidget</span></code></a>(self)</p></td>
@@ -1191,16 +1191,16 @@
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.open_ndisplay_camera_popup" title="napari.qt.QtViewerButtons.open_ndisplay_camera_popup"><code class="xref py py-obj docutils literal notranslate"><span class="pre">open_ndisplay_camera_popup</span></code></a>()</p></td>
 <td><p>Show controls for camera settings based on ndisplay mode.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.overrideWindowFlags" title="napari.qt.QtViewerButtons.overrideWindowFlags"><code class="xref py py-obj docutils literal notranslate"><span class="pre">overrideWindowFlags</span></code></a>(self, type)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.overrideWindowFlags" title="napari.qt.QtViewerButtons.overrideWindowFlags"><code class="xref py py-obj docutils literal notranslate"><span class="pre">overrideWindowFlags</span></code></a>(self, type)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.overrideWindowState" title="napari.qt.QtViewerButtons.overrideWindowState"><code class="xref py py-obj docutils literal notranslate"><span class="pre">overrideWindowState</span></code></a>(self, state)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.overrideWindowState" title="napari.qt.QtViewerButtons.overrideWindowState"><code class="xref py py-obj docutils literal notranslate"><span class="pre">overrideWindowState</span></code></a>(self, state)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.paintEngine" title="napari.qt.QtViewerButtons.paintEngine"><code class="xref py py-obj docutils literal notranslate"><span class="pre">paintEngine</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.paintEvent" title="napari.qt.QtViewerButtons.paintEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">paintEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.paintEvent" title="napari.qt.QtViewerButtons.paintEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">paintEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.paintingActive" title="napari.qt.QtViewerButtons.paintingActive"><code class="xref py py-obj docutils literal notranslate"><span class="pre">paintingActive</span></code></a>(self)</p></td>
@@ -1227,7 +1227,7 @@
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.previousInFocusChain" title="napari.qt.QtViewerButtons.previousInFocusChain"><code class="xref py py-obj docutils literal notranslate"><span class="pre">previousInFocusChain</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.property" title="napari.qt.QtViewerButtons.property"><code class="xref py py-obj docutils literal notranslate"><span class="pre">property</span></code></a>(self, name)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.property" title="napari.qt.QtViewerButtons.property"><code class="xref py py-obj docutils literal notranslate"><span class="pre">property</span></code></a>(self, name)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.pyqtConfigure" title="napari.qt.QtViewerButtons.pyqtConfigure"><code class="xref py py-obj docutils literal notranslate"><span class="pre">pyqtConfigure</span></code></a>(...)</p></td>
@@ -1236,7 +1236,7 @@
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.raise_" title="napari.qt.QtViewerButtons.raise_"><code class="xref py py-obj docutils literal notranslate"><span class="pre">raise_</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.receivers" title="napari.qt.QtViewerButtons.receivers"><code class="xref py py-obj docutils literal notranslate"><span class="pre">receivers</span></code></a>(self, signal)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.receivers" title="napari.qt.QtViewerButtons.receivers"><code class="xref py py-obj docutils literal notranslate"><span class="pre">receivers</span></code></a>(self, signal)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.rect" title="napari.qt.QtViewerButtons.rect"><code class="xref py py-obj docutils literal notranslate"><span class="pre">rect</span></code></a>(self)</p></td>
@@ -1248,29 +1248,29 @@
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.releaseMouse" title="napari.qt.QtViewerButtons.releaseMouse"><code class="xref py py-obj docutils literal notranslate"><span class="pre">releaseMouse</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.releaseShortcut" title="napari.qt.QtViewerButtons.releaseShortcut"><code class="xref py py-obj docutils literal notranslate"><span class="pre">releaseShortcut</span></code></a>(self, id)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.releaseShortcut" title="napari.qt.QtViewerButtons.releaseShortcut"><code class="xref py py-obj docutils literal notranslate"><span class="pre">releaseShortcut</span></code></a>(self, id)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.removeAction" title="napari.qt.QtViewerButtons.removeAction"><code class="xref py py-obj docutils literal notranslate"><span class="pre">removeAction</span></code></a>(self, action)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.removeAction" title="napari.qt.QtViewerButtons.removeAction"><code class="xref py py-obj docutils literal notranslate"><span class="pre">removeAction</span></code></a>(self, action)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.removeEventFilter" title="napari.qt.QtViewerButtons.removeEventFilter"><code class="xref py py-obj docutils literal notranslate"><span class="pre">removeEventFilter</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.removeEventFilter" title="napari.qt.QtViewerButtons.removeEventFilter"><code class="xref py py-obj docutils literal notranslate"><span class="pre">removeEventFilter</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.render" title="napari.qt.QtViewerButtons.render"><code class="xref py py-obj docutils literal notranslate"><span class="pre">render</span></code></a>(, sourceRegion, flags, ...)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.render" title="napari.qt.QtViewerButtons.render"><code class="xref py py-obj docutils literal notranslate"><span class="pre">render</span></code></a>(, sourceRegion, flags, ...)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.repaint" title="napari.qt.QtViewerButtons.repaint"><code class="xref py py-obj docutils literal notranslate"><span class="pre">repaint</span></code></a>(-&gt; None
- -&gt; None)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.repaint" title="napari.qt.QtViewerButtons.repaint"><code class="xref py py-obj docutils literal notranslate"><span class="pre">repaint</span></code></a>(-&gt; None
+ -&gt; None)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.resize" title="napari.qt.QtViewerButtons.resize"><code class="xref py py-obj docutils literal notranslate"><span class="pre">resize</span></code></a>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.resizeEvent" title="napari.qt.QtViewerButtons.resizeEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">resizeEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.resizeEvent" title="napari.qt.QtViewerButtons.resizeEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">resizeEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.restoreGeometry" title="napari.qt.QtViewerButtons.restoreGeometry"><code class="xref py py-obj docutils literal notranslate"><span class="pre">restoreGeometry</span></code></a>(self, geometry)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.restoreGeometry" title="napari.qt.QtViewerButtons.restoreGeometry"><code class="xref py py-obj docutils literal notranslate"><span class="pre">restoreGeometry</span></code></a>(self, geometry)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.saveGeometry" title="napari.qt.QtViewerButtons.saveGeometry"><code class="xref py py-obj docutils literal notranslate"><span class="pre">saveGeometry</span></code></a>(self)</p></td>
@@ -1288,22 +1288,22 @@
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.senderSignalIndex" title="napari.qt.QtViewerButtons.senderSignalIndex"><code class="xref py py-obj docutils literal notranslate"><span class="pre">senderSignalIndex</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setAcceptDrops" title="napari.qt.QtViewerButtons.setAcceptDrops"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setAcceptDrops</span></code></a>(self, on)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setAcceptDrops" title="napari.qt.QtViewerButtons.setAcceptDrops"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setAcceptDrops</span></code></a>(self, on)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setAccessibleDescription" title="napari.qt.QtViewerButtons.setAccessibleDescription"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setAccessibleDescription</span></code></a>(self, description)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setAccessibleDescription" title="napari.qt.QtViewerButtons.setAccessibleDescription"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setAccessibleDescription</span></code></a>(self, description)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setAccessibleName" title="napari.qt.QtViewerButtons.setAccessibleName"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setAccessibleName</span></code></a>(self, name)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setAccessibleName" title="napari.qt.QtViewerButtons.setAccessibleName"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setAccessibleName</span></code></a>(self, name)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setAttribute" title="napari.qt.QtViewerButtons.setAttribute"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setAttribute</span></code></a>(self, attribute[, on])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setAttribute" title="napari.qt.QtViewerButtons.setAttribute"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setAttribute</span></code></a>(self, attribute[, on])</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setAutoFillBackground" title="napari.qt.QtViewerButtons.setAutoFillBackground"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setAutoFillBackground</span></code></a>(self, enabled)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setAutoFillBackground" title="napari.qt.QtViewerButtons.setAutoFillBackground"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setAutoFillBackground</span></code></a>(self, enabled)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setBackgroundRole" title="napari.qt.QtViewerButtons.setBackgroundRole"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setBackgroundRole</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setBackgroundRole" title="napari.qt.QtViewerButtons.setBackgroundRole"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setBackgroundRole</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setBaseSize" title="napari.qt.QtViewerButtons.setBaseSize"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setBaseSize</span></code></a>()</p></td>
@@ -1312,121 +1312,121 @@
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setContentsMargins" title="napari.qt.QtViewerButtons.setContentsMargins"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setContentsMargins</span></code></a>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setContextMenuPolicy" title="napari.qt.QtViewerButtons.setContextMenuPolicy"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setContextMenuPolicy</span></code></a>(self, policy)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setContextMenuPolicy" title="napari.qt.QtViewerButtons.setContextMenuPolicy"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setContextMenuPolicy</span></code></a>(self, policy)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setCursor" title="napari.qt.QtViewerButtons.setCursor"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setCursor</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setCursor" title="napari.qt.QtViewerButtons.setCursor"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setCursor</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setDisabled" title="napari.qt.QtViewerButtons.setDisabled"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setDisabled</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setDisabled" title="napari.qt.QtViewerButtons.setDisabled"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setDisabled</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setEnabled" title="napari.qt.QtViewerButtons.setEnabled"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setEnabled</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setEnabled" title="napari.qt.QtViewerButtons.setEnabled"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setEnabled</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setFixedHeight" title="napari.qt.QtViewerButtons.setFixedHeight"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setFixedHeight</span></code></a>(self, h)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setFixedHeight" title="napari.qt.QtViewerButtons.setFixedHeight"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setFixedHeight</span></code></a>(self, h)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setFixedSize" title="napari.qt.QtViewerButtons.setFixedSize"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setFixedSize</span></code></a>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setFixedWidth" title="napari.qt.QtViewerButtons.setFixedWidth"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setFixedWidth</span></code></a>(self, w)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setFixedWidth" title="napari.qt.QtViewerButtons.setFixedWidth"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setFixedWidth</span></code></a>(self, w)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setFocus" title="napari.qt.QtViewerButtons.setFocus"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setFocus</span></code></a>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setFocusPolicy" title="napari.qt.QtViewerButtons.setFocusPolicy"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setFocusPolicy</span></code></a>(self, policy)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setFocusPolicy" title="napari.qt.QtViewerButtons.setFocusPolicy"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setFocusPolicy</span></code></a>(self, policy)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setFocusProxy" title="napari.qt.QtViewerButtons.setFocusProxy"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setFocusProxy</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setFocusProxy" title="napari.qt.QtViewerButtons.setFocusProxy"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setFocusProxy</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setFont" title="napari.qt.QtViewerButtons.setFont"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setFont</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setFont" title="napari.qt.QtViewerButtons.setFont"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setFont</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setForegroundRole" title="napari.qt.QtViewerButtons.setForegroundRole"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setForegroundRole</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setForegroundRole" title="napari.qt.QtViewerButtons.setForegroundRole"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setForegroundRole</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setFrameRect" title="napari.qt.QtViewerButtons.setFrameRect"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setFrameRect</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setFrameRect" title="napari.qt.QtViewerButtons.setFrameRect"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setFrameRect</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setFrameShadow" title="napari.qt.QtViewerButtons.setFrameShadow"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setFrameShadow</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setFrameShadow" title="napari.qt.QtViewerButtons.setFrameShadow"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setFrameShadow</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setFrameShape" title="napari.qt.QtViewerButtons.setFrameShape"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setFrameShape</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setFrameShape" title="napari.qt.QtViewerButtons.setFrameShape"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setFrameShape</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setFrameStyle" title="napari.qt.QtViewerButtons.setFrameStyle"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setFrameStyle</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setFrameStyle" title="napari.qt.QtViewerButtons.setFrameStyle"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setFrameStyle</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setGeometry" title="napari.qt.QtViewerButtons.setGeometry"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setGeometry</span></code></a>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setGraphicsEffect" title="napari.qt.QtViewerButtons.setGraphicsEffect"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setGraphicsEffect</span></code></a>(self, effect)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setGraphicsEffect" title="napari.qt.QtViewerButtons.setGraphicsEffect"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setGraphicsEffect</span></code></a>(self, effect)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setHidden" title="napari.qt.QtViewerButtons.setHidden"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setHidden</span></code></a>(self, hidden)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setHidden" title="napari.qt.QtViewerButtons.setHidden"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setHidden</span></code></a>(self, hidden)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setInputMethodHints" title="napari.qt.QtViewerButtons.setInputMethodHints"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setInputMethodHints</span></code></a>(self, hints)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setInputMethodHints" title="napari.qt.QtViewerButtons.setInputMethodHints"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setInputMethodHints</span></code></a>(self, hints)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setLayout" title="napari.qt.QtViewerButtons.setLayout"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setLayout</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setLayout" title="napari.qt.QtViewerButtons.setLayout"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setLayout</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setLayoutDirection" title="napari.qt.QtViewerButtons.setLayoutDirection"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setLayoutDirection</span></code></a>(self, direction)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setLayoutDirection" title="napari.qt.QtViewerButtons.setLayoutDirection"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setLayoutDirection</span></code></a>(self, direction)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setLineWidth" title="napari.qt.QtViewerButtons.setLineWidth"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setLineWidth</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setLineWidth" title="napari.qt.QtViewerButtons.setLineWidth"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setLineWidth</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setLocale" title="napari.qt.QtViewerButtons.setLocale"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setLocale</span></code></a>(self, locale)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setLocale" title="napari.qt.QtViewerButtons.setLocale"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setLocale</span></code></a>(self, locale)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setMask" title="napari.qt.QtViewerButtons.setMask"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setMask</span></code></a>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setMaximumHeight" title="napari.qt.QtViewerButtons.setMaximumHeight"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setMaximumHeight</span></code></a>(self, maxh)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setMaximumHeight" title="napari.qt.QtViewerButtons.setMaximumHeight"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setMaximumHeight</span></code></a>(self, maxh)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setMaximumSize" title="napari.qt.QtViewerButtons.setMaximumSize"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setMaximumSize</span></code></a>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setMaximumWidth" title="napari.qt.QtViewerButtons.setMaximumWidth"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setMaximumWidth</span></code></a>(self, maxw)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setMaximumWidth" title="napari.qt.QtViewerButtons.setMaximumWidth"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setMaximumWidth</span></code></a>(self, maxw)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setMidLineWidth" title="napari.qt.QtViewerButtons.setMidLineWidth"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setMidLineWidth</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setMidLineWidth" title="napari.qt.QtViewerButtons.setMidLineWidth"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setMidLineWidth</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setMinimumHeight" title="napari.qt.QtViewerButtons.setMinimumHeight"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setMinimumHeight</span></code></a>(self, minh)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setMinimumHeight" title="napari.qt.QtViewerButtons.setMinimumHeight"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setMinimumHeight</span></code></a>(self, minh)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setMinimumSize" title="napari.qt.QtViewerButtons.setMinimumSize"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setMinimumSize</span></code></a>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setMinimumWidth" title="napari.qt.QtViewerButtons.setMinimumWidth"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setMinimumWidth</span></code></a>(self, minw)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setMinimumWidth" title="napari.qt.QtViewerButtons.setMinimumWidth"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setMinimumWidth</span></code></a>(self, minw)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setMouseTracking" title="napari.qt.QtViewerButtons.setMouseTracking"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setMouseTracking</span></code></a>(self, enable)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setMouseTracking" title="napari.qt.QtViewerButtons.setMouseTracking"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setMouseTracking</span></code></a>(self, enable)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setObjectName" title="napari.qt.QtViewerButtons.setObjectName"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setObjectName</span></code></a>(self, name)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setObjectName" title="napari.qt.QtViewerButtons.setObjectName"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setObjectName</span></code></a>(self, name)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setPalette" title="napari.qt.QtViewerButtons.setPalette"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setPalette</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setPalette" title="napari.qt.QtViewerButtons.setPalette"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setPalette</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setParent" title="napari.qt.QtViewerButtons.setParent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setParent</span></code></a>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setProperty" title="napari.qt.QtViewerButtons.setProperty"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setProperty</span></code></a>(self, name, value)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setProperty" title="napari.qt.QtViewerButtons.setProperty"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setProperty</span></code></a>(self, name, value)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setShortcutAutoRepeat" title="napari.qt.QtViewerButtons.setShortcutAutoRepeat"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setShortcutAutoRepeat</span></code></a>(self, id[, enabled])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setShortcutAutoRepeat" title="napari.qt.QtViewerButtons.setShortcutAutoRepeat"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setShortcutAutoRepeat</span></code></a>(self, id[, enabled])</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setShortcutEnabled" title="napari.qt.QtViewerButtons.setShortcutEnabled"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setShortcutEnabled</span></code></a>(self, id[, enabled])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setShortcutEnabled" title="napari.qt.QtViewerButtons.setShortcutEnabled"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setShortcutEnabled</span></code></a>(self, id[, enabled])</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setSizeIncrement" title="napari.qt.QtViewerButtons.setSizeIncrement"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setSizeIncrement</span></code></a>()</p></td>
@@ -1435,67 +1435,67 @@
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setSizePolicy" title="napari.qt.QtViewerButtons.setSizePolicy"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setSizePolicy</span></code></a>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setStatusTip" title="napari.qt.QtViewerButtons.setStatusTip"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setStatusTip</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setStatusTip" title="napari.qt.QtViewerButtons.setStatusTip"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setStatusTip</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setStyle" title="napari.qt.QtViewerButtons.setStyle"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setStyle</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setStyle" title="napari.qt.QtViewerButtons.setStyle"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setStyle</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setStyleSheet" title="napari.qt.QtViewerButtons.setStyleSheet"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setStyleSheet</span></code></a>(self, styleSheet)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setStyleSheet" title="napari.qt.QtViewerButtons.setStyleSheet"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setStyleSheet</span></code></a>(self, styleSheet)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setTabOrder" title="napari.qt.QtViewerButtons.setTabOrder"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setTabOrder</span></code></a>(a0, a1)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setTabOrder" title="napari.qt.QtViewerButtons.setTabOrder"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setTabOrder</span></code></a>(a0, a1)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setTabletTracking" title="napari.qt.QtViewerButtons.setTabletTracking"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setTabletTracking</span></code></a>(self, enable)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setTabletTracking" title="napari.qt.QtViewerButtons.setTabletTracking"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setTabletTracking</span></code></a>(self, enable)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setToolTip" title="napari.qt.QtViewerButtons.setToolTip"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setToolTip</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setToolTip" title="napari.qt.QtViewerButtons.setToolTip"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setToolTip</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setToolTipDuration" title="napari.qt.QtViewerButtons.setToolTipDuration"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setToolTipDuration</span></code></a>(self, msec)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setToolTipDuration" title="napari.qt.QtViewerButtons.setToolTipDuration"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setToolTipDuration</span></code></a>(self, msec)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setUpdatesEnabled" title="napari.qt.QtViewerButtons.setUpdatesEnabled"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setUpdatesEnabled</span></code></a>(self, enable)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setUpdatesEnabled" title="napari.qt.QtViewerButtons.setUpdatesEnabled"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setUpdatesEnabled</span></code></a>(self, enable)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setVisible" title="napari.qt.QtViewerButtons.setVisible"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setVisible</span></code></a>(self, visible)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setVisible" title="napari.qt.QtViewerButtons.setVisible"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setVisible</span></code></a>(self, visible)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setWhatsThis" title="napari.qt.QtViewerButtons.setWhatsThis"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWhatsThis</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setWhatsThis" title="napari.qt.QtViewerButtons.setWhatsThis"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWhatsThis</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setWindowFilePath" title="napari.qt.QtViewerButtons.setWindowFilePath"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowFilePath</span></code></a>(self, filePath)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setWindowFilePath" title="napari.qt.QtViewerButtons.setWindowFilePath"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowFilePath</span></code></a>(self, filePath)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setWindowFlag" title="napari.qt.QtViewerButtons.setWindowFlag"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowFlag</span></code></a>(self, a0[, on])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setWindowFlag" title="napari.qt.QtViewerButtons.setWindowFlag"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowFlag</span></code></a>(self, a0[, on])</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setWindowFlags" title="napari.qt.QtViewerButtons.setWindowFlags"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowFlags</span></code></a>(self, type)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setWindowFlags" title="napari.qt.QtViewerButtons.setWindowFlags"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowFlags</span></code></a>(self, type)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setWindowIcon" title="napari.qt.QtViewerButtons.setWindowIcon"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowIcon</span></code></a>(self, icon)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setWindowIcon" title="napari.qt.QtViewerButtons.setWindowIcon"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowIcon</span></code></a>(self, icon)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setWindowIconText" title="napari.qt.QtViewerButtons.setWindowIconText"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowIconText</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setWindowIconText" title="napari.qt.QtViewerButtons.setWindowIconText"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowIconText</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setWindowModality" title="napari.qt.QtViewerButtons.setWindowModality"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowModality</span></code></a>(self, windowModality)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setWindowModality" title="napari.qt.QtViewerButtons.setWindowModality"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowModality</span></code></a>(self, windowModality)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setWindowModified" title="napari.qt.QtViewerButtons.setWindowModified"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowModified</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setWindowModified" title="napari.qt.QtViewerButtons.setWindowModified"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowModified</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setWindowOpacity" title="napari.qt.QtViewerButtons.setWindowOpacity"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowOpacity</span></code></a>(self, level)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setWindowOpacity" title="napari.qt.QtViewerButtons.setWindowOpacity"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowOpacity</span></code></a>(self, level)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setWindowRole" title="napari.qt.QtViewerButtons.setWindowRole"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowRole</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setWindowRole" title="napari.qt.QtViewerButtons.setWindowRole"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowRole</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setWindowState" title="napari.qt.QtViewerButtons.setWindowState"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowState</span></code></a>(self, state)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setWindowState" title="napari.qt.QtViewerButtons.setWindowState"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowState</span></code></a>(self, state)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setWindowTitle" title="napari.qt.QtViewerButtons.setWindowTitle"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowTitle</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.setWindowTitle" title="napari.qt.QtViewerButtons.setWindowTitle"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setWindowTitle</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.sharedPainter" title="napari.qt.QtViewerButtons.sharedPainter"><code class="xref py py-obj docutils literal notranslate"><span class="pre">sharedPainter</span></code></a>(self)</p></td>
@@ -1504,7 +1504,7 @@
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.show" title="napari.qt.QtViewerButtons.show"><code class="xref py py-obj docutils literal notranslate"><span class="pre">show</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.showEvent" title="napari.qt.QtViewerButtons.showEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">showEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.showEvent" title="napari.qt.QtViewerButtons.showEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">showEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.showFullScreen" title="napari.qt.QtViewerButtons.showFullScreen"><code class="xref py py-obj docutils literal notranslate"><span class="pre">showFullScreen</span></code></a>(self)</p></td>
@@ -1534,10 +1534,10 @@
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.sizePolicy" title="napari.qt.QtViewerButtons.sizePolicy"><code class="xref py py-obj docutils literal notranslate"><span class="pre">sizePolicy</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.stackUnder" title="napari.qt.QtViewerButtons.stackUnder"><code class="xref py py-obj docutils literal notranslate"><span class="pre">stackUnder</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.stackUnder" title="napari.qt.QtViewerButtons.stackUnder"><code class="xref py py-obj docutils literal notranslate"><span class="pre">stackUnder</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.startTimer" title="napari.qt.QtViewerButtons.startTimer"><code class="xref py py-obj docutils literal notranslate"><span class="pre">startTimer</span></code></a>(self, interval[, timerType])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.startTimer" title="napari.qt.QtViewerButtons.startTimer"><code class="xref py py-obj docutils literal notranslate"><span class="pre">startTimer</span></code></a>(self, interval[, timerType])</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.statusTip" title="napari.qt.QtViewerButtons.statusTip"><code class="xref py py-obj docutils literal notranslate"><span class="pre">statusTip</span></code></a>(self)</p></td>
@@ -1549,16 +1549,16 @@
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.styleSheet" title="napari.qt.QtViewerButtons.styleSheet"><code class="xref py py-obj docutils literal notranslate"><span class="pre">styleSheet</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.tabletEvent" title="napari.qt.QtViewerButtons.tabletEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">tabletEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.tabletEvent" title="napari.qt.QtViewerButtons.tabletEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">tabletEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.testAttribute" title="napari.qt.QtViewerButtons.testAttribute"><code class="xref py py-obj docutils literal notranslate"><span class="pre">testAttribute</span></code></a>(self, attribute)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.testAttribute" title="napari.qt.QtViewerButtons.testAttribute"><code class="xref py py-obj docutils literal notranslate"><span class="pre">testAttribute</span></code></a>(self, attribute)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.thread" title="napari.qt.QtViewerButtons.thread"><code class="xref py py-obj docutils literal notranslate"><span class="pre">thread</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.timerEvent" title="napari.qt.QtViewerButtons.timerEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">timerEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.timerEvent" title="napari.qt.QtViewerButtons.timerEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">timerEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.toolTip" title="napari.qt.QtViewerButtons.toolTip"><code class="xref py py-obj docutils literal notranslate"><span class="pre">toolTip</span></code></a>(self)</p></td>
@@ -1567,13 +1567,13 @@
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.toolTipDuration" title="napari.qt.QtViewerButtons.toolTipDuration"><code class="xref py py-obj docutils literal notranslate"><span class="pre">toolTipDuration</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.tr" title="napari.qt.QtViewerButtons.tr"><code class="xref py py-obj docutils literal notranslate"><span class="pre">tr</span></code></a>(self, sourceText[, disambiguation, n])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.tr" title="napari.qt.QtViewerButtons.tr"><code class="xref py py-obj docutils literal notranslate"><span class="pre">tr</span></code></a>(self, sourceText[, disambiguation, n])</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.underMouse" title="napari.qt.QtViewerButtons.underMouse"><code class="xref py py-obj docutils literal notranslate"><span class="pre">underMouse</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.ungrabGesture" title="napari.qt.QtViewerButtons.ungrabGesture"><code class="xref py py-obj docutils literal notranslate"><span class="pre">ungrabGesture</span></code></a>(self, type)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.ungrabGesture" title="napari.qt.QtViewerButtons.ungrabGesture"><code class="xref py py-obj docutils literal notranslate"><span class="pre">ungrabGesture</span></code></a>(self, type)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.unsetCursor" title="napari.qt.QtViewerButtons.unsetCursor"><code class="xref py py-obj docutils literal notranslate"><span class="pre">unsetCursor</span></code></a>(self)</p></td>
@@ -1585,8 +1585,8 @@
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.unsetLocale" title="napari.qt.QtViewerButtons.unsetLocale"><code class="xref py py-obj docutils literal notranslate"><span class="pre">unsetLocale</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.update" title="napari.qt.QtViewerButtons.update"><code class="xref py py-obj docutils literal notranslate"><span class="pre">update</span></code></a>(-&gt; None
- -&gt; None)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.update" title="napari.qt.QtViewerButtons.update"><code class="xref py py-obj docutils literal notranslate"><span class="pre">update</span></code></a>(-&gt; None
+ -&gt; None)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.updateGeometry" title="napari.qt.QtViewerButtons.updateGeometry"><code class="xref py py-obj docutils literal notranslate"><span class="pre">updateGeometry</span></code></a>(self)</p></td>
@@ -1604,7 +1604,7 @@
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.whatsThis" title="napari.qt.QtViewerButtons.whatsThis"><code class="xref py py-obj docutils literal notranslate"><span class="pre">whatsThis</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.wheelEvent" title="napari.qt.QtViewerButtons.wheelEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">wheelEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.wheelEvent" title="napari.qt.QtViewerButtons.wheelEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">wheelEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.QtViewerButtons.width" title="napari.qt.QtViewerButtons.width"><code class="xref py py-obj docutils literal notranslate"><span class="pre">width</span></code></a>(self)</p></td>

--- a/0.6.5/api/napari.qt.Window.html
+++ b/0.6.5/api/napari.qt.Window.html
@@ -67,8 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
@@ -677,43 +677,43 @@
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.Window.activate" title="napari.qt.Window.activate"><code class="xref py py-obj docutils literal notranslate"><span class="pre">activate</span></code></a>()</p></td>
 <td><p>Make the viewer the currently active window.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.Window.add_dock_widget" title="napari.qt.Window.add_dock_widget"><code class="xref py py-obj docutils literal notranslate"><span class="pre">add_dock_widget</span></code></a>(widget, *[, name, area, ...])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.Window.add_dock_widget" title="napari.qt.Window.add_dock_widget"><code class="xref py py-obj docutils literal notranslate"><span class="pre">add_dock_widget</span></code></a>(widget, *[, name, area, ...])</p></td>
 <td><p>Convenience method to add a QDockWidget to the main window.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.Window.add_function_widget" title="napari.qt.Window.add_function_widget"><code class="xref py py-obj docutils literal notranslate"><span class="pre">add_function_widget</span></code></a>(function, *[, ...])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.Window.add_function_widget" title="napari.qt.Window.add_function_widget"><code class="xref py py-obj docutils literal notranslate"><span class="pre">add_function_widget</span></code></a>(function, *[, ...])</p></td>
 <td><p>Turn a function into a dock widget via magicgui.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.Window.add_plugin_dock_widget" title="napari.qt.Window.add_plugin_dock_widget"><code class="xref py py-obj docutils literal notranslate"><span class="pre">add_plugin_dock_widget</span></code></a>(plugin_name[, ...])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.Window.add_plugin_dock_widget" title="napari.qt.Window.add_plugin_dock_widget"><code class="xref py py-obj docutils literal notranslate"><span class="pre">add_plugin_dock_widget</span></code></a>(plugin_name[, ...])</p></td>
 <td><p>Add plugin dock widget if not already added.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.Window.clipboard" title="napari.qt.Window.clipboard"><code class="xref py py-obj docutils literal notranslate"><span class="pre">clipboard</span></code></a>([flash, canvas_only])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.Window.clipboard" title="napari.qt.Window.clipboard"><code class="xref py py-obj docutils literal notranslate"><span class="pre">clipboard</span></code></a>([flash, canvas_only])</p></td>
 <td><p>Copy screenshot of current viewer to the clipboard.</p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.Window.close" title="napari.qt.Window.close"><code class="xref py py-obj docutils literal notranslate"><span class="pre">close</span></code></a>()</p></td>
 <td><p>Close the viewer window and cleanup sub-widgets.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.Window.export_figure" title="napari.qt.Window.export_figure"><code class="xref py py-obj docutils literal notranslate"><span class="pre">export_figure</span></code></a>([path, scale, flash])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.Window.export_figure" title="napari.qt.Window.export_figure"><code class="xref py py-obj docutils literal notranslate"><span class="pre">export_figure</span></code></a>([path, scale, flash])</p></td>
 <td><p>Export an image of the full extent of the displayed layer data.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.Window.export_rois" title="napari.qt.Window.export_rois"><code class="xref py py-obj docutils literal notranslate"><span class="pre">export_rois</span></code></a>(rois[, paths, scale])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.Window.export_rois" title="napari.qt.Window.export_rois"><code class="xref py py-obj docutils literal notranslate"><span class="pre">export_rois</span></code></a>(rois[, paths, scale])</p></td>
 <td><p>Export the given rectangular rois to specified file paths.</p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.Window.geometry" title="napari.qt.Window.geometry"><code class="xref py py-obj docutils literal notranslate"><span class="pre">geometry</span></code></a>()</p></td>
 <td><p>Get the geometry of the widget</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.Window.remove_dock_widget" title="napari.qt.Window.remove_dock_widget"><code class="xref py py-obj docutils literal notranslate"><span class="pre">remove_dock_widget</span></code></a>(widget[, menu])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.Window.remove_dock_widget" title="napari.qt.Window.remove_dock_widget"><code class="xref py py-obj docutils literal notranslate"><span class="pre">remove_dock_widget</span></code></a>(widget[, menu])</p></td>
 <td><p>Removes specified dock widget.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.Window.resize" title="napari.qt.Window.resize"><code class="xref py py-obj docutils literal notranslate"><span class="pre">resize</span></code></a>(width, height)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.Window.resize" title="napari.qt.Window.resize"><code class="xref py py-obj docutils literal notranslate"><span class="pre">resize</span></code></a>(width, height)</p></td>
 <td><p>Resize the window.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.Window.screenshot" title="napari.qt.Window.screenshot"><code class="xref py py-obj docutils literal notranslate"><span class="pre">screenshot</span></code></a>([path, size, scale, flash, ...])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.Window.screenshot" title="napari.qt.Window.screenshot"><code class="xref py py-obj docutils literal notranslate"><span class="pre">screenshot</span></code></a>([path, size, scale, flash, ...])</p></td>
 <td><p>Take currently displayed viewer and convert to an image array.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.Window.set_geometry" title="napari.qt.Window.set_geometry"><code class="xref py py-obj docutils literal notranslate"><span class="pre">set_geometry</span></code></a>(left, top, width, height)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.Window.set_geometry" title="napari.qt.Window.set_geometry"><code class="xref py py-obj docutils literal notranslate"><span class="pre">set_geometry</span></code></a>(left, top, width, height)</p></td>
 <td><p>Set the geometry of the widget</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.Window.show" title="napari.qt.Window.show"><code class="xref py py-obj docutils literal notranslate"><span class="pre">show</span></code></a>(*[, block])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.Window.show" title="napari.qt.Window.show"><code class="xref py py-obj docutils literal notranslate"><span class="pre">show</span></code></a>(*[, block])</p></td>
 <td><p>Resize, show, and bring forward the window.</p></td>
 </tr>
 </tbody>

--- a/0.6.5/api/napari.qt.html
+++ b/0.6.5/api/napari.qt.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/api/napari.qt.threading.FunctionWorker.html
+++ b/0.6.5/api/napari.qt.threading.FunctionWorker.html
@@ -67,8 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
@@ -628,7 +628,7 @@
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.FunctionWorker.run" title="napari.qt.threading.FunctionWorker.run"><code class="xref py py-obj docutils literal notranslate"><span class="pre">run</span></code></a>()</p></td>
 <td><p>Start the worker.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.FunctionWorker.setAutoDelete" title="napari.qt.threading.FunctionWorker.setAutoDelete"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setAutoDelete</span></code></a>(self, _autoDelete)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.FunctionWorker.setAutoDelete" title="napari.qt.threading.FunctionWorker.setAutoDelete"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setAutoDelete</span></code></a>(self, _autoDelete)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.FunctionWorker.start" title="napari.qt.threading.FunctionWorker.start"><code class="xref py py-obj docutils literal notranslate"><span class="pre">start</span></code></a>()</p></td>

--- a/0.6.5/api/napari.qt.threading.GeneratorWorker.html
+++ b/0.6.5/api/napari.qt.threading.GeneratorWorker.html
@@ -67,8 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
@@ -637,7 +637,7 @@
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorker.send" title="napari.qt.threading.GeneratorWorker.send"><code class="xref py py-obj docutils literal notranslate"><span class="pre">send</span></code></a>(value)</p></td>
 <td><p>Send a value into the function (if a generator was used).</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorker.setAutoDelete" title="napari.qt.threading.GeneratorWorker.setAutoDelete"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setAutoDelete</span></code></a>(self, _autoDelete)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorker.setAutoDelete" title="napari.qt.threading.GeneratorWorker.setAutoDelete"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setAutoDelete</span></code></a>(self, _autoDelete)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorker.start" title="napari.qt.threading.GeneratorWorker.start"><code class="xref py py-obj docutils literal notranslate"><span class="pre">start</span></code></a>()</p></td>

--- a/0.6.5/api/napari.qt.threading.GeneratorWorkerSignals.html
+++ b/0.6.5/api/napari.qt.threading.GeneratorWorkerSignals.html
@@ -67,8 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
@@ -613,28 +613,28 @@
 <p class="rubric">Methods</p>
 <div class="pst-scrollable-table-container"><table class="autosummary longtable table autosummary">
 <tbody>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorkerSignals.blockSignals" title="napari.qt.threading.GeneratorWorkerSignals.blockSignals"><code class="xref py py-obj docutils literal notranslate"><span class="pre">blockSignals</span></code></a>(self, b)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorkerSignals.blockSignals" title="napari.qt.threading.GeneratorWorkerSignals.blockSignals"><code class="xref py py-obj docutils literal notranslate"><span class="pre">blockSignals</span></code></a>(self, b)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorkerSignals.childEvent" title="napari.qt.threading.GeneratorWorkerSignals.childEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">childEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorkerSignals.childEvent" title="napari.qt.threading.GeneratorWorkerSignals.childEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">childEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorkerSignals.children" title="napari.qt.threading.GeneratorWorkerSignals.children"><code class="xref py py-obj docutils literal notranslate"><span class="pre">children</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorkerSignals.connectNotify" title="napari.qt.threading.GeneratorWorkerSignals.connectNotify"><code class="xref py py-obj docutils literal notranslate"><span class="pre">connectNotify</span></code></a>(self, signal)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorkerSignals.connectNotify" title="napari.qt.threading.GeneratorWorkerSignals.connectNotify"><code class="xref py py-obj docutils literal notranslate"><span class="pre">connectNotify</span></code></a>(self, signal)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorkerSignals.customEvent" title="napari.qt.threading.GeneratorWorkerSignals.customEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">customEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorkerSignals.customEvent" title="napari.qt.threading.GeneratorWorkerSignals.customEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">customEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorkerSignals.deleteLater" title="napari.qt.threading.GeneratorWorkerSignals.deleteLater"><code class="xref py py-obj docutils literal notranslate"><span class="pre">deleteLater</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorkerSignals.disconnect" title="napari.qt.threading.GeneratorWorkerSignals.disconnect"><code class="xref py py-obj docutils literal notranslate"><span class="pre">disconnect</span></code></a>(-&gt; bool)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorkerSignals.disconnect" title="napari.qt.threading.GeneratorWorkerSignals.disconnect"><code class="xref py py-obj docutils literal notranslate"><span class="pre">disconnect</span></code></a>(-&gt; bool)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorkerSignals.disconnectNotify" title="napari.qt.threading.GeneratorWorkerSignals.disconnectNotify"><code class="xref py py-obj docutils literal notranslate"><span class="pre">disconnectNotify</span></code></a>(self, signal)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorkerSignals.disconnectNotify" title="napari.qt.threading.GeneratorWorkerSignals.disconnectNotify"><code class="xref py py-obj docutils literal notranslate"><span class="pre">disconnectNotify</span></code></a>(self, signal)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorkerSignals.dumpObjectInfo" title="napari.qt.threading.GeneratorWorkerSignals.dumpObjectInfo"><code class="xref py py-obj docutils literal notranslate"><span class="pre">dumpObjectInfo</span></code></a>(self)</p></td>
@@ -646,25 +646,25 @@
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorkerSignals.dynamicPropertyNames" title="napari.qt.threading.GeneratorWorkerSignals.dynamicPropertyNames"><code class="xref py py-obj docutils literal notranslate"><span class="pre">dynamicPropertyNames</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorkerSignals.event" title="napari.qt.threading.GeneratorWorkerSignals.event"><code class="xref py py-obj docutils literal notranslate"><span class="pre">event</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorkerSignals.event" title="napari.qt.threading.GeneratorWorkerSignals.event"><code class="xref py py-obj docutils literal notranslate"><span class="pre">event</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorkerSignals.eventFilter" title="napari.qt.threading.GeneratorWorkerSignals.eventFilter"><code class="xref py py-obj docutils literal notranslate"><span class="pre">eventFilter</span></code></a>(self, a0, a1)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorkerSignals.eventFilter" title="napari.qt.threading.GeneratorWorkerSignals.eventFilter"><code class="xref py py-obj docutils literal notranslate"><span class="pre">eventFilter</span></code></a>(self, a0, a1)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorkerSignals.findChild" title="napari.qt.threading.GeneratorWorkerSignals.findChild"><code class="xref py py-obj docutils literal notranslate"><span class="pre">findChild</span></code></a>(-&gt; QObjectT)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorkerSignals.findChild" title="napari.qt.threading.GeneratorWorkerSignals.findChild"><code class="xref py py-obj docutils literal notranslate"><span class="pre">findChild</span></code></a>(-&gt; QObjectT)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorkerSignals.findChildren" title="napari.qt.threading.GeneratorWorkerSignals.findChildren"><code class="xref py py-obj docutils literal notranslate"><span class="pre">findChildren</span></code></a>(...)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorkerSignals.inherits" title="napari.qt.threading.GeneratorWorkerSignals.inherits"><code class="xref py py-obj docutils literal notranslate"><span class="pre">inherits</span></code></a>(self, classname)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorkerSignals.inherits" title="napari.qt.threading.GeneratorWorkerSignals.inherits"><code class="xref py py-obj docutils literal notranslate"><span class="pre">inherits</span></code></a>(self, classname)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorkerSignals.installEventFilter" title="napari.qt.threading.GeneratorWorkerSignals.installEventFilter"><code class="xref py py-obj docutils literal notranslate"><span class="pre">installEventFilter</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorkerSignals.installEventFilter" title="napari.qt.threading.GeneratorWorkerSignals.installEventFilter"><code class="xref py py-obj docutils literal notranslate"><span class="pre">installEventFilter</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorkerSignals.isSignalConnected" title="napari.qt.threading.GeneratorWorkerSignals.isSignalConnected"><code class="xref py py-obj docutils literal notranslate"><span class="pre">isSignalConnected</span></code></a>(self, signal)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorkerSignals.isSignalConnected" title="napari.qt.threading.GeneratorWorkerSignals.isSignalConnected"><code class="xref py py-obj docutils literal notranslate"><span class="pre">isSignalConnected</span></code></a>(self, signal)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorkerSignals.isWidgetType" title="napari.qt.threading.GeneratorWorkerSignals.isWidgetType"><code class="xref py py-obj docutils literal notranslate"><span class="pre">isWidgetType</span></code></a>(self)</p></td>
@@ -673,13 +673,13 @@
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorkerSignals.isWindowType" title="napari.qt.threading.GeneratorWorkerSignals.isWindowType"><code class="xref py py-obj docutils literal notranslate"><span class="pre">isWindowType</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorkerSignals.killTimer" title="napari.qt.threading.GeneratorWorkerSignals.killTimer"><code class="xref py py-obj docutils literal notranslate"><span class="pre">killTimer</span></code></a>(self, id)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorkerSignals.killTimer" title="napari.qt.threading.GeneratorWorkerSignals.killTimer"><code class="xref py py-obj docutils literal notranslate"><span class="pre">killTimer</span></code></a>(self, id)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorkerSignals.metaObject" title="napari.qt.threading.GeneratorWorkerSignals.metaObject"><code class="xref py py-obj docutils literal notranslate"><span class="pre">metaObject</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorkerSignals.moveToThread" title="napari.qt.threading.GeneratorWorkerSignals.moveToThread"><code class="xref py py-obj docutils literal notranslate"><span class="pre">moveToThread</span></code></a>(self, thread)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorkerSignals.moveToThread" title="napari.qt.threading.GeneratorWorkerSignals.moveToThread"><code class="xref py py-obj docutils literal notranslate"><span class="pre">moveToThread</span></code></a>(self, thread)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorkerSignals.objectName" title="napari.qt.threading.GeneratorWorkerSignals.objectName"><code class="xref py py-obj docutils literal notranslate"><span class="pre">objectName</span></code></a>(self)</p></td>
@@ -688,16 +688,16 @@
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorkerSignals.parent" title="napari.qt.threading.GeneratorWorkerSignals.parent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">parent</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorkerSignals.property" title="napari.qt.threading.GeneratorWorkerSignals.property"><code class="xref py py-obj docutils literal notranslate"><span class="pre">property</span></code></a>(self, name)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorkerSignals.property" title="napari.qt.threading.GeneratorWorkerSignals.property"><code class="xref py py-obj docutils literal notranslate"><span class="pre">property</span></code></a>(self, name)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorkerSignals.pyqtConfigure" title="napari.qt.threading.GeneratorWorkerSignals.pyqtConfigure"><code class="xref py py-obj docutils literal notranslate"><span class="pre">pyqtConfigure</span></code></a>(...)</p></td>
 <td><p>Each keyword argument is either the name of a Qt property or a Qt signal.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorkerSignals.receivers" title="napari.qt.threading.GeneratorWorkerSignals.receivers"><code class="xref py py-obj docutils literal notranslate"><span class="pre">receivers</span></code></a>(self, signal)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorkerSignals.receivers" title="napari.qt.threading.GeneratorWorkerSignals.receivers"><code class="xref py py-obj docutils literal notranslate"><span class="pre">receivers</span></code></a>(self, signal)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorkerSignals.removeEventFilter" title="napari.qt.threading.GeneratorWorkerSignals.removeEventFilter"><code class="xref py py-obj docutils literal notranslate"><span class="pre">removeEventFilter</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorkerSignals.removeEventFilter" title="napari.qt.threading.GeneratorWorkerSignals.removeEventFilter"><code class="xref py py-obj docutils literal notranslate"><span class="pre">removeEventFilter</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorkerSignals.sender" title="napari.qt.threading.GeneratorWorkerSignals.sender"><code class="xref py py-obj docutils literal notranslate"><span class="pre">sender</span></code></a>(self)</p></td>
@@ -706,28 +706,28 @@
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorkerSignals.senderSignalIndex" title="napari.qt.threading.GeneratorWorkerSignals.senderSignalIndex"><code class="xref py py-obj docutils literal notranslate"><span class="pre">senderSignalIndex</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorkerSignals.setObjectName" title="napari.qt.threading.GeneratorWorkerSignals.setObjectName"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setObjectName</span></code></a>(self, name)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorkerSignals.setObjectName" title="napari.qt.threading.GeneratorWorkerSignals.setObjectName"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setObjectName</span></code></a>(self, name)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorkerSignals.setParent" title="napari.qt.threading.GeneratorWorkerSignals.setParent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setParent</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorkerSignals.setParent" title="napari.qt.threading.GeneratorWorkerSignals.setParent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setParent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorkerSignals.setProperty" title="napari.qt.threading.GeneratorWorkerSignals.setProperty"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setProperty</span></code></a>(self, name, value)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorkerSignals.setProperty" title="napari.qt.threading.GeneratorWorkerSignals.setProperty"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setProperty</span></code></a>(self, name, value)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorkerSignals.signalsBlocked" title="napari.qt.threading.GeneratorWorkerSignals.signalsBlocked"><code class="xref py py-obj docutils literal notranslate"><span class="pre">signalsBlocked</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorkerSignals.startTimer" title="napari.qt.threading.GeneratorWorkerSignals.startTimer"><code class="xref py py-obj docutils literal notranslate"><span class="pre">startTimer</span></code></a>(self, interval[, timerType])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorkerSignals.startTimer" title="napari.qt.threading.GeneratorWorkerSignals.startTimer"><code class="xref py py-obj docutils literal notranslate"><span class="pre">startTimer</span></code></a>(self, interval[, timerType])</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorkerSignals.thread" title="napari.qt.threading.GeneratorWorkerSignals.thread"><code class="xref py py-obj docutils literal notranslate"><span class="pre">thread</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorkerSignals.timerEvent" title="napari.qt.threading.GeneratorWorkerSignals.timerEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">timerEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorkerSignals.timerEvent" title="napari.qt.threading.GeneratorWorkerSignals.timerEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">timerEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorkerSignals.tr" title="napari.qt.threading.GeneratorWorkerSignals.tr"><code class="xref py py-obj docutils literal notranslate"><span class="pre">tr</span></code></a>(self, sourceText[, disambiguation, n])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.GeneratorWorkerSignals.tr" title="napari.qt.threading.GeneratorWorkerSignals.tr"><code class="xref py py-obj docutils literal notranslate"><span class="pre">tr</span></code></a>(self, sourceText[, disambiguation, n])</p></td>
 <td><p></p></td>
 </tr>
 </tbody>

--- a/0.6.5/api/napari.qt.threading.WorkerBase.html
+++ b/0.6.5/api/napari.qt.threading.WorkerBase.html
@@ -67,8 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
@@ -629,7 +629,7 @@
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBase.run" title="napari.qt.threading.WorkerBase.run"><code class="xref py py-obj docutils literal notranslate"><span class="pre">run</span></code></a>()</p></td>
 <td><p>Start the worker.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBase.setAutoDelete" title="napari.qt.threading.WorkerBase.setAutoDelete"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setAutoDelete</span></code></a>(self, _autoDelete)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBase.setAutoDelete" title="napari.qt.threading.WorkerBase.setAutoDelete"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setAutoDelete</span></code></a>(self, _autoDelete)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBase.start" title="napari.qt.threading.WorkerBase.start"><code class="xref py py-obj docutils literal notranslate"><span class="pre">start</span></code></a>()</p></td>

--- a/0.6.5/api/napari.qt.threading.WorkerBaseSignals.html
+++ b/0.6.5/api/napari.qt.threading.WorkerBaseSignals.html
@@ -67,8 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
@@ -613,28 +613,28 @@
 <p class="rubric">Methods</p>
 <div class="pst-scrollable-table-container"><table class="autosummary longtable table autosummary">
 <tbody>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBaseSignals.blockSignals" title="napari.qt.threading.WorkerBaseSignals.blockSignals"><code class="xref py py-obj docutils literal notranslate"><span class="pre">blockSignals</span></code></a>(self, b)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBaseSignals.blockSignals" title="napari.qt.threading.WorkerBaseSignals.blockSignals"><code class="xref py py-obj docutils literal notranslate"><span class="pre">blockSignals</span></code></a>(self, b)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBaseSignals.childEvent" title="napari.qt.threading.WorkerBaseSignals.childEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">childEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBaseSignals.childEvent" title="napari.qt.threading.WorkerBaseSignals.childEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">childEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBaseSignals.children" title="napari.qt.threading.WorkerBaseSignals.children"><code class="xref py py-obj docutils literal notranslate"><span class="pre">children</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBaseSignals.connectNotify" title="napari.qt.threading.WorkerBaseSignals.connectNotify"><code class="xref py py-obj docutils literal notranslate"><span class="pre">connectNotify</span></code></a>(self, signal)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBaseSignals.connectNotify" title="napari.qt.threading.WorkerBaseSignals.connectNotify"><code class="xref py py-obj docutils literal notranslate"><span class="pre">connectNotify</span></code></a>(self, signal)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBaseSignals.customEvent" title="napari.qt.threading.WorkerBaseSignals.customEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">customEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBaseSignals.customEvent" title="napari.qt.threading.WorkerBaseSignals.customEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">customEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBaseSignals.deleteLater" title="napari.qt.threading.WorkerBaseSignals.deleteLater"><code class="xref py py-obj docutils literal notranslate"><span class="pre">deleteLater</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBaseSignals.disconnect" title="napari.qt.threading.WorkerBaseSignals.disconnect"><code class="xref py py-obj docutils literal notranslate"><span class="pre">disconnect</span></code></a>(-&gt; bool)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBaseSignals.disconnect" title="napari.qt.threading.WorkerBaseSignals.disconnect"><code class="xref py py-obj docutils literal notranslate"><span class="pre">disconnect</span></code></a>(-&gt; bool)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBaseSignals.disconnectNotify" title="napari.qt.threading.WorkerBaseSignals.disconnectNotify"><code class="xref py py-obj docutils literal notranslate"><span class="pre">disconnectNotify</span></code></a>(self, signal)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBaseSignals.disconnectNotify" title="napari.qt.threading.WorkerBaseSignals.disconnectNotify"><code class="xref py py-obj docutils literal notranslate"><span class="pre">disconnectNotify</span></code></a>(self, signal)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBaseSignals.dumpObjectInfo" title="napari.qt.threading.WorkerBaseSignals.dumpObjectInfo"><code class="xref py py-obj docutils literal notranslate"><span class="pre">dumpObjectInfo</span></code></a>(self)</p></td>
@@ -646,25 +646,25 @@
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBaseSignals.dynamicPropertyNames" title="napari.qt.threading.WorkerBaseSignals.dynamicPropertyNames"><code class="xref py py-obj docutils literal notranslate"><span class="pre">dynamicPropertyNames</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBaseSignals.event" title="napari.qt.threading.WorkerBaseSignals.event"><code class="xref py py-obj docutils literal notranslate"><span class="pre">event</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBaseSignals.event" title="napari.qt.threading.WorkerBaseSignals.event"><code class="xref py py-obj docutils literal notranslate"><span class="pre">event</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBaseSignals.eventFilter" title="napari.qt.threading.WorkerBaseSignals.eventFilter"><code class="xref py py-obj docutils literal notranslate"><span class="pre">eventFilter</span></code></a>(self, a0, a1)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBaseSignals.eventFilter" title="napari.qt.threading.WorkerBaseSignals.eventFilter"><code class="xref py py-obj docutils literal notranslate"><span class="pre">eventFilter</span></code></a>(self, a0, a1)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBaseSignals.findChild" title="napari.qt.threading.WorkerBaseSignals.findChild"><code class="xref py py-obj docutils literal notranslate"><span class="pre">findChild</span></code></a>(-&gt; QObjectT)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBaseSignals.findChild" title="napari.qt.threading.WorkerBaseSignals.findChild"><code class="xref py py-obj docutils literal notranslate"><span class="pre">findChild</span></code></a>(-&gt; QObjectT)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBaseSignals.findChildren" title="napari.qt.threading.WorkerBaseSignals.findChildren"><code class="xref py py-obj docutils literal notranslate"><span class="pre">findChildren</span></code></a>(...)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBaseSignals.inherits" title="napari.qt.threading.WorkerBaseSignals.inherits"><code class="xref py py-obj docutils literal notranslate"><span class="pre">inherits</span></code></a>(self, classname)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBaseSignals.inherits" title="napari.qt.threading.WorkerBaseSignals.inherits"><code class="xref py py-obj docutils literal notranslate"><span class="pre">inherits</span></code></a>(self, classname)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBaseSignals.installEventFilter" title="napari.qt.threading.WorkerBaseSignals.installEventFilter"><code class="xref py py-obj docutils literal notranslate"><span class="pre">installEventFilter</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBaseSignals.installEventFilter" title="napari.qt.threading.WorkerBaseSignals.installEventFilter"><code class="xref py py-obj docutils literal notranslate"><span class="pre">installEventFilter</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBaseSignals.isSignalConnected" title="napari.qt.threading.WorkerBaseSignals.isSignalConnected"><code class="xref py py-obj docutils literal notranslate"><span class="pre">isSignalConnected</span></code></a>(self, signal)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBaseSignals.isSignalConnected" title="napari.qt.threading.WorkerBaseSignals.isSignalConnected"><code class="xref py py-obj docutils literal notranslate"><span class="pre">isSignalConnected</span></code></a>(self, signal)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBaseSignals.isWidgetType" title="napari.qt.threading.WorkerBaseSignals.isWidgetType"><code class="xref py py-obj docutils literal notranslate"><span class="pre">isWidgetType</span></code></a>(self)</p></td>
@@ -673,13 +673,13 @@
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBaseSignals.isWindowType" title="napari.qt.threading.WorkerBaseSignals.isWindowType"><code class="xref py py-obj docutils literal notranslate"><span class="pre">isWindowType</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBaseSignals.killTimer" title="napari.qt.threading.WorkerBaseSignals.killTimer"><code class="xref py py-obj docutils literal notranslate"><span class="pre">killTimer</span></code></a>(self, id)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBaseSignals.killTimer" title="napari.qt.threading.WorkerBaseSignals.killTimer"><code class="xref py py-obj docutils literal notranslate"><span class="pre">killTimer</span></code></a>(self, id)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBaseSignals.metaObject" title="napari.qt.threading.WorkerBaseSignals.metaObject"><code class="xref py py-obj docutils literal notranslate"><span class="pre">metaObject</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBaseSignals.moveToThread" title="napari.qt.threading.WorkerBaseSignals.moveToThread"><code class="xref py py-obj docutils literal notranslate"><span class="pre">moveToThread</span></code></a>(self, thread)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBaseSignals.moveToThread" title="napari.qt.threading.WorkerBaseSignals.moveToThread"><code class="xref py py-obj docutils literal notranslate"><span class="pre">moveToThread</span></code></a>(self, thread)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBaseSignals.objectName" title="napari.qt.threading.WorkerBaseSignals.objectName"><code class="xref py py-obj docutils literal notranslate"><span class="pre">objectName</span></code></a>(self)</p></td>
@@ -688,16 +688,16 @@
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBaseSignals.parent" title="napari.qt.threading.WorkerBaseSignals.parent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">parent</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBaseSignals.property" title="napari.qt.threading.WorkerBaseSignals.property"><code class="xref py py-obj docutils literal notranslate"><span class="pre">property</span></code></a>(self, name)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBaseSignals.property" title="napari.qt.threading.WorkerBaseSignals.property"><code class="xref py py-obj docutils literal notranslate"><span class="pre">property</span></code></a>(self, name)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBaseSignals.pyqtConfigure" title="napari.qt.threading.WorkerBaseSignals.pyqtConfigure"><code class="xref py py-obj docutils literal notranslate"><span class="pre">pyqtConfigure</span></code></a>(...)</p></td>
 <td><p>Each keyword argument is either the name of a Qt property or a Qt signal.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBaseSignals.receivers" title="napari.qt.threading.WorkerBaseSignals.receivers"><code class="xref py py-obj docutils literal notranslate"><span class="pre">receivers</span></code></a>(self, signal)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBaseSignals.receivers" title="napari.qt.threading.WorkerBaseSignals.receivers"><code class="xref py py-obj docutils literal notranslate"><span class="pre">receivers</span></code></a>(self, signal)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBaseSignals.removeEventFilter" title="napari.qt.threading.WorkerBaseSignals.removeEventFilter"><code class="xref py py-obj docutils literal notranslate"><span class="pre">removeEventFilter</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBaseSignals.removeEventFilter" title="napari.qt.threading.WorkerBaseSignals.removeEventFilter"><code class="xref py py-obj docutils literal notranslate"><span class="pre">removeEventFilter</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBaseSignals.sender" title="napari.qt.threading.WorkerBaseSignals.sender"><code class="xref py py-obj docutils literal notranslate"><span class="pre">sender</span></code></a>(self)</p></td>
@@ -706,28 +706,28 @@
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBaseSignals.senderSignalIndex" title="napari.qt.threading.WorkerBaseSignals.senderSignalIndex"><code class="xref py py-obj docutils literal notranslate"><span class="pre">senderSignalIndex</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBaseSignals.setObjectName" title="napari.qt.threading.WorkerBaseSignals.setObjectName"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setObjectName</span></code></a>(self, name)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBaseSignals.setObjectName" title="napari.qt.threading.WorkerBaseSignals.setObjectName"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setObjectName</span></code></a>(self, name)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBaseSignals.setParent" title="napari.qt.threading.WorkerBaseSignals.setParent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setParent</span></code></a>(self, a0)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBaseSignals.setParent" title="napari.qt.threading.WorkerBaseSignals.setParent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setParent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBaseSignals.setProperty" title="napari.qt.threading.WorkerBaseSignals.setProperty"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setProperty</span></code></a>(self, name, value)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBaseSignals.setProperty" title="napari.qt.threading.WorkerBaseSignals.setProperty"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setProperty</span></code></a>(self, name, value)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBaseSignals.signalsBlocked" title="napari.qt.threading.WorkerBaseSignals.signalsBlocked"><code class="xref py py-obj docutils literal notranslate"><span class="pre">signalsBlocked</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBaseSignals.startTimer" title="napari.qt.threading.WorkerBaseSignals.startTimer"><code class="xref py py-obj docutils literal notranslate"><span class="pre">startTimer</span></code></a>(self, interval[, timerType])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBaseSignals.startTimer" title="napari.qt.threading.WorkerBaseSignals.startTimer"><code class="xref py py-obj docutils literal notranslate"><span class="pre">startTimer</span></code></a>(self, interval[, timerType])</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBaseSignals.thread" title="napari.qt.threading.WorkerBaseSignals.thread"><code class="xref py py-obj docutils literal notranslate"><span class="pre">thread</span></code></a>(self)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBaseSignals.timerEvent" title="napari.qt.threading.WorkerBaseSignals.timerEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">timerEvent</span></code></a>(self, a0)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBaseSignals.timerEvent" title="napari.qt.threading.WorkerBaseSignals.timerEvent"><code class="xref py py-obj docutils literal notranslate"><span class="pre">timerEvent</span></code></a>(self, a0)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBaseSignals.tr" title="napari.qt.threading.WorkerBaseSignals.tr"><code class="xref py py-obj docutils literal notranslate"><span class="pre">tr</span></code></a>(self, sourceText[, disambiguation, n])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.qt.threading.WorkerBaseSignals.tr" title="napari.qt.threading.WorkerBaseSignals.tr"><code class="xref py py-obj docutils literal notranslate"><span class="pre">tr</span></code></a>(self, sourceText[, disambiguation, n])</p></td>
 <td><p></p></td>
 </tr>
 </tbody>

--- a/0.6.5/api/napari.qt.threading.html
+++ b/0.6.5/api/napari.qt.threading.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/api/napari.types.ArrayBase.html
+++ b/0.6.5/api/napari.types.ArrayBase.html
@@ -67,8 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/api/napari.types.SampleDict.html
+++ b/0.6.5/api/napari.types.SampleDict.html
@@ -67,8 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
@@ -622,7 +622,7 @@
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.types.SampleDict.fromkeys" title="napari.types.SampleDict.fromkeys"><code class="xref py py-obj docutils literal notranslate"><span class="pre">fromkeys</span></code></a>([value])</p></td>
 <td><p>Create a new dictionary with keys from iterable and values set to value.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.types.SampleDict.get" title="napari.types.SampleDict.get"><code class="xref py py-obj docutils literal notranslate"><span class="pre">get</span></code></a>(key[, default])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.types.SampleDict.get" title="napari.types.SampleDict.get"><code class="xref py py-obj docutils literal notranslate"><span class="pre">get</span></code></a>(key[, default])</p></td>
 <td><p>Return the value for key if key is in the dictionary, else default.</p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.types.SampleDict.items" title="napari.types.SampleDict.items"><code class="xref py py-obj docutils literal notranslate"><span class="pre">items</span></code></a>()</p></td>
@@ -637,10 +637,10 @@
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.types.SampleDict.popitem" title="napari.types.SampleDict.popitem"><code class="xref py py-obj docutils literal notranslate"><span class="pre">popitem</span></code></a>()</p></td>
 <td><p>Remove and return a (key, value) pair as a 2-tuple.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.types.SampleDict.setdefault" title="napari.types.SampleDict.setdefault"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setdefault</span></code></a>(key[, default])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.types.SampleDict.setdefault" title="napari.types.SampleDict.setdefault"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setdefault</span></code></a>(key[, default])</p></td>
 <td><p>Insert key with a value of default if key is not in the dictionary.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.types.SampleDict.update" title="napari.types.SampleDict.update"><code class="xref py py-obj docutils literal notranslate"><span class="pre">update</span></code></a>([E, ]**F)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.types.SampleDict.update" title="napari.types.SampleDict.update"><code class="xref py py-obj docutils literal notranslate"><span class="pre">update</span></code></a>([E, ]**F)</p></td>
 <td><p>If E is present and has a .keys() method, then does:  for k in E: D[k] = E[k] If E is present and lacks a .keys() method, then does:  for k, v in E: D[k] = v In either case, this is followed by: for k in F:  D[k] = F[k]</p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.types.SampleDict.values" title="napari.types.SampleDict.values"><code class="xref py py-obj docutils literal notranslate"><span class="pre">values</span></code></a>()</p></td>

--- a/0.6.5/api/napari.types.html
+++ b/0.6.5/api/napari.types.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/api/napari.utils.Colormap.html
+++ b/0.6.5/api/napari.utils.Colormap.html
@@ -67,8 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
@@ -708,10 +708,10 @@ color per control point). If ‘zero’, ncontrols
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.Colormap.construct" title="napari.utils.Colormap.construct"><code class="xref py py-obj docutils literal notranslate"><span class="pre">construct</span></code></a>([_fields_set])</p></td>
 <td><p>Creates a new model setting __dict__ and __fields_set__ from trusted or pre-validated data.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.Colormap.copy" title="napari.utils.Colormap.copy"><code class="xref py py-obj docutils literal notranslate"><span class="pre">copy</span></code></a>(*[, include, exclude, update, deep])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.Colormap.copy" title="napari.utils.Colormap.copy"><code class="xref py py-obj docutils literal notranslate"><span class="pre">copy</span></code></a>(*[, include, exclude, update, deep])</p></td>
 <td><p>Duplicate a model, optionally choose which fields to include, exclude and change.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.Colormap.dict" title="napari.utils.Colormap.dict"><code class="xref py py-obj docutils literal notranslate"><span class="pre">dict</span></code></a>(*[, include, exclude, by_alias, ...])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.Colormap.dict" title="napari.utils.Colormap.dict"><code class="xref py py-obj docutils literal notranslate"><span class="pre">dict</span></code></a>(*[, include, exclude, by_alias, ...])</p></td>
 <td><p>Generate a dictionary representation of the model, optionally specifying which fields to include or exclude.</p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.Colormap.enums_as_values" title="napari.utils.Colormap.enums_as_values"><code class="xref py py-obj docutils literal notranslate"><span class="pre">enums_as_values</span></code></a>([as_values])</p></td>
@@ -720,31 +720,31 @@ color per control point). If ‘zero’, ncontrols
 <tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">from_orm</span></code>(obj)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.Colormap.json" title="napari.utils.Colormap.json"><code class="xref py py-obj docutils literal notranslate"><span class="pre">json</span></code></a>(*[, include, exclude, by_alias, ...])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.Colormap.json" title="napari.utils.Colormap.json"><code class="xref py py-obj docutils literal notranslate"><span class="pre">json</span></code></a>(*[, include, exclude, by_alias, ...])</p></td>
 <td><p>Generate a JSON representation of the model, <cite>include</cite> and <cite>exclude</cite> arguments as per <cite>dict()</cite>.</p></td>
 </tr>
 <tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">map</span></code>(values)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">parse_file</span></code>(path, *[, content_type, ...])</p></td>
+<tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">parse_file</span></code>(path, *[, content_type, ...])</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">parse_obj</span></code>(obj)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">parse_raw</span></code>(b, *[, content_type, encoding, ...])</p></td>
+<tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">parse_raw</span></code>(b, *[, content_type, encoding, ...])</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.Colormap.reset" title="napari.utils.Colormap.reset"><code class="xref py py-obj docutils literal notranslate"><span class="pre">reset</span></code></a>()</p></td>
 <td><p>Reset the state of the model to default values.</p></td>
 </tr>
-<tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">schema</span></code>([by_alias, ref_template])</p></td>
+<tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">schema</span></code>([by_alias, ref_template])</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">schema_json</span></code>(*[, by_alias, ref_template])</p></td>
+<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">schema_json</span></code>(*[, by_alias, ref_template])</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.Colormap.update" title="napari.utils.Colormap.update"><code class="xref py py-obj docutils literal notranslate"><span class="pre">update</span></code></a>(values[, recurse])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.Colormap.update" title="napari.utils.Colormap.update"><code class="xref py py-obj docutils literal notranslate"><span class="pre">update</span></code></a>(values[, recurse])</p></td>
 <td><p>Update a model in place.</p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.Colormap.update_forward_refs" title="napari.utils.Colormap.update_forward_refs"><code class="xref py py-obj docutils literal notranslate"><span class="pre">update_forward_refs</span></code></a>(**localns)</p></td>

--- a/0.6.5/api/napari.utils.CyclicLabelColormap.html
+++ b/0.6.5/api/napari.utils.CyclicLabelColormap.html
@@ -67,8 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
@@ -688,10 +688,10 @@ It will be removed in the future release.</p>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.CyclicLabelColormap.construct" title="napari.utils.CyclicLabelColormap.construct"><code class="xref py py-obj docutils literal notranslate"><span class="pre">construct</span></code></a>([_fields_set])</p></td>
 <td><p>Creates a new model setting __dict__ and __fields_set__ from trusted or pre-validated data.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.CyclicLabelColormap.copy" title="napari.utils.CyclicLabelColormap.copy"><code class="xref py py-obj docutils literal notranslate"><span class="pre">copy</span></code></a>(*[, include, exclude, update, deep])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.CyclicLabelColormap.copy" title="napari.utils.CyclicLabelColormap.copy"><code class="xref py py-obj docutils literal notranslate"><span class="pre">copy</span></code></a>(*[, include, exclude, update, deep])</p></td>
 <td><p>Duplicate a model, optionally choose which fields to include, exclude and change.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.CyclicLabelColormap.dict" title="napari.utils.CyclicLabelColormap.dict"><code class="xref py py-obj docutils literal notranslate"><span class="pre">dict</span></code></a>(*[, include, exclude, by_alias, ...])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.CyclicLabelColormap.dict" title="napari.utils.CyclicLabelColormap.dict"><code class="xref py py-obj docutils literal notranslate"><span class="pre">dict</span></code></a>(*[, include, exclude, by_alias, ...])</p></td>
 <td><p>Generate a dictionary representation of the model, optionally specifying which fields to include or exclude.</p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.CyclicLabelColormap.enums_as_values" title="napari.utils.CyclicLabelColormap.enums_as_values"><code class="xref py py-obj docutils literal notranslate"><span class="pre">enums_as_values</span></code></a>([as_values])</p></td>
@@ -700,34 +700,34 @@ It will be removed in the future release.</p>
 <tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">from_orm</span></code>(obj)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.CyclicLabelColormap.json" title="napari.utils.CyclicLabelColormap.json"><code class="xref py py-obj docutils literal notranslate"><span class="pre">json</span></code></a>(*[, include, exclude, by_alias, ...])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.CyclicLabelColormap.json" title="napari.utils.CyclicLabelColormap.json"><code class="xref py py-obj docutils literal notranslate"><span class="pre">json</span></code></a>(*[, include, exclude, by_alias, ...])</p></td>
 <td><p>Generate a JSON representation of the model, <cite>include</cite> and <cite>exclude</cite> arguments as per <cite>dict()</cite>.</p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.CyclicLabelColormap.map" title="napari.utils.CyclicLabelColormap.map"><code class="xref py py-obj docutils literal notranslate"><span class="pre">map</span></code></a>(values)</p></td>
 <td><p>Map values to colors.</p></td>
 </tr>
-<tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">parse_file</span></code>(path, *[, content_type, ...])</p></td>
+<tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">parse_file</span></code>(path, *[, content_type, ...])</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">parse_obj</span></code>(obj)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">parse_raw</span></code>(b, *[, content_type, encoding, ...])</p></td>
+<tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">parse_raw</span></code>(b, *[, content_type, encoding, ...])</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.CyclicLabelColormap.reset" title="napari.utils.CyclicLabelColormap.reset"><code class="xref py py-obj docutils literal notranslate"><span class="pre">reset</span></code></a>()</p></td>
 <td><p>Reset the state of the model to default values.</p></td>
 </tr>
-<tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">schema</span></code>([by_alias, ref_template])</p></td>
+<tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">schema</span></code>([by_alias, ref_template])</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">schema_json</span></code>(*[, by_alias, ref_template])</p></td>
+<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">schema_json</span></code>(*[, by_alias, ref_template])</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.CyclicLabelColormap.shuffle" title="napari.utils.CyclicLabelColormap.shuffle"><code class="xref py py-obj docutils literal notranslate"><span class="pre">shuffle</span></code></a>(seed)</p></td>
 <td><p>Shuffle the colormap colors.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.CyclicLabelColormap.update" title="napari.utils.CyclicLabelColormap.update"><code class="xref py py-obj docutils literal notranslate"><span class="pre">update</span></code></a>(values[, recurse])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.CyclicLabelColormap.update" title="napari.utils.CyclicLabelColormap.update"><code class="xref py py-obj docutils literal notranslate"><span class="pre">update</span></code></a>(values[, recurse])</p></td>
 <td><p>Update a model in place.</p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.CyclicLabelColormap.update_forward_refs" title="napari.utils.CyclicLabelColormap.update_forward_refs"><code class="xref py py-obj docutils literal notranslate"><span class="pre">update_forward_refs</span></code></a>(**localns)</p></td>

--- a/0.6.5/api/napari.utils.DirectLabelColormap.html
+++ b/0.6.5/api/napari.utils.DirectLabelColormap.html
@@ -67,8 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
@@ -662,10 +662,10 @@ If <cite>True</cite> only selected label will be not transparent.</p>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.DirectLabelColormap.construct" title="napari.utils.DirectLabelColormap.construct"><code class="xref py py-obj docutils literal notranslate"><span class="pre">construct</span></code></a>([_fields_set])</p></td>
 <td><p>Creates a new model setting __dict__ and __fields_set__ from trusted or pre-validated data.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.DirectLabelColormap.copy" title="napari.utils.DirectLabelColormap.copy"><code class="xref py py-obj docutils literal notranslate"><span class="pre">copy</span></code></a>(*[, include, exclude, update, deep])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.DirectLabelColormap.copy" title="napari.utils.DirectLabelColormap.copy"><code class="xref py py-obj docutils literal notranslate"><span class="pre">copy</span></code></a>(*[, include, exclude, update, deep])</p></td>
 <td><p>Duplicate a model, optionally choose which fields to include, exclude and change.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.DirectLabelColormap.dict" title="napari.utils.DirectLabelColormap.dict"><code class="xref py py-obj docutils literal notranslate"><span class="pre">dict</span></code></a>(*[, include, exclude, by_alias, ...])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.DirectLabelColormap.dict" title="napari.utils.DirectLabelColormap.dict"><code class="xref py py-obj docutils literal notranslate"><span class="pre">dict</span></code></a>(*[, include, exclude, by_alias, ...])</p></td>
 <td><p>Generate a dictionary representation of the model, optionally specifying which fields to include or exclude.</p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.DirectLabelColormap.enums_as_values" title="napari.utils.DirectLabelColormap.enums_as_values"><code class="xref py py-obj docutils literal notranslate"><span class="pre">enums_as_values</span></code></a>([as_values])</p></td>
@@ -674,31 +674,31 @@ If <cite>True</cite> only selected label will be not transparent.</p>
 <tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">from_orm</span></code>(obj)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.DirectLabelColormap.json" title="napari.utils.DirectLabelColormap.json"><code class="xref py py-obj docutils literal notranslate"><span class="pre">json</span></code></a>(*[, include, exclude, by_alias, ...])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.DirectLabelColormap.json" title="napari.utils.DirectLabelColormap.json"><code class="xref py py-obj docutils literal notranslate"><span class="pre">json</span></code></a>(*[, include, exclude, by_alias, ...])</p></td>
 <td><p>Generate a JSON representation of the model, <cite>include</cite> and <cite>exclude</cite> arguments as per <cite>dict()</cite>.</p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.DirectLabelColormap.map" title="napari.utils.DirectLabelColormap.map"><code class="xref py py-obj docutils literal notranslate"><span class="pre">map</span></code></a>(values)</p></td>
 <td><p>Map values to colors.</p></td>
 </tr>
-<tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">parse_file</span></code>(path, *[, content_type, ...])</p></td>
+<tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">parse_file</span></code>(path, *[, content_type, ...])</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">parse_obj</span></code>(obj)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">parse_raw</span></code>(b, *[, content_type, encoding, ...])</p></td>
+<tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">parse_raw</span></code>(b, *[, content_type, encoding, ...])</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.DirectLabelColormap.reset" title="napari.utils.DirectLabelColormap.reset"><code class="xref py py-obj docutils literal notranslate"><span class="pre">reset</span></code></a>()</p></td>
 <td><p>Reset the state of the model to default values.</p></td>
 </tr>
-<tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">schema</span></code>([by_alias, ref_template])</p></td>
+<tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">schema</span></code>([by_alias, ref_template])</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">schema_json</span></code>(*[, by_alias, ref_template])</p></td>
+<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">schema_json</span></code>(*[, by_alias, ref_template])</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.DirectLabelColormap.update" title="napari.utils.DirectLabelColormap.update"><code class="xref py py-obj docutils literal notranslate"><span class="pre">update</span></code></a>(values[, recurse])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.DirectLabelColormap.update" title="napari.utils.DirectLabelColormap.update"><code class="xref py py-obj docutils literal notranslate"><span class="pre">update</span></code></a>(values[, recurse])</p></td>
 <td><p>Update a model in place.</p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.DirectLabelColormap.update_forward_refs" title="napari.utils.DirectLabelColormap.update_forward_refs"><code class="xref py py-obj docutils literal notranslate"><span class="pre">update_forward_refs</span></code></a>(**localns)</p></td>

--- a/0.6.5/api/napari.utils.NotebookScreenshot.html
+++ b/0.6.5/api/napari.utils.NotebookScreenshot.html
@@ -67,8 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/api/napari.utils.cancelable_progress.html
+++ b/0.6.5/api/napari.utils.cancelable_progress.html
@@ -67,8 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
@@ -640,22 +640,22 @@ to close resources, repair state, etc.</p>
 <tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">close</span></code>()</p></td>
 <td><p>Close progress object and emit event.</p></td>
 </tr>
-<tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">display</span></code>([msg, pos])</p></td>
+<tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">display</span></code>([msg, pos])</p></td>
 <td><p>Update the display and emit eta event.</p></td>
 </tr>
-<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">external_write_mode</span></code>([file, nolock])</p></td>
+<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">external_write_mode</span></code>([file, nolock])</p></td>
 <td><p>Disable tqdm within context and refresh tqdm when exits.</p></td>
 </tr>
 <tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">format_interval</span></code>(t)</p></td>
 <td><p>Formats a number of seconds as a clock time, [H:]MM:SS</p></td>
 </tr>
-<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">format_meter</span></code>(n, total, elapsed[, ncols, ...])</p></td>
+<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">format_meter</span></code>(n, total, elapsed[, ncols, ...])</p></td>
 <td><p>Return a string-based progress bar given some parameters</p></td>
 </tr>
 <tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">format_num</span></code>(n)</p></td>
 <td><p>Intelligent scientific notation (.3g).</p></td>
 </tr>
-<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">format_sizeof</span></code>(num[, suffix, divisor])</p></td>
+<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">format_sizeof</span></code>(num[, suffix, divisor])</p></td>
 <td><p>Formats a number (greater than unity) with SI Order of Magnitude prefixes.</p></td>
 </tr>
 <tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_lock</span></code>()</p></td>
@@ -670,7 +670,7 @@ to close resources, repair state, etc.</p>
 <tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">pandas</span></code>(**tqdm_kwargs)</p></td>
 <td><p>Registers the current <cite>tqdm</cite> class with</p></td>
 </tr>
-<tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">refresh</span></code>([nolock, lock_args])</p></td>
+<tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">refresh</span></code>([nolock, lock_args])</p></td>
 <td><p>Force refresh the display of this bar.</p></td>
 </tr>
 <tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">reset</span></code>([total])</p></td>
@@ -679,16 +679,16 @@ to close resources, repair state, etc.</p>
 <tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">set_description</span></code>(desc)</p></td>
 <td><p>Update progress description and emit description event.</p></td>
 </tr>
-<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">set_description_str</span></code>([desc, refresh])</p></td>
+<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">set_description_str</span></code>([desc, refresh])</p></td>
 <td><p>Set/modify description without ': ' appended.</p></td>
 </tr>
 <tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">set_lock</span></code>(lock)</p></td>
 <td><p>Set the global lock.</p></td>
 </tr>
-<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">set_postfix</span></code>([ordered_dict, refresh])</p></td>
+<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">set_postfix</span></code>([ordered_dict, refresh])</p></td>
 <td><p>Set/modify postfix (additional stats) with automatic formatting based on datatype.</p></td>
 </tr>
-<tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">set_postfix_str</span></code>([s, refresh])</p></td>
+<tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">set_postfix_str</span></code>([s, refresh])</p></td>
 <td><p>Postfix without dictionary expansion, similar to prefix handling.</p></td>
 </tr>
 <tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">status_printer</span></code>(file)</p></td>
@@ -700,10 +700,10 @@ to close resources, repair state, etc.</p>
 <tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">update</span></code>([n])</p></td>
 <td><p>Update progress value by n and emit value event</p></td>
 </tr>
-<tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">wrapattr</span></code>(stream, method[, total, bytes])</p></td>
+<tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">wrapattr</span></code>(stream, method[, total, bytes])</p></td>
 <td><p>stream  : file-like object. method  : str, &quot;read&quot; or &quot;write&quot;. The result of <cite>read()</cite> and     the first argument of <cite>write()</cite> should have a <cite>len()</cite>.</p></td>
 </tr>
-<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">write</span></code>(s[, file, end, nolock])</p></td>
+<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">write</span></code>(s[, file, end, nolock])</p></td>
 <td><p>Print a message via tqdm (without overlap with bars).</p></td>
 </tr>
 </tbody>

--- a/0.6.5/api/napari.utils.events.EmitterGroup.html
+++ b/0.6.5/api/napari.utils.events.EmitterGroup.html
@@ -67,8 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
@@ -663,7 +663,7 @@ group of emitters to default callbacks.  By default, false.</p></li>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.events.EmitterGroup.blocker_all" title="napari.utils.events.EmitterGroup.blocker_all"><code class="xref py py-obj docutils literal notranslate"><span class="pre">blocker_all</span></code></a>()</p></td>
 <td><p>Return an EventBlockerAll to be used in 'with' statements</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.events.EmitterGroup.connect" title="napari.utils.events.EmitterGroup.connect"><code class="xref py py-obj docutils literal notranslate"><span class="pre">connect</span></code></a>(callback[, ref, position, before, after])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.events.EmitterGroup.connect" title="napari.utils.events.EmitterGroup.connect"><code class="xref py py-obj docutils literal notranslate"><span class="pre">connect</span></code></a>(callback[, ref, position, before, after])</p></td>
 <td><p>Connect the callback to the event group.</p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.events.EmitterGroup.disconnect" title="napari.utils.events.EmitterGroup.disconnect"><code class="xref py py-obj docutils literal notranslate"><span class="pre">disconnect</span></code></a>([callback])</p></td>

--- a/0.6.5/api/napari.utils.events.Event.html
+++ b/0.6.5/api/napari.utils.events.Event.html
@@ -67,8 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/api/napari.utils.events.EventEmitter.html
+++ b/0.6.5/api/napari.utils.events.EventEmitter.html
@@ -67,8 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
@@ -653,7 +653,7 @@ have their .source property set to this value.</p></li>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.events.EventEmitter.blocker" title="napari.utils.events.EventEmitter.blocker"><code class="xref py py-obj docutils literal notranslate"><span class="pre">blocker</span></code></a>([callback])</p></td>
 <td><p>Return an EventBlocker to be used in 'with' statements</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.events.EventEmitter.connect" title="napari.utils.events.EventEmitter.connect"><code class="xref py py-obj docutils literal notranslate"><span class="pre">connect</span></code></a>(callback[, ref, position, before, ...])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.events.EventEmitter.connect" title="napari.utils.events.EventEmitter.connect"><code class="xref py py-obj docutils literal notranslate"><span class="pre">connect</span></code></a>(callback[, ref, position, before, ...])</p></td>
 <td><p>Connect this emitter to a new callback.</p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.events.EventEmitter.disconnect" title="napari.utils.events.EventEmitter.disconnect"><code class="xref py py-obj docutils literal notranslate"><span class="pre">disconnect</span></code></a>([callback])</p></td>

--- a/0.6.5/api/napari.utils.events.EventedDict.html
+++ b/0.6.5/api/napari.utils.events.EventedDict.html
@@ -67,8 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
@@ -666,7 +666,7 @@ the <code class="docutils literal notranslate"><span class="pre">basetype</span>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.events.EventedDict.setdefault" title="napari.utils.events.EventedDict.setdefault"><code class="xref py py-obj docutils literal notranslate"><span class="pre">setdefault</span></code></a>(k[,d])</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.events.EventedDict.update" title="napari.utils.events.EventedDict.update"><code class="xref py py-obj docutils literal notranslate"><span class="pre">update</span></code></a>([E, ]**F)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.events.EventedDict.update" title="napari.utils.events.EventedDict.update"><code class="xref py py-obj docutils literal notranslate"><span class="pre">update</span></code></a>([E, ]**F)</p></td>
 <td><p>If E present and has a .keys() method, does:     for k in E: D[k] = E[k] If E present and lacks .keys() method, does:     for (k, v) in E: D[k] = v In either case, this is followed by: for k, v in F.items(): D[k] = v</p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.events.EventedDict.values" title="napari.utils.events.EventedDict.values"><code class="xref py py-obj docutils literal notranslate"><span class="pre">values</span></code></a>()</p></td>

--- a/0.6.5/api/napari.utils.events.EventedList.html
+++ b/0.6.5/api/napari.utils.events.EventedList.html
@@ -67,8 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
@@ -655,16 +655,16 @@ to that type.</p></li>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.events.EventedList.extend" title="napari.utils.events.EventedList.extend"><code class="xref py py-obj docutils literal notranslate"><span class="pre">extend</span></code></a>(values)</p></td>
 <td><p>S.extend(iterable) -- extend sequence by appending elements from the iterable</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.events.EventedList.index" title="napari.utils.events.EventedList.index"><code class="xref py py-obj docutils literal notranslate"><span class="pre">index</span></code></a>(value[, start, stop])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.events.EventedList.index" title="napari.utils.events.EventedList.index"><code class="xref py py-obj docutils literal notranslate"><span class="pre">index</span></code></a>(value[, start, stop])</p></td>
 <td><p>Return first index of value.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.events.EventedList.insert" title="napari.utils.events.EventedList.insert"><code class="xref py py-obj docutils literal notranslate"><span class="pre">insert</span></code></a>(index, value)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.events.EventedList.insert" title="napari.utils.events.EventedList.insert"><code class="xref py py-obj docutils literal notranslate"><span class="pre">insert</span></code></a>(index, value)</p></td>
 <td><p>Insert <code class="docutils literal notranslate"><span class="pre">value</span></code> before index.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.events.EventedList.move" title="napari.utils.events.EventedList.move"><code class="xref py py-obj docutils literal notranslate"><span class="pre">move</span></code></a>(src_index[, dest_index])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.events.EventedList.move" title="napari.utils.events.EventedList.move"><code class="xref py py-obj docutils literal notranslate"><span class="pre">move</span></code></a>(src_index[, dest_index])</p></td>
 <td><p>Insert object at <code class="docutils literal notranslate"><span class="pre">src_index</span></code> before <code class="docutils literal notranslate"><span class="pre">dest_index</span></code>.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.events.EventedList.move_multiple" title="napari.utils.events.EventedList.move_multiple"><code class="xref py py-obj docutils literal notranslate"><span class="pre">move_multiple</span></code></a>(sources[, dest_index])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.events.EventedList.move_multiple" title="napari.utils.events.EventedList.move_multiple"><code class="xref py py-obj docutils literal notranslate"><span class="pre">move_multiple</span></code></a>(sources[, dest_index])</p></td>
 <td><p>Move a batch of <cite>sources</cite> indices, to a single destination.</p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.events.EventedList.pop" title="napari.utils.events.EventedList.pop"><code class="xref py py-obj docutils literal notranslate"><span class="pre">pop</span></code></a>([index])</p></td>

--- a/0.6.5/api/napari.utils.events.EventedModel.html
+++ b/0.6.5/api/napari.utils.events.EventedModel.html
@@ -67,8 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
@@ -619,10 +619,10 @@ not validated (#4138) and should be correctly typed.</p>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.events.EventedModel.construct" title="napari.utils.events.EventedModel.construct"><code class="xref py py-obj docutils literal notranslate"><span class="pre">construct</span></code></a>([_fields_set])</p></td>
 <td><p>Creates a new model setting __dict__ and __fields_set__ from trusted or pre-validated data.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.events.EventedModel.copy" title="napari.utils.events.EventedModel.copy"><code class="xref py py-obj docutils literal notranslate"><span class="pre">copy</span></code></a>(*[, include, exclude, update, deep])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.events.EventedModel.copy" title="napari.utils.events.EventedModel.copy"><code class="xref py py-obj docutils literal notranslate"><span class="pre">copy</span></code></a>(*[, include, exclude, update, deep])</p></td>
 <td><p>Duplicate a model, optionally choose which fields to include, exclude and change.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.events.EventedModel.dict" title="napari.utils.events.EventedModel.dict"><code class="xref py py-obj docutils literal notranslate"><span class="pre">dict</span></code></a>(*[, include, exclude, by_alias, ...])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.events.EventedModel.dict" title="napari.utils.events.EventedModel.dict"><code class="xref py py-obj docutils literal notranslate"><span class="pre">dict</span></code></a>(*[, include, exclude, by_alias, ...])</p></td>
 <td><p>Generate a dictionary representation of the model, optionally specifying which fields to include or exclude.</p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.events.EventedModel.enums_as_values" title="napari.utils.events.EventedModel.enums_as_values"><code class="xref py py-obj docutils literal notranslate"><span class="pre">enums_as_values</span></code></a>([as_values])</p></td>
@@ -631,28 +631,28 @@ not validated (#4138) and should be correctly typed.</p>
 <tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">from_orm</span></code>(obj)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.events.EventedModel.json" title="napari.utils.events.EventedModel.json"><code class="xref py py-obj docutils literal notranslate"><span class="pre">json</span></code></a>(*[, include, exclude, by_alias, ...])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.events.EventedModel.json" title="napari.utils.events.EventedModel.json"><code class="xref py py-obj docutils literal notranslate"><span class="pre">json</span></code></a>(*[, include, exclude, by_alias, ...])</p></td>
 <td><p>Generate a JSON representation of the model, <cite>include</cite> and <cite>exclude</cite> arguments as per <cite>dict()</cite>.</p></td>
 </tr>
-<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">parse_file</span></code>(path, *[, content_type, ...])</p></td>
+<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">parse_file</span></code>(path, *[, content_type, ...])</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">parse_obj</span></code>(obj)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">parse_raw</span></code>(b, *[, content_type, encoding, ...])</p></td>
+<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">parse_raw</span></code>(b, *[, content_type, encoding, ...])</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.events.EventedModel.reset" title="napari.utils.events.EventedModel.reset"><code class="xref py py-obj docutils literal notranslate"><span class="pre">reset</span></code></a>()</p></td>
 <td><p>Reset the state of the model to default values.</p></td>
 </tr>
-<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">schema</span></code>([by_alias, ref_template])</p></td>
+<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">schema</span></code>([by_alias, ref_template])</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">schema_json</span></code>(*[, by_alias, ref_template])</p></td>
+<tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">schema_json</span></code>(*[, by_alias, ref_template])</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.events.EventedModel.update" title="napari.utils.events.EventedModel.update"><code class="xref py py-obj docutils literal notranslate"><span class="pre">update</span></code></a>(values[, recurse])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.events.EventedModel.update" title="napari.utils.events.EventedModel.update"><code class="xref py py-obj docutils literal notranslate"><span class="pre">update</span></code></a>(values[, recurse])</p></td>
 <td><p>Update a model in place.</p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.events.EventedModel.update_forward_refs" title="napari.utils.events.EventedModel.update_forward_refs"><code class="xref py py-obj docutils literal notranslate"><span class="pre">update_forward_refs</span></code></a>(**localns)</p></td>

--- a/0.6.5/api/napari.utils.events.EventedSet.html
+++ b/0.6.5/api/napari.utils.events.EventedSet.html
@@ -67,8 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
@@ -674,7 +674,7 @@ and/or removed from the set.</p>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.events.EventedSet.update" title="napari.utils.events.EventedSet.update"><code class="xref py py-obj docutils literal notranslate"><span class="pre">update</span></code></a>([others])</p></td>
 <td><p>Update this set with the union of this set and others</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.events.EventedSet.validate" title="napari.utils.events.EventedSet.validate"><code class="xref py py-obj docutils literal notranslate"><span class="pre">validate</span></code></a>(v, field)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.events.EventedSet.validate" title="napari.utils.events.EventedSet.validate"><code class="xref py py-obj docutils literal notranslate"><span class="pre">validate</span></code></a>(v, field)</p></td>
 <td><p>Pydantic validator.</p></td>
 </tr>
 </tbody>

--- a/0.6.5/api/napari.utils.events.NestableEventedList.html
+++ b/0.6.5/api/napari.utils.events.NestableEventedList.html
@@ -67,8 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
@@ -667,16 +667,16 @@ to that type.</p></li>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.events.NestableEventedList.has_index" title="napari.utils.events.NestableEventedList.has_index"><code class="xref py py-obj docutils literal notranslate"><span class="pre">has_index</span></code></a>(index)</p></td>
 <td><p>Return true if <cite>index</cite> is valid for this nestable list.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.events.NestableEventedList.index" title="napari.utils.events.NestableEventedList.index"><code class="xref py py-obj docutils literal notranslate"><span class="pre">index</span></code></a>(value[, start, stop])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.events.NestableEventedList.index" title="napari.utils.events.NestableEventedList.index"><code class="xref py py-obj docutils literal notranslate"><span class="pre">index</span></code></a>(value[, start, stop])</p></td>
 <td><p>Return first index of value.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.events.NestableEventedList.insert" title="napari.utils.events.NestableEventedList.insert"><code class="xref py py-obj docutils literal notranslate"><span class="pre">insert</span></code></a>(index, value)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.events.NestableEventedList.insert" title="napari.utils.events.NestableEventedList.insert"><code class="xref py py-obj docutils literal notranslate"><span class="pre">insert</span></code></a>(index, value)</p></td>
 <td><p>Insert object before index.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.events.NestableEventedList.move" title="napari.utils.events.NestableEventedList.move"><code class="xref py py-obj docutils literal notranslate"><span class="pre">move</span></code></a>(src_index[, dest_index])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.events.NestableEventedList.move" title="napari.utils.events.NestableEventedList.move"><code class="xref py py-obj docutils literal notranslate"><span class="pre">move</span></code></a>(src_index[, dest_index])</p></td>
 <td><p>Move a single item from <code class="docutils literal notranslate"><span class="pre">src_index</span></code> to <code class="docutils literal notranslate"><span class="pre">dest_index</span></code>.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.events.NestableEventedList.move_multiple" title="napari.utils.events.NestableEventedList.move_multiple"><code class="xref py py-obj docutils literal notranslate"><span class="pre">move_multiple</span></code></a>(sources[, dest_index])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.events.NestableEventedList.move_multiple" title="napari.utils.events.NestableEventedList.move_multiple"><code class="xref py py-obj docutils literal notranslate"><span class="pre">move_multiple</span></code></a>(sources[, dest_index])</p></td>
 <td><p>Move a batch of <cite>sources</cite> indices, to a single destination.</p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.events.NestableEventedList.pop" title="napari.utils.events.NestableEventedList.pop"><code class="xref py py-obj docutils literal notranslate"><span class="pre">pop</span></code></a>([index])</p></td>

--- a/0.6.5/api/napari.utils.events.SelectableEventedList.html
+++ b/0.6.5/api/napari.utils.events.SelectableEventedList.html
@@ -67,8 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
@@ -648,19 +648,19 @@ and/or removed from the set.</p></li>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.events.SelectableEventedList.extend" title="napari.utils.events.SelectableEventedList.extend"><code class="xref py py-obj docutils literal notranslate"><span class="pre">extend</span></code></a>(values)</p></td>
 <td><p>S.extend(iterable) -- extend sequence by appending elements from the iterable</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.events.SelectableEventedList.index" title="napari.utils.events.SelectableEventedList.index"><code class="xref py py-obj docutils literal notranslate"><span class="pre">index</span></code></a>(value[, start, stop])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.events.SelectableEventedList.index" title="napari.utils.events.SelectableEventedList.index"><code class="xref py py-obj docutils literal notranslate"><span class="pre">index</span></code></a>(value[, start, stop])</p></td>
 <td><p>Return first index of value.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.events.SelectableEventedList.insert" title="napari.utils.events.SelectableEventedList.insert"><code class="xref py py-obj docutils literal notranslate"><span class="pre">insert</span></code></a>(index, value)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.events.SelectableEventedList.insert" title="napari.utils.events.SelectableEventedList.insert"><code class="xref py py-obj docutils literal notranslate"><span class="pre">insert</span></code></a>(index, value)</p></td>
 <td><p>Insert <code class="docutils literal notranslate"><span class="pre">value</span></code> before index.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.events.SelectableEventedList.move" title="napari.utils.events.SelectableEventedList.move"><code class="xref py py-obj docutils literal notranslate"><span class="pre">move</span></code></a>(src_index[, dest_index])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.events.SelectableEventedList.move" title="napari.utils.events.SelectableEventedList.move"><code class="xref py py-obj docutils literal notranslate"><span class="pre">move</span></code></a>(src_index[, dest_index])</p></td>
 <td><p>Insert object at <code class="docutils literal notranslate"><span class="pre">src_index</span></code> before <code class="docutils literal notranslate"><span class="pre">dest_index</span></code>.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.events.SelectableEventedList.move_multiple" title="napari.utils.events.SelectableEventedList.move_multiple"><code class="xref py py-obj docutils literal notranslate"><span class="pre">move_multiple</span></code></a>(sources[, dest_index])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.events.SelectableEventedList.move_multiple" title="napari.utils.events.SelectableEventedList.move_multiple"><code class="xref py py-obj docutils literal notranslate"><span class="pre">move_multiple</span></code></a>(sources[, dest_index])</p></td>
 <td><p>Move a batch of <cite>sources</cite> indices, to a single destination.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.events.SelectableEventedList.move_selected" title="napari.utils.events.SelectableEventedList.move_selected"><code class="xref py py-obj docutils literal notranslate"><span class="pre">move_selected</span></code></a>(index, insert)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.events.SelectableEventedList.move_selected" title="napari.utils.events.SelectableEventedList.move_selected"><code class="xref py py-obj docutils literal notranslate"><span class="pre">move_selected</span></code></a>(index, insert)</p></td>
 <td><p>Reorder list by moving the item at index and inserting it at the insert index.</p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.events.SelectableEventedList.pop" title="napari.utils.events.SelectableEventedList.pop"><code class="xref py py-obj docutils literal notranslate"><span class="pre">pop</span></code></a>([index])</p></td>
@@ -678,7 +678,7 @@ and/or removed from the set.</p></li>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.events.SelectableEventedList.select_all" title="napari.utils.events.SelectableEventedList.select_all"><code class="xref py py-obj docutils literal notranslate"><span class="pre">select_all</span></code></a>()</p></td>
 <td><p>Select all items in the list.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.events.SelectableEventedList.select_next" title="napari.utils.events.SelectableEventedList.select_next"><code class="xref py py-obj docutils literal notranslate"><span class="pre">select_next</span></code></a>([step, shift])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.events.SelectableEventedList.select_next" title="napari.utils.events.SelectableEventedList.select_next"><code class="xref py py-obj docutils literal notranslate"><span class="pre">select_next</span></code></a>([step, shift])</p></td>
 <td><p>Selects next item from list.</p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.events.SelectableEventedList.select_previous" title="napari.utils.events.SelectableEventedList.select_previous"><code class="xref py py-obj docutils literal notranslate"><span class="pre">select_previous</span></code></a>([shift])</p></td>

--- a/0.6.5/api/napari.utils.events.Selection.html
+++ b/0.6.5/api/napari.utils.events.Selection.html
@@ -67,8 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
@@ -721,7 +721,7 @@ handling mouse/key events.</p>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.events.Selection.update" title="napari.utils.events.Selection.update"><code class="xref py py-obj docutils literal notranslate"><span class="pre">update</span></code></a>([others])</p></td>
 <td><p>Update this set with the union of this set and others</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.events.Selection.validate" title="napari.utils.events.Selection.validate"><code class="xref py py-obj docutils literal notranslate"><span class="pre">validate</span></code></a>(v, field)</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.events.Selection.validate" title="napari.utils.events.Selection.validate"><code class="xref py py-obj docutils literal notranslate"><span class="pre">validate</span></code></a>(v, field)</p></td>
 <td><p>Pydantic validator.</p></td>
 </tr>
 </tbody>

--- a/0.6.5/api/napari.utils.events.SupportsEvents.html
+++ b/0.6.5/api/napari.utils.events.SupportsEvents.html
@@ -67,8 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/api/napari.utils.events.TypedMutableSequence.html
+++ b/0.6.5/api/napari.utils.events.TypedMutableSequence.html
@@ -67,8 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
@@ -645,10 +645,10 @@ whos attribute <code class="docutils literal notranslate"><span class="pre">.nam
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.events.TypedMutableSequence.extend" title="napari.utils.events.TypedMutableSequence.extend"><code class="xref py py-obj docutils literal notranslate"><span class="pre">extend</span></code></a>(values)</p></td>
 <td><p>S.extend(iterable) -- extend sequence by appending elements from the iterable</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.events.TypedMutableSequence.index" title="napari.utils.events.TypedMutableSequence.index"><code class="xref py py-obj docutils literal notranslate"><span class="pre">index</span></code></a>(value[, start, stop])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.events.TypedMutableSequence.index" title="napari.utils.events.TypedMutableSequence.index"><code class="xref py py-obj docutils literal notranslate"><span class="pre">index</span></code></a>(value[, start, stop])</p></td>
 <td><p>Return first index of value.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.events.TypedMutableSequence.insert" title="napari.utils.events.TypedMutableSequence.insert"><code class="xref py py-obj docutils literal notranslate"><span class="pre">insert</span></code></a>(index, value)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.events.TypedMutableSequence.insert" title="napari.utils.events.TypedMutableSequence.insert"><code class="xref py py-obj docutils literal notranslate"><span class="pre">insert</span></code></a>(index, value)</p></td>
 <td><p>S.insert(index, value) -- insert value before index</p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.events.TypedMutableSequence.pop" title="napari.utils.events.TypedMutableSequence.pop"><code class="xref py py-obj docutils literal notranslate"><span class="pre">pop</span></code></a>([index])</p></td>

--- a/0.6.5/api/napari.utils.events.html
+++ b/0.6.5/api/napari.utils.events.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/api/napari.utils.html
+++ b/0.6.5/api/napari.utils.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/api/napari.utils.nbscreenshot.html
+++ b/0.6.5/api/napari.utils.nbscreenshot.html
@@ -67,8 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/api/napari.utils.notifications.ErrorNotification.html
+++ b/0.6.5/api/napari.utils.notifications.ErrorNotification.html
@@ -67,8 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
@@ -620,10 +620,10 @@
 <tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">as_text</span></code>()</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">from_exception</span></code>(exc, **kwargs)</p></td>
+<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">from_exception</span></code>(exc, **kwargs)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">from_warning</span></code>(warning, **kwargs)</p></td>
+<tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">from_warning</span></code>(warning, **kwargs)</p></td>
 <td><p></p></td>
 </tr>
 </tbody>

--- a/0.6.5/api/napari.utils.notifications.Notification.html
+++ b/0.6.5/api/napari.utils.notifications.Notification.html
@@ -67,8 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
@@ -627,10 +627,10 @@ and the callable is a callback to perform when the action is triggered.
 <p class="rubric">Methods</p>
 <div class="pst-scrollable-table-container"><table class="autosummary longtable table autosummary">
 <tbody>
-<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">from_exception</span></code>(exc, **kwargs)</p></td>
+<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">from_exception</span></code>(exc, **kwargs)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">from_warning</span></code>(warning, **kwargs)</p></td>
+<tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">from_warning</span></code>(warning, **kwargs)</p></td>
 <td><p></p></td>
 </tr>
 </tbody>

--- a/0.6.5/api/napari.utils.notifications.NotificationManager.html
+++ b/0.6.5/api/napari.utils.notifications.NotificationManager.html
@@ -67,8 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
@@ -632,7 +632,7 @@ re-entrency of the hooks themselves.</p>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.notifications.NotificationManager.install_hooks" title="napari.utils.notifications.NotificationManager.install_hooks"><code class="xref py py-obj docutils literal notranslate"><span class="pre">install_hooks</span></code></a>()</p></td>
 <td><p>Install a <cite>sys.excepthook</cite>, a <cite>showwarning</cite> hook and a threading.excepthook to display any message in the UI, storing the previous hooks to be restored if necessary.</p></td>
 </tr>
-<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">receive_error</span></code>(exctype, value[, traceback, ...])</p></td>
+<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">receive_error</span></code>(exctype, value[, traceback, ...])</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">receive_info</span></code>(message)</p></td>
@@ -641,7 +641,7 @@ re-entrency of the hooks themselves.</p>
 <tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">receive_thread_error</span></code>(args)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">receive_warning</span></code>(message, category, filename, ...)</p></td>
+<tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">receive_warning</span></code>(message, category, filename, ...)</p></td>
 <td><p></p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.notifications.NotificationManager.restore_hooks" title="napari.utils.notifications.NotificationManager.restore_hooks"><code class="xref py py-obj docutils literal notranslate"><span class="pre">restore_hooks</span></code></a>()</p></td>

--- a/0.6.5/api/napari.utils.notifications.NotificationSeverity.html
+++ b/0.6.5/api/napari.utils.notifications.NotificationSeverity.html
@@ -67,8 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/api/napari.utils.notifications.WarningNotification.html
+++ b/0.6.5/api/napari.utils.notifications.WarningNotification.html
@@ -67,8 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
@@ -614,10 +614,10 @@
 <p class="rubric">Methods</p>
 <div class="pst-scrollable-table-container"><table class="autosummary longtable table autosummary">
 <tbody>
-<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">from_exception</span></code>(exc, **kwargs)</p></td>
+<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">from_exception</span></code>(exc, **kwargs)</p></td>
 <td><p></p></td>
 </tr>
-<tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">from_warning</span></code>(warning, **kwargs)</p></td>
+<tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">from_warning</span></code>(warning, **kwargs)</p></td>
 <td><p></p></td>
 </tr>
 </tbody>

--- a/0.6.5/api/napari.utils.notifications.html
+++ b/0.6.5/api/napari.utils.notifications.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/api/napari.utils.perf.PerfEvent.html
+++ b/0.6.5/api/napari.utils.perf.PerfEvent.html
@@ -67,8 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/api/napari.utils.perf.html
+++ b/0.6.5/api/napari.utils.perf.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/api/napari.utils.progress.html
+++ b/0.6.5/api/napari.utils.progress.html
@@ -67,8 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
@@ -659,22 +659,22 @@ bar in the terminal.</p>
 <tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">close</span></code>()</p></td>
 <td><p>Close progress object and emit event.</p></td>
 </tr>
-<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">display</span></code>([msg, pos])</p></td>
+<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">display</span></code>([msg, pos])</p></td>
 <td><p>Update the display and emit eta event.</p></td>
 </tr>
-<tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">external_write_mode</span></code>([file, nolock])</p></td>
+<tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">external_write_mode</span></code>([file, nolock])</p></td>
 <td><p>Disable tqdm within context and refresh tqdm when exits.</p></td>
 </tr>
 <tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">format_interval</span></code>(t)</p></td>
 <td><p>Formats a number of seconds as a clock time, [H:]MM:SS</p></td>
 </tr>
-<tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">format_meter</span></code>(n, total, elapsed[, ncols, ...])</p></td>
+<tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">format_meter</span></code>(n, total, elapsed[, ncols, ...])</p></td>
 <td><p>Return a string-based progress bar given some parameters</p></td>
 </tr>
 <tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">format_num</span></code>(n)</p></td>
 <td><p>Intelligent scientific notation (.3g).</p></td>
 </tr>
-<tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">format_sizeof</span></code>(num[, suffix, divisor])</p></td>
+<tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">format_sizeof</span></code>(num[, suffix, divisor])</p></td>
 <td><p>Formats a number (greater than unity) with SI Order of Magnitude prefixes.</p></td>
 </tr>
 <tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">get_lock</span></code>()</p></td>
@@ -689,7 +689,7 @@ bar in the terminal.</p>
 <tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">pandas</span></code>(**tqdm_kwargs)</p></td>
 <td><p>Registers the current <cite>tqdm</cite> class with</p></td>
 </tr>
-<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">refresh</span></code>([nolock, lock_args])</p></td>
+<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">refresh</span></code>([nolock, lock_args])</p></td>
 <td><p>Force refresh the display of this bar.</p></td>
 </tr>
 <tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">reset</span></code>([total])</p></td>
@@ -698,16 +698,16 @@ bar in the terminal.</p>
 <tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">set_description</span></code>(desc)</p></td>
 <td><p>Update progress description and emit description event.</p></td>
 </tr>
-<tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">set_description_str</span></code>([desc, refresh])</p></td>
+<tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">set_description_str</span></code>([desc, refresh])</p></td>
 <td><p>Set/modify description without ': ' appended.</p></td>
 </tr>
 <tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">set_lock</span></code>(lock)</p></td>
 <td><p>Set the global lock.</p></td>
 </tr>
-<tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">set_postfix</span></code>([ordered_dict, refresh])</p></td>
+<tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">set_postfix</span></code>([ordered_dict, refresh])</p></td>
 <td><p>Set/modify postfix (additional stats) with automatic formatting based on datatype.</p></td>
 </tr>
-<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">set_postfix_str</span></code>([s, refresh])</p></td>
+<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">set_postfix_str</span></code>([s, refresh])</p></td>
 <td><p>Postfix without dictionary expansion, similar to prefix handling.</p></td>
 </tr>
 <tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">status_printer</span></code>(file)</p></td>
@@ -719,10 +719,10 @@ bar in the terminal.</p>
 <tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">update</span></code>([n])</p></td>
 <td><p>Update progress value by n and emit value event</p></td>
 </tr>
-<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">wrapattr</span></code>(stream, method[, total, bytes])</p></td>
+<tr class="row-odd"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">wrapattr</span></code>(stream, method[, total, bytes])</p></td>
 <td><p>stream  : file-like object. method  : str, &quot;read&quot; or &quot;write&quot;. The result of <cite>read()</cite> and     the first argument of <cite>write()</cite> should have a <cite>len()</cite>.</p></td>
 </tr>
-<tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">write</span></code>(s[, file, end, nolock])</p></td>
+<tr class="row-even"><td><p><code class="xref py py-obj docutils literal notranslate"><span class="pre">write</span></code>(s[, file, end, nolock])</p></td>
 <td><p>Print a message via tqdm (without overlap with bars).</p></td>
 </tr>
 </tbody>

--- a/0.6.5/api/napari.utils.transforms.Affine.html
+++ b/0.6.5/api/napari.utils.transforms.Affine.html
@@ -67,8 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
@@ -668,7 +668,7 @@ other parameters.</p></li>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.transforms.Affine.expand_dims" title="napari.utils.transforms.Affine.expand_dims"><code class="xref py py-obj docutils literal notranslate"><span class="pre">expand_dims</span></code></a>(axes)</p></td>
 <td><p>Return a transform with added axes for non-visible dimensions.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.transforms.Affine.replace_slice" title="napari.utils.transforms.Affine.replace_slice"><code class="xref py py-obj docutils literal notranslate"><span class="pre">replace_slice</span></code></a>(axes, transform)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.transforms.Affine.replace_slice" title="napari.utils.transforms.Affine.replace_slice"><code class="xref py py-obj docutils literal notranslate"><span class="pre">replace_slice</span></code></a>(axes, transform)</p></td>
 <td><p>Returns a transform where the transform at the indicated n dimensions is replaced with another n-dimensional transform</p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.transforms.Affine.set_slice" title="napari.utils.transforms.Affine.set_slice"><code class="xref py py-obj docutils literal notranslate"><span class="pre">set_slice</span></code></a>(axes)</p></td>

--- a/0.6.5/api/napari.utils.transforms.CompositeAffine.html
+++ b/0.6.5/api/napari.utils.transforms.CompositeAffine.html
@@ -67,8 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
@@ -647,7 +647,7 @@ other parameters.</p></li>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.transforms.CompositeAffine.expand_dims" title="napari.utils.transforms.CompositeAffine.expand_dims"><code class="xref py py-obj docutils literal notranslate"><span class="pre">expand_dims</span></code></a>(axes)</p></td>
 <td><p>Return a transform with added axes for non-visible dimensions.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.transforms.CompositeAffine.replace_slice" title="napari.utils.transforms.CompositeAffine.replace_slice"><code class="xref py py-obj docutils literal notranslate"><span class="pre">replace_slice</span></code></a>(axes, transform)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.transforms.CompositeAffine.replace_slice" title="napari.utils.transforms.CompositeAffine.replace_slice"><code class="xref py py-obj docutils literal notranslate"><span class="pre">replace_slice</span></code></a>(axes, transform)</p></td>
 <td><p>Returns a transform where the transform at the indicated n dimensions is replaced with another n-dimensional transform</p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.transforms.CompositeAffine.set_slice" title="napari.utils.transforms.CompositeAffine.set_slice"><code class="xref py py-obj docutils literal notranslate"><span class="pre">set_slice</span></code></a>(axes)</p></td>

--- a/0.6.5/api/napari.utils.transforms.ScaleTranslate.html
+++ b/0.6.5/api/napari.utils.transforms.ScaleTranslate.html
@@ -67,8 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/api/napari.utils.transforms.Transform.html
+++ b/0.6.5/api/napari.utils.transforms.Transform.html
@@ -67,8 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/api/napari.utils.transforms.TransformChain.html
+++ b/0.6.5/api/napari.utils.transforms.TransformChain.html
@@ -67,8 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
@@ -634,16 +634,16 @@
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.transforms.TransformChain.extend" title="napari.utils.transforms.TransformChain.extend"><code class="xref py py-obj docutils literal notranslate"><span class="pre">extend</span></code></a>(values)</p></td>
 <td><p>S.extend(iterable) -- extend sequence by appending elements from the iterable</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.transforms.TransformChain.index" title="napari.utils.transforms.TransformChain.index"><code class="xref py py-obj docutils literal notranslate"><span class="pre">index</span></code></a>(value[, start, stop])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.transforms.TransformChain.index" title="napari.utils.transforms.TransformChain.index"><code class="xref py py-obj docutils literal notranslate"><span class="pre">index</span></code></a>(value[, start, stop])</p></td>
 <td><p>Return first index of value.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.transforms.TransformChain.insert" title="napari.utils.transforms.TransformChain.insert"><code class="xref py py-obj docutils literal notranslate"><span class="pre">insert</span></code></a>(index, value)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.transforms.TransformChain.insert" title="napari.utils.transforms.TransformChain.insert"><code class="xref py py-obj docutils literal notranslate"><span class="pre">insert</span></code></a>(index, value)</p></td>
 <td><p>Insert <code class="docutils literal notranslate"><span class="pre">value</span></code> before index.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.transforms.TransformChain.move" title="napari.utils.transforms.TransformChain.move"><code class="xref py py-obj docutils literal notranslate"><span class="pre">move</span></code></a>(src_index[, dest_index])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.transforms.TransformChain.move" title="napari.utils.transforms.TransformChain.move"><code class="xref py py-obj docutils literal notranslate"><span class="pre">move</span></code></a>(src_index[, dest_index])</p></td>
 <td><p>Insert object at <code class="docutils literal notranslate"><span class="pre">src_index</span></code> before <code class="docutils literal notranslate"><span class="pre">dest_index</span></code>.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.transforms.TransformChain.move_multiple" title="napari.utils.transforms.TransformChain.move_multiple"><code class="xref py py-obj docutils literal notranslate"><span class="pre">move_multiple</span></code></a>(sources[, dest_index])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.utils.transforms.TransformChain.move_multiple" title="napari.utils.transforms.TransformChain.move_multiple"><code class="xref py py-obj docutils literal notranslate"><span class="pre">move_multiple</span></code></a>(sources[, dest_index])</p></td>
 <td><p>Move a batch of <cite>sources</cite> indices, to a single destination.</p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.utils.transforms.TransformChain.pop" title="napari.utils.transforms.TransformChain.pop"><code class="xref py py-obj docutils literal notranslate"><span class="pre">pop</span></code></a>([index])</p></td>

--- a/0.6.5/api/napari.utils.transforms.html
+++ b/0.6.5/api/napari.utils.transforms.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/api/napari.view_layers.html
+++ b/0.6.5/api/napari.view_layers.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/api/napari.window.Window.html
+++ b/0.6.5/api/napari.window.Window.html
@@ -67,8 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
@@ -677,43 +677,43 @@
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.window.Window.activate" title="napari.window.Window.activate"><code class="xref py py-obj docutils literal notranslate"><span class="pre">activate</span></code></a>()</p></td>
 <td><p>Make the viewer the currently active window.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.window.Window.add_dock_widget" title="napari.window.Window.add_dock_widget"><code class="xref py py-obj docutils literal notranslate"><span class="pre">add_dock_widget</span></code></a>(widget, *[, name, area, ...])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.window.Window.add_dock_widget" title="napari.window.Window.add_dock_widget"><code class="xref py py-obj docutils literal notranslate"><span class="pre">add_dock_widget</span></code></a>(widget, *[, name, area, ...])</p></td>
 <td><p>Convenience method to add a QDockWidget to the main window.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.window.Window.add_function_widget" title="napari.window.Window.add_function_widget"><code class="xref py py-obj docutils literal notranslate"><span class="pre">add_function_widget</span></code></a>(function, *[, ...])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.window.Window.add_function_widget" title="napari.window.Window.add_function_widget"><code class="xref py py-obj docutils literal notranslate"><span class="pre">add_function_widget</span></code></a>(function, *[, ...])</p></td>
 <td><p>Turn a function into a dock widget via magicgui.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.window.Window.add_plugin_dock_widget" title="napari.window.Window.add_plugin_dock_widget"><code class="xref py py-obj docutils literal notranslate"><span class="pre">add_plugin_dock_widget</span></code></a>(plugin_name[, ...])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.window.Window.add_plugin_dock_widget" title="napari.window.Window.add_plugin_dock_widget"><code class="xref py py-obj docutils literal notranslate"><span class="pre">add_plugin_dock_widget</span></code></a>(plugin_name[, ...])</p></td>
 <td><p>Add plugin dock widget if not already added.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.window.Window.clipboard" title="napari.window.Window.clipboard"><code class="xref py py-obj docutils literal notranslate"><span class="pre">clipboard</span></code></a>([flash, canvas_only])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.window.Window.clipboard" title="napari.window.Window.clipboard"><code class="xref py py-obj docutils literal notranslate"><span class="pre">clipboard</span></code></a>([flash, canvas_only])</p></td>
 <td><p>Copy screenshot of current viewer to the clipboard.</p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="#napari.window.Window.close" title="napari.window.Window.close"><code class="xref py py-obj docutils literal notranslate"><span class="pre">close</span></code></a>()</p></td>
 <td><p>Close the viewer window and cleanup sub-widgets.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.window.Window.export_figure" title="napari.window.Window.export_figure"><code class="xref py py-obj docutils literal notranslate"><span class="pre">export_figure</span></code></a>([path, scale, flash])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.window.Window.export_figure" title="napari.window.Window.export_figure"><code class="xref py py-obj docutils literal notranslate"><span class="pre">export_figure</span></code></a>([path, scale, flash])</p></td>
 <td><p>Export an image of the full extent of the displayed layer data.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.window.Window.export_rois" title="napari.window.Window.export_rois"><code class="xref py py-obj docutils literal notranslate"><span class="pre">export_rois</span></code></a>(rois[, paths, scale])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.window.Window.export_rois" title="napari.window.Window.export_rois"><code class="xref py py-obj docutils literal notranslate"><span class="pre">export_rois</span></code></a>(rois[, paths, scale])</p></td>
 <td><p>Export the given rectangular rois to specified file paths.</p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="#napari.window.Window.geometry" title="napari.window.Window.geometry"><code class="xref py py-obj docutils literal notranslate"><span class="pre">geometry</span></code></a>()</p></td>
 <td><p>Get the geometry of the widget</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.window.Window.remove_dock_widget" title="napari.window.Window.remove_dock_widget"><code class="xref py py-obj docutils literal notranslate"><span class="pre">remove_dock_widget</span></code></a>(widget[, menu])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.window.Window.remove_dock_widget" title="napari.window.Window.remove_dock_widget"><code class="xref py py-obj docutils literal notranslate"><span class="pre">remove_dock_widget</span></code></a>(widget[, menu])</p></td>
 <td><p>Removes specified dock widget.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.window.Window.resize" title="napari.window.Window.resize"><code class="xref py py-obj docutils literal notranslate"><span class="pre">resize</span></code></a>(width, height)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.window.Window.resize" title="napari.window.Window.resize"><code class="xref py py-obj docutils literal notranslate"><span class="pre">resize</span></code></a>(width, height)</p></td>
 <td><p>Resize the window.</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.window.Window.screenshot" title="napari.window.Window.screenshot"><code class="xref py py-obj docutils literal notranslate"><span class="pre">screenshot</span></code></a>([path, size, scale, flash, ...])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.window.Window.screenshot" title="napari.window.Window.screenshot"><code class="xref py py-obj docutils literal notranslate"><span class="pre">screenshot</span></code></a>([path, size, scale, flash, ...])</p></td>
 <td><p>Take currently displayed viewer and convert to an image array.</p></td>
 </tr>
-<tr class="row-odd"><td><p><a class="reference internal" href="#napari.window.Window.set_geometry" title="napari.window.Window.set_geometry"><code class="xref py py-obj docutils literal notranslate"><span class="pre">set_geometry</span></code></a>(left, top, width, height)</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="#napari.window.Window.set_geometry" title="napari.window.Window.set_geometry"><code class="xref py py-obj docutils literal notranslate"><span class="pre">set_geometry</span></code></a>(left, top, width, height)</p></td>
 <td><p>Set the geometry of the widget</p></td>
 </tr>
-<tr class="row-even"><td><p><a class="reference internal" href="#napari.window.Window.show" title="napari.window.Window.show"><code class="xref py py-obj docutils literal notranslate"><span class="pre">show</span></code></a>(*[, block])</p></td>
+<tr class="row-even"><td><p><a class="reference internal" href="#napari.window.Window.show" title="napari.window.Window.show"><code class="xref py py-obj docutils literal notranslate"><span class="pre">show</span></code></a>(*[, block])</p></td>
 <td><p>Resize, show, and bring forward the window.</p></td>
 </tr>
 </tbody>

--- a/0.6.5/api/napari.window.html
+++ b/0.6.5/api/napari.window.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/api/viewer.html
+++ b/0.6.5/api/viewer.html
@@ -67,8 +67,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />
@@ -598,7 +598,7 @@
 <h1>napari.Viewer<a class="headerlink" href="#napari-viewer" title="Link to this heading">#</a></h1>
 <div class="pst-scrollable-table-container"><table class="autosummary longtable table autosummary">
 <tbody>
-<tr class="row-odd"><td><p><a class="reference internal" href="napari.Viewer.html#napari.Viewer" title="napari.Viewer"><code class="xref py py-obj docutils literal notranslate"><span class="pre">napari.Viewer</span></code></a>(*[, title, ndisplay, order, ...])</p></td>
+<tr class="row-odd"><td><p><a class="reference internal" href="napari.Viewer.html#napari.Viewer" title="napari.Viewer"><code class="xref py py-obj docutils literal notranslate"><span class="pre">napari.Viewer</span></code></a>(*[, title, ndisplay, order, ...])</p></td>
 <td><p>Napari ndarray viewer.</p></td>
 </tr>
 </tbody>

--- a/0.6.5/community/code_of_conduct.html
+++ b/0.6.5/community/code_of_conduct.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/community/code_of_conduct_reporting.html
+++ b/0.6.5/community/code_of_conduct_reporting.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/community/governance.html
+++ b/0.6.5/community/governance.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/community/index.html
+++ b/0.6.5/community/index.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/community/licensing.html
+++ b/0.6.5/community/licensing.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/community/meeting_schedule.html
+++ b/0.6.5/community/meeting_schedule.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/community/mission_and_values.html
+++ b/0.6.5/community/mission_and_values.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/community/resources.html
+++ b/0.6.5/community/resources.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/community/team.html
+++ b/0.6.5/community/team.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/community/working_groups.html
+++ b/0.6.5/community/working_groups.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/developers/architecture/app_model.html
+++ b/0.6.5/developers/architecture/app_model.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/developers/architecture/dir_organization.html
+++ b/0.6.5/developers/architecture/dir_organization.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/developers/architecture/index.html
+++ b/0.6.5/developers/architecture/index.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/developers/architecture/magicgui_type_reg.html
+++ b/0.6.5/developers/architecture/magicgui_type_reg.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/developers/architecture/napari_models.html
+++ b/0.6.5/developers/architecture/napari_models.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/developers/architecture/ui_sections/application_menus_ui.html
+++ b/0.6.5/developers/architecture/ui_sections/application_menus_ui.html
@@ -105,8 +105,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.5/developers/architecture/ui_sections/application_status_bar_ui.html
+++ b/0.6.5/developers/architecture/ui_sections/application_status_bar_ui.html
@@ -105,8 +105,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.5/developers/architecture/ui_sections/console_ui.html
+++ b/0.6.5/developers/architecture/ui_sections/console_ui.html
@@ -105,8 +105,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.5/developers/architecture/ui_sections/dialogs_ui.html
+++ b/0.6.5/developers/architecture/ui_sections/dialogs_ui.html
@@ -105,8 +105,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.5/developers/architecture/ui_sections/index.html
+++ b/0.6.5/developers/architecture/ui_sections/index.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.5/developers/architecture/ui_sections/layers_controls_ui.html
+++ b/0.6.5/developers/architecture/ui_sections/layers_controls_ui.html
@@ -105,8 +105,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.5/developers/architecture/ui_sections/layers_list_ui.html
+++ b/0.6.5/developers/architecture/ui_sections/layers_list_ui.html
@@ -105,8 +105,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.5/developers/architecture/ui_sections/viewer_ui.html
+++ b/0.6.5/developers/architecture/ui_sections/viewer_ui.html
@@ -105,8 +105,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.5/developers/contributing/dev_install.html
+++ b/0.6.5/developers/contributing/dev_install.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/developers/contributing/documentation/docs_deployment.html
+++ b/0.6.5/developers/contributing/documentation/docs_deployment.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.5/developers/contributing/documentation/docs_template.html
+++ b/0.6.5/developers/contributing/documentation/docs_template.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.5/developers/contributing/documentation/index.html
+++ b/0.6.5/developers/contributing/documentation/index.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.5/developers/contributing/index.html
+++ b/0.6.5/developers/contributing/index.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/developers/contributing/performance/benchmarks.html
+++ b/0.6.5/developers/contributing/performance/benchmarks.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.5/developers/contributing/performance/index.html
+++ b/0.6.5/developers/contributing/performance/index.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.5/developers/contributing/performance/profiling.html
+++ b/0.6.5/developers/contributing/performance/profiling.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../../genindex.html" />
     <link rel="search" title="Search" href="../../../search.html" />

--- a/0.6.5/developers/contributing/testing.html
+++ b/0.6.5/developers/contributing/testing.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/developers/contributing/translations.html
+++ b/0.6.5/developers/contributing/translations.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/developers/coredev/core_dev_guide.html
+++ b/0.6.5/developers/coredev/core_dev_guide.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/developers/coredev/maintenance.html
+++ b/0.6.5/developers/coredev/maintenance.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/developers/coredev/packaging.html
+++ b/0.6.5/developers/coredev/packaging.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/developers/coredev/release.html
+++ b/0.6.5/developers/coredev/release.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/developers/index.html
+++ b/0.6.5/developers/index.html
@@ -71,8 +71,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/further-resources/glossary.html
+++ b/0.6.5/further-resources/glossary.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/further-resources/napari-workshops.html
+++ b/0.6.5/further-resources/napari-workshops.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/further-resources/sample_data.html
+++ b/0.6.5/further-resources/sample_data.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery.html
+++ b/0.6.5/gallery.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="genindex.html" />
     <link rel="search" title="Search" href="search.html" />

--- a/0.6.5/gallery/3D_paths.html
+++ b/0.6.5/gallery/3D_paths.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/3Dimage_plane_rendering.html
+++ b/0.6.5/gallery/3Dimage_plane_rendering.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/action_manager.html
+++ b/0.6.5/gallery/action_manager.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/add-points-3d.html
+++ b/0.6.5/gallery/add-points-3d.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/add_3D_image.html
+++ b/0.6.5/gallery/add_3D_image.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/add_grayscale_image.html
+++ b/0.6.5/gallery/add_grayscale_image.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/add_image.html
+++ b/0.6.5/gallery/add_image.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/add_image_transformed.html
+++ b/0.6.5/gallery/add_image_transformed.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/add_labels.html
+++ b/0.6.5/gallery/add_labels.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/add_labels_with_features.html
+++ b/0.6.5/gallery/add_labels_with_features.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/add_multiscale_image.html
+++ b/0.6.5/gallery/add_multiscale_image.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/add_points.html
+++ b/0.6.5/gallery/add_points.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/add_points_on_nD_shapes.html
+++ b/0.6.5/gallery/add_points_on_nD_shapes.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/add_points_with_features.html
+++ b/0.6.5/gallery/add_points_with_features.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/add_points_with_multicolor_text.html
+++ b/0.6.5/gallery/add_points_with_multicolor_text.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/add_points_with_text.html
+++ b/0.6.5/gallery/add_points_with_text.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/add_shapes.html
+++ b/0.6.5/gallery/add_shapes.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/add_shapes_with_features.html
+++ b/0.6.5/gallery/add_shapes_with_features.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/add_shapes_with_text.html
+++ b/0.6.5/gallery/add_shapes_with_text.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/add_surface_2D.html
+++ b/0.6.5/gallery/add_surface_2D.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/add_vectors.html
+++ b/0.6.5/gallery/add_vectors.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/add_vectors_color_by_angle.html
+++ b/0.6.5/gallery/add_vectors_color_by_angle.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/add_vectors_image.html
+++ b/0.6.5/gallery/add_vectors_image.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/affine_coffee_cup.html
+++ b/0.6.5/gallery/affine_coffee_cup.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/affine_transforms.html
+++ b/0.6.5/gallery/affine_transforms.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/annotate-2d.html
+++ b/0.6.5/gallery/annotate-2d.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/annotate_segmentation_with_text.html
+++ b/0.6.5/gallery/annotate_segmentation_with_text.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/bbox_annotator.html
+++ b/0.6.5/gallery/bbox_annotator.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/concentric-spheres.html
+++ b/0.6.5/gallery/concentric-spheres.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/cursor_position.html
+++ b/0.6.5/gallery/cursor_position.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/cursor_ray.html
+++ b/0.6.5/gallery/cursor_ray.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/custom_key_bindings.html
+++ b/0.6.5/gallery/custom_key_bindings.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/custom_mouse_functions.html
+++ b/0.6.5/gallery/custom_mouse_functions.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/dask_nD_image.html
+++ b/0.6.5/gallery/dask_nD_image.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/drag_and_drop_python_code.html
+++ b/0.6.5/gallery/drag_and_drop_python_code.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/dynamic-projections-dask.html
+++ b/0.6.5/gallery/dynamic-projections-dask.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/export_figure.html
+++ b/0.6.5/gallery/export_figure.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/export_rois.html
+++ b/0.6.5/gallery/export_rois.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/features_table_widget.html
+++ b/0.6.5/gallery/features_table_widget.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/fourier_transform_playground.html
+++ b/0.6.5/gallery/fourier_transform_playground.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/get_current_viewer.html
+++ b/0.6.5/gallery/get_current_viewer.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/glasbey-colormap.html
+++ b/0.6.5/gallery/glasbey-colormap.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/grid_mode.html
+++ b/0.6.5/gallery/grid_mode.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/image-points-3d.html
+++ b/0.6.5/gallery/image-points-3d.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/image_border.html
+++ b/0.6.5/gallery/image_border.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/image_custom_kernel.html
+++ b/0.6.5/gallery/image_custom_kernel.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/image_depth.html
+++ b/0.6.5/gallery/image_depth.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/imshow.html
+++ b/0.6.5/gallery/imshow.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/inherit_viewer_style.html
+++ b/0.6.5/gallery/inherit_viewer_style.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/interaction_box_image.html
+++ b/0.6.5/gallery/interaction_box_image.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/interactive_move_rectangle_3d.html
+++ b/0.6.5/gallery/interactive_move_rectangle_3d.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/interactive_scripting.html
+++ b/0.6.5/gallery/interactive_scripting.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/labels-2d.html
+++ b/0.6.5/gallery/labels-2d.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/labels3d.html
+++ b/0.6.5/gallery/labels3d.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/layer_bounding_box.html
+++ b/0.6.5/gallery/layer_bounding_box.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/layer_text_scaling.html
+++ b/0.6.5/gallery/layer_text_scaling.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/layers.html
+++ b/0.6.5/gallery/layers.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/linked_layers.html
+++ b/0.6.5/gallery/linked_layers.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/magic_image_arithmetic.html
+++ b/0.6.5/gallery/magic_image_arithmetic.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/magic_parameter_sweep.html
+++ b/0.6.5/gallery/magic_parameter_sweep.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/magic_viewer.html
+++ b/0.6.5/gallery/magic_viewer.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/minimum_blending.html
+++ b/0.6.5/gallery/minimum_blending.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/mixed-dimensions-labels.html
+++ b/0.6.5/gallery/mixed-dimensions-labels.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/mouse_drag_callback.html
+++ b/0.6.5/gallery/mouse_drag_callback.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/mouse_drag_image_warping.html
+++ b/0.6.5/gallery/mouse_drag_image_warping.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/multiple_viewer_widget.html
+++ b/0.6.5/gallery/multiple_viewer_widget.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/nD_image.html
+++ b/0.6.5/gallery/nD_image.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/nD_labels.html
+++ b/0.6.5/gallery/nD_labels.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/nD_multiscale_image.html
+++ b/0.6.5/gallery/nD_multiscale_image.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/nD_multiscale_image_non_uniform.html
+++ b/0.6.5/gallery/nD_multiscale_image_non_uniform.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/nD_points.html
+++ b/0.6.5/gallery/nD_points.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/nD_points_with_features.html
+++ b/0.6.5/gallery/nD_points_with_features.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/nD_shapes.html
+++ b/0.6.5/gallery/nD_shapes.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/nD_shapes_with_text.html
+++ b/0.6.5/gallery/nD_shapes_with_text.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/nD_surface.html
+++ b/0.6.5/gallery/nD_surface.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/nD_vectors.html
+++ b/0.6.5/gallery/nD_vectors.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/nD_vectors_image.html
+++ b/0.6.5/gallery/nD_vectors_image.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/new_theme.html
+++ b/0.6.5/gallery/new_theme.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/paint-nd.html
+++ b/0.6.5/gallery/paint-nd.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/pass_colormaps.html
+++ b/0.6.5/gallery/pass_colormaps.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/point_cloud.html
+++ b/0.6.5/gallery/point_cloud.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/points-over-time.html
+++ b/0.6.5/gallery/points-over-time.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/reader_plugin.html
+++ b/0.6.5/gallery/reader_plugin.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/scale_bar.html
+++ b/0.6.5/gallery/scale_bar.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/screenshot_and_export_figure.html
+++ b/0.6.5/gallery/screenshot_and_export_figure.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/set_colormaps.html
+++ b/0.6.5/gallery/set_colormaps.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/set_theme.html
+++ b/0.6.5/gallery/set_theme.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/sg_execution_times.html
+++ b/0.6.5/gallery/sg_execution_times.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/shapes_to_labels.html
+++ b/0.6.5/gallery/shapes_to_labels.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/show_points_based_on_feature.html
+++ b/0.6.5/gallery/show_points_based_on_feature.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/spherical_points.html
+++ b/0.6.5/gallery/spherical_points.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/surface_multi_texture.html
+++ b/0.6.5/gallery/surface_multi_texture.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/surface_normals_wireframe.html
+++ b/0.6.5/gallery/surface_normals_wireframe.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/surface_texture_and_colors.html
+++ b/0.6.5/gallery/surface_texture_and_colors.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/surface_timeseries.html
+++ b/0.6.5/gallery/surface_timeseries.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/swap_dims.html
+++ b/0.6.5/gallery/swap_dims.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/to_screenshot.html
+++ b/0.6.5/gallery/to_screenshot.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/tracks_2d.html
+++ b/0.6.5/gallery/tracks_2d.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/tracks_3d.html
+++ b/0.6.5/gallery/tracks_3d.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/tracks_3d_with_graph.html
+++ b/0.6.5/gallery/tracks_3d_with_graph.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/update_console.html
+++ b/0.6.5/gallery/update_console.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/viewer_fps_label.html
+++ b/0.6.5/gallery/viewer_fps_label.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/vortex.html
+++ b/0.6.5/gallery/vortex.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/without_gui_qt.html
+++ b/0.6.5/gallery/without_gui_qt.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/gallery/xarray-latlon-timeseries.html
+++ b/0.6.5/gallery/xarray-latlon-timeseries.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/genindex.html
+++ b/0.6.5/genindex.html
@@ -94,8 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="#" />
     <link rel="search" title="Search" href="search.html" />

--- a/0.6.5/guides/3D_interactivity.html
+++ b/0.6.5/guides/3D_interactivity.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/guides/_layer_events.html
+++ b/0.6.5/guides/_layer_events.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/guides/_layerlist_events.html
+++ b/0.6.5/guides/_layerlist_events.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/guides/_viewer_events.html
+++ b/0.6.5/guides/_viewer_events.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/guides/contexts_expressions.html
+++ b/0.6.5/guides/contexts_expressions.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/guides/event_loop.html
+++ b/0.6.5/guides/event_loop.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/guides/events_reference.html
+++ b/0.6.5/guides/events_reference.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/guides/handedness.html
+++ b/0.6.5/guides/handedness.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/guides/index.html
+++ b/0.6.5/guides/index.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/guides/layers.html
+++ b/0.6.5/guides/layers.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/guides/performance.html
+++ b/0.6.5/guides/performance.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/guides/preferences.html
+++ b/0.6.5/guides/preferences.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/guides/rendering.html
+++ b/0.6.5/guides/rendering.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/guides/threading.html
+++ b/0.6.5/guides/threading.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/guides/triangulation.html
+++ b/0.6.5/guides/triangulation.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/howtos/docker.html
+++ b/0.6.5/howtos/docker.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/howtos/extending/connecting_events.html
+++ b/0.6.5/howtos/extending/connecting_events.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/howtos/extending/index.html
+++ b/0.6.5/howtos/extending/index.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/howtos/extending/magicgui.html
+++ b/0.6.5/howtos/extending/magicgui.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/howtos/headless.html
+++ b/0.6.5/howtos/headless.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/howtos/index.html
+++ b/0.6.5/howtos/index.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/howtos/layers/image.html
+++ b/0.6.5/howtos/layers/image.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/howtos/layers/index.html
+++ b/0.6.5/howtos/layers/index.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/howtos/layers/labels.html
+++ b/0.6.5/howtos/layers/labels.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/howtos/layers/points.html
+++ b/0.6.5/howtos/layers/points.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/howtos/layers/shapes.html
+++ b/0.6.5/howtos/layers/shapes.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/howtos/layers/surface.html
+++ b/0.6.5/howtos/layers/surface.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/howtos/layers/tracks.html
+++ b/0.6.5/howtos/layers/tracks.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/howtos/layers/vectors.html
+++ b/0.6.5/howtos/layers/vectors.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/howtos/napari_imageJ.html
+++ b/0.6.5/howtos/napari_imageJ.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/howtos/perfmon.html
+++ b/0.6.5/howtos/perfmon.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/howtos/themes.html
+++ b/0.6.5/howtos/themes.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/index.html
+++ b/0.6.5/index.html
@@ -71,8 +71,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="genindex.html" />
     <link rel="search" title="Search" href="search.html" />

--- a/0.6.5/naps/0-nap-process.html
+++ b/0.6.5/naps/0-nap-process.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/naps/1-institutional-funding-partners.html
+++ b/0.6.5/naps/1-institutional-funding-partners.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/naps/2-conda-based-packaging.html
+++ b/0.6.5/naps/2-conda-based-packaging.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/naps/3-spaces.html
+++ b/0.6.5/naps/3-spaces.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/naps/4-async-slicing.html
+++ b/0.6.5/naps/4-async-slicing.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/naps/5-new-logo.html
+++ b/0.6.5/naps/5-new-logo.html
@@ -71,8 +71,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/naps/6-contributable-menus.html
+++ b/0.6.5/naps/6-contributable-menus.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/naps/7-key-binding-dispatch.html
+++ b/0.6.5/naps/7-key-binding-dispatch.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/naps/8-telemetry.html
+++ b/0.6.5/naps/8-telemetry.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/naps/9-multiple-canvases.html
+++ b/0.6.5/naps/9-multiple-canvases.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/naps/index.html
+++ b/0.6.5/naps/index.html
@@ -71,8 +71,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/naps/template.html
+++ b/0.6.5/naps/template.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/plugins/advanced_topics/adapted_plugin_guide.html
+++ b/0.6.5/plugins/advanced_topics/adapted_plugin_guide.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/plugins/advanced_topics/index.html
+++ b/0.6.5/plugins/advanced_topics/index.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/plugins/advanced_topics/npe1.html
+++ b/0.6.5/plugins/advanced_topics/npe1.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/plugins/advanced_topics/npe2_migration_guide.html
+++ b/0.6.5/plugins/advanced_topics/npe2_migration_guide.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/plugins/advanced_topics/widget_communication.html
+++ b/0.6.5/plugins/advanced_topics/widget_communication.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/plugins/building_a_plugin/best_practices.html
+++ b/0.6.5/plugins/building_a_plugin/best_practices.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/plugins/building_a_plugin/debug_plugins.html
+++ b/0.6.5/plugins/building_a_plugin/debug_plugins.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/plugins/building_a_plugin/first_plugin.html
+++ b/0.6.5/plugins/building_a_plugin/first_plugin.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/plugins/building_a_plugin/guides.html
+++ b/0.6.5/plugins/building_a_plugin/guides.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/plugins/building_a_plugin/index.html
+++ b/0.6.5/plugins/building_a_plugin/index.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/plugins/index.html
+++ b/0.6.5/plugins/index.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/plugins/start_using_plugins/finding_and_installing_plugins.html
+++ b/0.6.5/plugins/start_using_plugins/finding_and_installing_plugins.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/plugins/technical_references/contributions.html
+++ b/0.6.5/plugins/technical_references/contributions.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/plugins/technical_references/index.html
+++ b/0.6.5/plugins/technical_references/index.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/plugins/technical_references/manifest.html
+++ b/0.6.5/plugins/technical_references/manifest.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/plugins/testing_and_publishing/deploy.html
+++ b/0.6.5/plugins/testing_and_publishing/deploy.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/plugins/testing_and_publishing/index.html
+++ b/0.6.5/plugins/testing_and_publishing/index.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/plugins/testing_and_publishing/test.html
+++ b/0.6.5/plugins/testing_and_publishing/test.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/plugins/testing_workshop_docs/1-pythons-assert-keyword.html
+++ b/0.6.5/plugins/testing_workshop_docs/1-pythons-assert-keyword.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/plugins/testing_workshop_docs/2-pytest-testing-frameworks.html
+++ b/0.6.5/plugins/testing_workshop_docs/2-pytest-testing-frameworks.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/plugins/testing_workshop_docs/3-readers-and-fixtures.html
+++ b/0.6.5/plugins/testing_workshop_docs/3-readers-and-fixtures.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/plugins/testing_workshop_docs/4-test-coverage.html
+++ b/0.6.5/plugins/testing_workshop_docs/4-test-coverage.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/plugins/testing_workshop_docs/index.html
+++ b/0.6.5/plugins/testing_workshop_docs/index.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/plugins/testing_workshop_docs/testing-resources.html
+++ b/0.6.5/plugins/testing_workshop_docs/testing-resources.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/plugins/virtual_environment_docs/1-virtual-environments.html
+++ b/0.6.5/plugins/virtual_environment_docs/1-virtual-environments.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/plugins/virtual_environment_docs/2-deploying-your-plugin.html
+++ b/0.6.5/plugins/virtual_environment_docs/2-deploying-your-plugin.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/plugins/virtual_environment_docs/3-version-management.html
+++ b/0.6.5/plugins/virtual_environment_docs/3-version-management.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/plugins/virtual_environment_docs/4-developer-tools.html
+++ b/0.6.5/plugins/virtual_environment_docs/4-developer-tools.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/plugins/virtual_environment_docs/5-survey.html
+++ b/0.6.5/plugins/virtual_environment_docs/5-survey.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/plugins/virtual_environment_docs/index.html
+++ b/0.6.5/plugins/virtual_environment_docs/index.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/py-modindex.html
+++ b/0.6.5/py-modindex.html
@@ -94,8 +94,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="genindex.html" />
     <link rel="search" title="Search" href="search.html" />

--- a/0.6.5/release/index.html
+++ b/0.6.5/release/index.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/release/release_0_1_0.html
+++ b/0.6.5/release/release_0_1_0.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/release/release_0_1_3.html
+++ b/0.6.5/release/release_0_1_3.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/release/release_0_1_5.html
+++ b/0.6.5/release/release_0_1_5.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/release/release_0_2_0.html
+++ b/0.6.5/release/release_0_2_0.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/release/release_0_2_1.html
+++ b/0.6.5/release/release_0_2_1.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/release/release_0_2_10.html
+++ b/0.6.5/release/release_0_2_10.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/release/release_0_2_11.html
+++ b/0.6.5/release/release_0_2_11.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/release/release_0_2_12.html
+++ b/0.6.5/release/release_0_2_12.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/release/release_0_2_3.html
+++ b/0.6.5/release/release_0_2_3.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/release/release_0_2_4.html
+++ b/0.6.5/release/release_0_2_4.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/release/release_0_2_5.html
+++ b/0.6.5/release/release_0_2_5.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/release/release_0_2_6.html
+++ b/0.6.5/release/release_0_2_6.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/release/release_0_2_7.html
+++ b/0.6.5/release/release_0_2_7.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/release/release_0_2_8.html
+++ b/0.6.5/release/release_0_2_8.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/release/release_0_2_9.html
+++ b/0.6.5/release/release_0_2_9.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/release/release_0_3_0.html
+++ b/0.6.5/release/release_0_3_0.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/release/release_0_3_1.html
+++ b/0.6.5/release/release_0_3_1.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/release/release_0_3_2.html
+++ b/0.6.5/release/release_0_3_2.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/release/release_0_3_3.html
+++ b/0.6.5/release/release_0_3_3.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/release/release_0_3_4.html
+++ b/0.6.5/release/release_0_3_4.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/release/release_0_3_5.html
+++ b/0.6.5/release/release_0_3_5.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/release/release_0_3_6.html
+++ b/0.6.5/release/release_0_3_6.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/release/release_0_3_7.html
+++ b/0.6.5/release/release_0_3_7.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/release/release_0_3_8.html
+++ b/0.6.5/release/release_0_3_8.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/release/release_0_4_0.html
+++ b/0.6.5/release/release_0_4_0.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/release/release_0_4_1.html
+++ b/0.6.5/release/release_0_4_1.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/release/release_0_4_10.html
+++ b/0.6.5/release/release_0_4_10.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/release/release_0_4_11.html
+++ b/0.6.5/release/release_0_4_11.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/release/release_0_4_12.html
+++ b/0.6.5/release/release_0_4_12.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/release/release_0_4_13.html
+++ b/0.6.5/release/release_0_4_13.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/release/release_0_4_14.html
+++ b/0.6.5/release/release_0_4_14.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/release/release_0_4_15.html
+++ b/0.6.5/release/release_0_4_15.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/release/release_0_4_16.html
+++ b/0.6.5/release/release_0_4_16.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/release/release_0_4_17.html
+++ b/0.6.5/release/release_0_4_17.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/release/release_0_4_18.html
+++ b/0.6.5/release/release_0_4_18.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/release/release_0_4_19.html
+++ b/0.6.5/release/release_0_4_19.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/release/release_0_4_2.html
+++ b/0.6.5/release/release_0_4_2.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/release/release_0_4_3.html
+++ b/0.6.5/release/release_0_4_3.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/release/release_0_4_4.html
+++ b/0.6.5/release/release_0_4_4.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/release/release_0_4_5.html
+++ b/0.6.5/release/release_0_4_5.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/release/release_0_4_6.html
+++ b/0.6.5/release/release_0_4_6.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/release/release_0_4_7.html
+++ b/0.6.5/release/release_0_4_7.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/release/release_0_4_8.html
+++ b/0.6.5/release/release_0_4_8.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/release/release_0_4_9.html
+++ b/0.6.5/release/release_0_4_9.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/release/release_0_5_0.html
+++ b/0.6.5/release/release_0_5_0.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/release/release_0_5_1.html
+++ b/0.6.5/release/release_0_5_1.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/release/release_0_5_2.html
+++ b/0.6.5/release/release_0_5_2.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/release/release_0_5_3.html
+++ b/0.6.5/release/release_0_5_3.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/release/release_0_5_4.html
+++ b/0.6.5/release/release_0_5_4.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/release/release_0_5_5.html
+++ b/0.6.5/release/release_0_5_5.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/release/release_0_5_6.html
+++ b/0.6.5/release/release_0_5_6.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/release/release_0_6_0.html
+++ b/0.6.5/release/release_0_6_0.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/release/release_0_6_1.html
+++ b/0.6.5/release/release_0_6_1.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/release/release_0_6_2.html
+++ b/0.6.5/release/release_0_6_2.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/release/release_0_6_3.html
+++ b/0.6.5/release/release_0_6_3.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/release/release_0_6_4.html
+++ b/0.6.5/release/release_0_6_4.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/release/release_0_6_5.html
+++ b/0.6.5/release/release_0_6_5.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/release/release_0_6_6.html
+++ b/0.6.5/release/release_0_6_6.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/roadmaps/0_3.html
+++ b/0.6.5/roadmaps/0_3.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/roadmaps/0_3_retrospective.html
+++ b/0.6.5/roadmaps/0_3_retrospective.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/roadmaps/0_4.html
+++ b/0.6.5/roadmaps/0_4.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/roadmaps/active_roadmap.html
+++ b/0.6.5/roadmaps/active_roadmap.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/roadmaps/index.html
+++ b/0.6.5/roadmaps/index.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/search.html
+++ b/0.6.5/search.html
@@ -93,8 +93,8 @@ window.addEventListener("load", load);
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
   <script src="_static/searchtools.js"></script>
   <script src="_static/language_data.js"></script>

--- a/0.6.5/sg_execution_times.html
+++ b/0.6.5/sg_execution_times.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="genindex.html" />
     <link rel="search" title="Search" href="search.html" />

--- a/0.6.5/troubleshooting.html
+++ b/0.6.5/troubleshooting.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="genindex.html" />
     <link rel="search" title="Search" href="search.html" />

--- a/0.6.5/tutorials/annotation/annotate_points.html
+++ b/0.6.5/tutorials/annotation/annotate_points.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/tutorials/annotation/index.html
+++ b/0.6.5/tutorials/annotation/index.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/tutorials/fundamentals/features.html
+++ b/0.6.5/tutorials/fundamentals/features.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/tutorials/fundamentals/getting_started.html
+++ b/0.6.5/tutorials/fundamentals/getting_started.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/tutorials/fundamentals/installation.html
+++ b/0.6.5/tutorials/fundamentals/installation.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/tutorials/fundamentals/installation_bundle_conda.html
+++ b/0.6.5/tutorials/fundamentals/installation_bundle_conda.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/tutorials/fundamentals/quick_start.html
+++ b/0.6.5/tutorials/fundamentals/quick_start.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/tutorials/fundamentals/viewer.html
+++ b/0.6.5/tutorials/fundamentals/viewer.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/tutorials/index.html
+++ b/0.6.5/tutorials/index.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/tutorials/processing/dask.html
+++ b/0.6.5/tutorials/processing/dask.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/tutorials/processing/index.html
+++ b/0.6.5/tutorials/processing/index.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/tutorials/segmentation/annotate_segmentation.html
+++ b/0.6.5/tutorials/segmentation/annotate_segmentation.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/tutorials/segmentation/index.html
+++ b/0.6.5/tutorials/segmentation/index.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/tutorials/start_index.html
+++ b/0.6.5/tutorials/start_index.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../genindex.html" />
     <link rel="search" title="Search" href="../search.html" />

--- a/0.6.5/tutorials/tracking/cell_tracking.html
+++ b/0.6.5/tutorials/tracking/cell_tracking.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/tutorials/tracking/index.html
+++ b/0.6.5/tutorials/tracking/index.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="../../genindex.html" />
     <link rel="search" title="Search" href="../../search.html" />

--- a/0.6.5/usage.html
+++ b/0.6.5/usage.html
@@ -69,8 +69,8 @@
         DOCUMENTATION_OPTIONS.theme_version = '0.16.1';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = 'https://napari.org/dev/_static/version_switcher.json';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '0.6.5';
-        DOCUMENTATION_OPTIONS.show_version_warning_banner =
-            true;
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = true;
+        DOCUMENTATION_OPTIONS.VERSION = "0.6.5";
         </script>
     <link rel="index" title="Index" href="genindex.html" />
     <link rel="search" title="Search" href="search.html" />


### PR DESCRIPTION
I swear this is the last time 😭 

Most of these involved forcing the version number to avoid the issues with the files that were unversioned and got copied over. In that case, a mismatch between the version number for which the page was built and the version number for the pages where it lived was causing the bad version warning.

It's many files, but most changes are one (maybe two) lines per file.